### PR TITLE
fix: four bugs causing reliable ping and state decode failures with QUIC transport

### DIFF
--- a/memberlist-core/src/network.rs
+++ b/memberlist-core/src/network.rs
@@ -67,7 +67,22 @@ where
     msg.advance(1);
 
     if let MessageType::Ack = mt {
-      let seqn = match Ack::decode_sequence_number(&msg) {
+      // The Ack is length-delimited in the message protocol. After advancing
+      // past the message type tag, the buffer starts with a varint length
+      // prefix. Decode and skip it so decode_sequence_number reads the raw
+      // Ack fields.
+      let (len_bytes, ack_len) =
+        varing::decode_u32_varint(&msg).map_err(|e| Error::custom(format!("decode ack length: {}", e).into()))?;
+      let ack_len =
+        usize::try_from(ack_len).map_err(|_| Error::custom("decode ack length: length does not fit in usize".into()))?;
+      let start = len_bytes.get();
+      let end = start
+        .checked_add(ack_len)
+        .ok_or_else(|| Error::custom("decode ack length: overflow computing ack payload range".into()))?;
+      let ack_data = msg
+        .get(start..end)
+        .ok_or_else(|| Error::custom("decode ack length: ack payload exceeds message buffer".into()))?;
+      let seqn = match Ack::decode_sequence_number(ack_data) {
         Ok(seqn) => seqn.1,
         Err(e) => return Err(e.into()),
       };

--- a/memberlist-core/src/network/stream.rs
+++ b/memberlist-core/src/network/stream.rs
@@ -269,6 +269,7 @@ where
         tracing::error!(err=%e, local = %self.inner.id, remote_node = %addr, "memberlist.stream: failed to receive");
 
         let err_resp = ErrorResponse::new(SmolStr::new(e.to_string()));
+        let deadline = <T::Runtime as RuntimeLite>::now() + self.inner.opts.timeout;
         let res = <T::Runtime as RuntimeLite>::timeout_at(
           deadline,
           self.send_message(&mut writter, [err_resp.into()]),
@@ -318,6 +319,7 @@ where
         }
 
         let ack = Ack::new(ping.sequence_number());
+        let deadline = <T::Runtime as RuntimeLite>::now() + self.inner.opts.timeout;
         let res = <T::Runtime as RuntimeLite>::timeout_at(
           deadline,
           self.send_message(&mut writter, [ack.into()]),

--- a/memberlist-core/src/state.rs
+++ b/memberlist-core/src/state.rs
@@ -1083,7 +1083,7 @@ where
     ping_sequence_number: u32,
     ack_rx: &async_channel::Receiver<AckMessage<<T::Runtime as RuntimeLite>::Instant>>,
     nack_rx: &async_channel::Receiver<()>,
-    deadline: <T::Runtime as RuntimeLite>::Instant,
+    _deadline: <T::Runtime as RuntimeLite>::Instant,
     awareness_delta: &AtomicIsize,
   ) {
     // Get some random live nodes.
@@ -1144,10 +1144,12 @@ where
     if !disable_reliable_pings {
       let target_addr = target.address().cheap_clone();
       let this = self.clone();
+      let reliable_deadline =
+        <T::Runtime as RuntimeLite>::now() + self.inner.opts.timeout;
       <T::Runtime as RuntimeLite>::spawn_detach(async move {
         scopeguard::defer!(fallback_tx.close(););
         match this
-          .send_ping_and_wait_for_ack(&target_addr, ind.into(), deadline)
+          .send_ping_and_wait_for_ack(&target_addr, ind.into(), reliable_deadline)
           .await
         {
           Ok(did_contact) => {

--- a/memberlist-proto/src/proto/encoder.rs
+++ b/memberlist-proto/src/proto/encoder.rs
@@ -809,6 +809,7 @@ where
   where
     E: Encodable,
   {
+    #[allow(unused_variables)]
     let (encoded_len, hint) = (hint.input_size, hint);
     let mut payload = Payload::new(self.overhead, hint.max_output_size);
     let buf = payload.data_mut();

--- a/memberlist-quic/src/stream_layer/quinn.rs
+++ b/memberlist-quic/src/stream_layer/quinn.rs
@@ -289,12 +289,15 @@ impl memberlist_core::proto::ProtoReader for QuinnProtoReader {
     } else {
       buf[..peek_len].copy_from_slice(&self.peek_buf);
       self.peek_buf.clear();
-      self
-        .stream
-        .read(&mut buf[peek_len..])
-        .await
-        .map(|read| read.unwrap_or(0))
-        .map_err(Into::into)
+      let mut total = peek_len;
+      while total < dst_len {
+        let n = self.stream.read(&mut buf[total..]).await?.unwrap_or(0);
+        if n == 0 {
+          break;
+        }
+        total += n;
+      }
+      Ok(total)
     }
   }
 
@@ -309,12 +312,18 @@ impl memberlist_core::proto::ProtoReader for QuinnProtoReader {
     } else {
       buf[..peek_len].copy_from_slice(&self.peek_buf);
       self.peek_buf.clear();
-      self
-        .stream
-        .read(&mut buf[peek_len..])
-        .await
-        .map(|_| ())
-        .map_err(Into::into)
+      let mut total = peek_len;
+      while total < dst_len {
+        let n = self.stream.read(&mut buf[total..]).await?.unwrap_or(0);
+        if n == 0 {
+          return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "unexpected eof",
+          ));
+        }
+        total += n;
+      }
+      Ok(())
     }
   }
 }

--- a/memberlist-quic/src/stream_layer/quinn.rs
+++ b/memberlist-quic/src/stream_layer/quinn.rs
@@ -251,29 +251,24 @@ impl memberlist_core::proto::ProtoReader for QuinnProtoReader {
         Ok(())
       }
       cmp::Ordering::Greater => {
-        let want = dst_len - peek_len;
         self.peek_buf.resize(dst_len, 0);
-        let readed = self
-          .stream
-          .read(&mut self.peek_buf[peek_len..peek_len + want])
-          .await?;
-
-        if let Some(n) = readed {
-          let has = peek_len + n;
-          if n < want {
+        let mut total = peek_len;
+        while total < dst_len {
+          let n = self
+            .stream
+            .read(&mut self.peek_buf[total..])
+            .await?
+            .unwrap_or(0);
+          if n == 0 {
             return Err(std::io::Error::new(
               std::io::ErrorKind::UnexpectedEof,
               "unexpected eof",
             ));
           }
-          buf[..has].copy_from_slice(&self.peek_buf);
-          Ok(())
-        } else {
-          Err(std::io::Error::new(
-            std::io::ErrorKind::UnexpectedEof,
-            "unexpected eof",
-          ))
+          total += n;
         }
+        buf.copy_from_slice(&self.peek_buf);
+        Ok(())
       }
     }
   }


### PR DESCRIPTION
## Summary

Fix four bugs that cause reliable ping and state exchange to fail when using the QUIC transport (memberlist-quic). All four bugs are latent on datagram transports but surface under QUIC due to its stream-based semantics and TLS handshake overhead.

- **QuinnProtoReader partial reads** — `read()` / `read_exact()` only called `stream.read()` once, returning truncated buffers. Last protobuf fields silently missing.
- **Deadline contention in `handle_conn()`** — `read_message()` and `send_message()` shared a single deadline. Slow reads consumed the deadline, so subsequent writes expired immediately.
- **Stale deadline in reliable ping fallback** — the reliable ping task inherited an already-expired probe deadline and failed instantly.
- **Ack length prefix decode error** — `send_ping_and_wait_for_ack()` passed the varint length prefix directly into `Ack::decode_sequence_number()`, which misinterpreted it as a field tag and skipped the actual sequence number, always returning 0.

## Errors observed (with real timestamps)

The following errors appeared in sequence when two QUIC-enabled serf nodes discovered each other:

### Phase 1: Partial reads (immediately at startup)
```
2026-05-13T06:43:06.657533Z ERROR egress{id=0}: serf_core::serf::delegate:
  serf: fail to decode remote state err=missing query_ltime in PushPullMessage
```
`query_ltime` is the **last field** in `PushPullMessage` serialization (order: `ltime → status_ltimes → left_members → event_ltime → events → query_ltime`). When `read_exact()` returned after a single partial `stream.read()`, the tail of the buffer was missing, so `query_ltime` was never decoded.

### Phase 2: Deadline contention (after partial reads fixed)
```
2026-05-13T08:16:53.619141Z ERROR egress{id=0}: memberlist_core::network::stream:
  memberlist.stream: failed to send ack response
  err=sending stopped by peer: error 0

2026-05-13T08:16:53.773091Z ERROR egress{id=0}: memberlist_core::state:
  memberlist.state: failed to send ping by reliable connection
  err=timed out
```
The first error: `read_message()` consumed most of the shared deadline, leaving no time for `send_message()` (Ack reply). The `timeout_at` cancelled the write, Quinn sent `STOP_SENDING(0)`.

The second error: reliable ping spawned **after** UDP probe timeout + indirect pings had already elapsed, inheriting the expired deadline.

### Phase 3: Ack decode error (after deadline fix, revealed hidden bug)
```
2026-05-13T08:53:37.368827Z ERROR egress{id=0}: memberlist_core::state:
  memberlist.state: failed to send ping by reliable connection
  err=sequence number mismatch: ping(1), ack(0)

2026-05-13T08:53:37.244103Z ERROR egress{id=0}: memberlist_core::state:
  memberlist.state: failed to send ping by reliable connection
  err=sequence number mismatch: ping(1), ack(0)
```
Both nodes simultaneously reported `ping(1), ack(0)`. The Ack response was length-delimited (`[msg_type_tag, length_varint, ack_payload]`). After skipping the type byte, the buffer started with the **varint length prefix**, not raw Ack data. `decode_sequence_number()` treated the length byte as a field tag, skipped it plus the next byte (which happened to be the actual `SEQUENCE_NUMBER_BYTE`), and returned default `0`.


## Changes

| File                                        | Bug                                                         | Fix                                                                         |
| ------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------- |
| `memberlist-quic/src/stream_layer/quinn.rs` | Partial reads → `missing query_ltime`                       | Loop in `read()` / `read_exact()` until buffer is full                      |
| `memberlist-core/src/network/stream.rs`     | Shared deadline → `WriteError::Stopped(0)`                  | Recompute fresh deadline before each `send_message()`                       |
| `memberlist-core/src/state.rs`              | Stale deadline → `err=timed out`                            | Compute fresh `reliable_deadline` at spawn time                             |
| `memberlist-core/src/network.rs`            | Length prefix → `sequence number mismatch: ping(N), ack(0)` | Decode and skip varint length prefix before `Ack::decode_sequence_number()` |
| `memberlist-proto/src/proto/encoder.rs`     | Lint warning                                                | Add `#[allow(unused_variables)]` for `encoded_len`                          |