### PR TITLE
feat(quic): use QUIC datagrams for unreliable packet transport

### DIFF
--- a/memberlist-proto/src/payload.rs
+++ b/memberlist-proto/src/payload.rs
@@ -1,4 +1,4 @@
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 
 /// A payload can be sent over the transport.
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -69,5 +69,13 @@ impl Payload {
   /// Returns the whole payload as a slice.
   pub fn as_slice(&self) -> &[u8] {
     &self.buf
+  }
+
+  /// Consumes the payload and returns its inner buffer as a [`Bytes`].
+  ///
+  /// This is zero-copy when this is the only reference to the buffer
+  /// (which is the common case for freshly-created payloads).
+  pub fn into_bytes(self) -> Bytes {
+    self.buf.freeze()
   }
 }

--- a/memberlist-quic/src/lib.rs
+++ b/memberlist-quic/src/lib.rs
@@ -298,6 +298,7 @@ where
   async fn fetch_connection(
     &self,
     addr: SocketAddr,
+    deadline: Option<R::Instant>,
   ) -> Result<S::Connection, QuicTransportError<A>> {
     if let Some(ent) = self.connection_pool.get(&addr) {
       let (_, connection) = ent.value();
@@ -307,7 +308,13 @@ where
     }
 
     let connector = self.next_connector(&addr);
-    let connection = connector.connect(addr).await?;
+    let connect_fut = connector.connect(addr);
+    let connection = match deadline {
+      Some(deadline) => R::timeout_at(deadline, connect_fut)
+        .await
+        .map_err(|e| QuicTransportError::Io(e.into()))??,
+      None => connect_fut.await?,
+    };
     self
       .connection_pool
       .insert(addr, (Instant::now(), connection.clone()));
@@ -319,7 +326,7 @@ where
     addr: SocketAddr,
     deadline: R::Instant,
   ) -> Result<S::Stream, QuicTransportError<A>> {
-    let conn = self.fetch_connection(addr).await?;
+    let conn = self.fetch_connection(addr, Some(deadline)).await?;
     R::timeout_at(deadline, conn.open_bi())
       .await
       .map_err(|e| QuicTransportError::Io(e.into()))?
@@ -461,7 +468,8 @@ where
     src: Payload,
   ) -> Result<(usize, <Self::Runtime as RuntimeLite>::Instant), Self::Error> {
     let start = <Self::Runtime as RuntimeLite>::now();
-    let conn = self.fetch_connection(*addr).await?;
+    let deadline = self.opts.timeout.map(|ttl| start + ttl);
+    let conn = self.fetch_connection(*addr, deadline).await?;
 
     // Datagrams don't need a stream type tag — they're already a separate
     // channel from streams.

--- a/memberlist-quic/src/lib.rs
+++ b/memberlist-quic/src/lib.rs
@@ -41,28 +41,6 @@ pub use options::*;
 pub mod stream_layer;
 use stream_layer::*;
 
-const PACKET_TAG: u8 = 254;
-const STREAM_TAG: u8 = 255;
-
-#[derive(Copy, Clone)]
-#[repr(u8)]
-enum StreamType {
-  Stream = STREAM_TAG,
-  Packet = PACKET_TAG,
-}
-
-impl TryFrom<u8> for StreamType {
-  type Error = u8;
-
-  fn try_from(value: u8) -> Result<Self, Self::Error> {
-    Ok(match value {
-      STREAM_TAG => Self::Stream,
-      PACKET_TAG => Self::Packet,
-      _ => return Err(value),
-    })
-  }
-}
-
 #[cfg(feature = "tokio")]
 /// [`QuicTransport`] based on [`tokio`](https://crates.io/crates/tokio).
 pub type TokioQuicTransport<I, A, S> = QuicTransport<I, A, S, agnostic_lite::tokio::TokioRuntime>;
@@ -187,7 +165,6 @@ where
         packet_tx: packet_tx.clone(),
         stream_tx: stream_tx.clone(),
         local_addr,
-        timeout: opts.timeout,
         shutdown_rx: shutdown_rx.clone(),
         #[cfg(feature = "metrics")]
         metric_labels: opts.metric_labels.clone().unwrap_or_default(),
@@ -229,7 +206,7 @@ where
       advertise_addr: final_advertise_addr,
       connection_pool,
       local_addr: self_addr,
-      max_packet_size: opts.max_packet_size.min(stream_layer.max_stream_data()),
+      max_packet_size: opts.max_packet_size,
       opts,
       packet_rx,
       stream_rx,
@@ -318,41 +295,35 @@ where
     }
   }
 
-  async fn fetch_stream(
+  async fn fetch_connection(
     &self,
     addr: SocketAddr,
-    timeout: Option<R::Instant>,
-  ) -> Result<S::Stream, QuicTransportError<A>> {
+  ) -> Result<S::Connection, QuicTransportError<A>> {
     if let Some(ent) = self.connection_pool.get(&addr) {
       let (_, connection) = ent.value();
       if !connection.is_closed().await {
-        if let Some(timeout) = timeout {
-          return R::timeout_at(timeout, connection.open_bi())
-            .await
-            .map_err(|e| QuicTransportError::Io(e.into()))?
-            .map(|(stream, _)| stream)
-            .map_err(Into::into);
-        } else {
-          return connection
-            .open_bi()
-            .await
-            .map(|(s, _)| s)
-            .map_err(Into::into);
-        }
+        return Ok(connection.clone());
       }
     }
 
     let connector = self.next_connector(&addr);
     let connection = connector.connect(addr).await?;
-    connection
-      .open_bi()
+    self
+      .connection_pool
+      .insert(addr, (Instant::now(), connection.clone()));
+    Ok(connection)
+  }
+
+  async fn open_stream(
+    &self,
+    addr: SocketAddr,
+    deadline: R::Instant,
+  ) -> Result<S::Stream, QuicTransportError<A>> {
+    let conn = self.fetch_connection(addr).await?;
+    R::timeout_at(deadline, conn.open_bi())
       .await
-      .map(|(s, _)| {
-        self
-          .connection_pool
-          .insert(addr, (Instant::now(), connection));
-        s
-      })
+      .map_err(|e| QuicTransportError::Io(e.into()))?
+      .map(|(s, _)| s)
       .map_err(Into::into)
   }
 }
@@ -426,7 +397,7 @@ where
 
   #[inline]
   fn header_overhead(&self) -> usize {
-    1
+    0
   }
 
   fn blocked_address(
@@ -443,49 +414,22 @@ where
 
   async fn read(
     &self,
-    from: &Self::ResolvedAddress,
-    conn: &mut <Self::Connection as Connection>::Reader,
+    _from: &Self::ResolvedAddress,
+    _conn: &mut <Self::Connection as Connection>::Reader,
   ) -> Result<usize, Self::Error> {
-    // Consume the stream type tag byte that was peeked by the processor
-    // in handle_stream(). The processor peeked exactly 1 byte to determine
-    // whether this is a Stream or Packet stream, so we must consume it here
-    // before the decoder reads the proto message payload.
-    let mut buf = [0; 1];
-    conn.read_exact(&mut buf).await?;
-    match StreamType::try_from(buf[0]) {
-      Ok(StreamType::Stream) => Ok(1),
-      Ok(StreamType::Packet) => Err(QuicTransportError::Io(std::io::Error::new(
-        std::io::ErrorKind::InvalidData,
-        format!("receive an unexpected packet stream from {from}"),
-      ))),
-      Err(tag) => Err(QuicTransportError::Io(std::io::Error::new(
-        std::io::ErrorKind::InvalidData,
-        format!(
-          "receive a stream from {from} with invalid type value: {}",
-          tag
-        ),
-      ))),
-    }
+    // The stream no longer carries a type tag byte since packets are now
+    // sent via QUIC datagrams instead of bidirectional streams.
+    // This method exists to satisfy the Transport trait interface but
+    // does nothing — all data on the stream is proto message data.
+    Ok(0)
   }
 
   async fn write(
     &self,
     conn: &mut <Self::Connection as Connection>::Writer,
-    mut src: Payload,
+    src: Payload,
   ) -> Result<usize, Self::Error> {
     use memberlist_core::proto::ProtoWriter;
-
-    let header = src.header_mut();
-    if header.is_empty() {
-      return Err(QuicTransportError::custom(
-        "not enough space for header".into(),
-      ));
-    }
-    header[0] = StreamType::Stream as u8;
-    let ttl = self
-      .opts
-      .timeout
-      .map(|ttl| <Self::Runtime as RuntimeLite>::now() + ttl);
 
     let src = src.as_slice();
     tracing::trace!(
@@ -494,6 +438,8 @@ where
       "memberlist_quic.stream"
     );
 
+    let start = <Self::Runtime as RuntimeLite>::now();
+    let ttl = self.opts.timeout.map(|ttl| start + ttl);
     match ttl {
       None => {
         conn.write_all(src).await?;
@@ -512,40 +458,38 @@ where
   async fn send_to(
     &self,
     addr: &Self::ResolvedAddress,
-    mut src: Payload,
+    src: Payload,
   ) -> Result<(usize, <Self::Runtime as RuntimeLite>::Instant), Self::Error> {
     let start = <Self::Runtime as RuntimeLite>::now();
-    let ttl = self.opts.timeout.map(|ttl| start + ttl);
-    let mut stream = self.fetch_stream(*addr, ttl).await?;
-    let header = src.header_mut();
-    if header.is_empty() {
-      return Err(QuicTransportError::custom(
-        "not enough space for header".into(),
-      ));
-    }
-    header[0] = StreamType::Packet as u8;
+    let conn = self.fetch_connection(*addr).await?;
 
-    let src = src.as_slice();
+    // Datagrams don't need a stream type tag — they're already a separate
+    // channel from streams.
+    let data = src.into_bytes();
+
     tracing::trace!(
-      total_bytes = %src.len(),
-      sent = ?src,
+      total_bytes = %data.len(),
+      sent = ?data,
       "memberlist_quic.packet"
     );
 
-    match ttl {
+    match self.opts.timeout {
       None => {
-        stream.write_all(src).await?;
-        stream.flush().await?;
-
-        Ok((src.len(), start))
+        let len = data.len();
+        conn.send_datagram(data).await?;
+        Ok((len, start))
       }
-      Some(ttl) => R::timeout_at(ttl, async {
-        stream.write_all(src).await?;
-        stream.flush().await.map(|_| (src.len(), start))
-      })
-      .await
-      .map_err(std::io::Error::from)?
-      .map_err(Into::into),
+      Some(ttl) => {
+        let deadline = start + ttl;
+        let len = data.len();
+        R::timeout_at(deadline, async {
+          conn.send_datagram(data).await?;
+          Ok::<_, QuicTransportError<A>>((len, start))
+        })
+        .await
+        .map_err(std::io::Error::from)?
+        .map_err(Into::into)
+      }
     }
   }
 
@@ -554,7 +498,7 @@ where
     addr: &<Self::Resolver as AddressResolver>::ResolvedAddress,
     deadline: R::Instant,
   ) -> Result<Self::Connection, Self::Error> {
-    self.fetch_stream(*addr, Some(deadline)).await
+    self.open_stream(*addr, deadline).await
   }
 
   fn packet(
@@ -571,7 +515,7 @@ where
 
   #[inline]
   fn packet_reliable(&self) -> bool {
-    true
+    false
   }
 
   #[inline]

--- a/memberlist-quic/src/options.rs
+++ b/memberlist-quic/src/options.rs
@@ -91,7 +91,8 @@ pub struct QuicTransportOptions<I, A: AddressResolver<ResolvedAddress = SocketAd
   /// Maximum packet size in bytes. Used as an upper bound when computing
   /// the effective `max_packet_size` for the transport.
   ///
-  /// Default is `usize::MAX`.
+  /// Default is `1150`, derived from the minimum QUIC path MTU (1200 bytes)
+  /// minus QUIC overhead and the datagram frame size.
   #[viewit(
     getter(const, attrs(doc = "Get the maximum packet size in bytes.")),
     setter(attrs(doc = "Set the maximum packet size in bytes. (Builder pattern)"))
@@ -273,7 +274,16 @@ impl<I, A: AddressResolver<ResolvedAddress = SocketAddr>, S: StreamLayer>
       stream_layer: stream_layer_opts,
       cidrs_policy: CIDRsPolicy::allow_all(),
       connection_pool_cleanup_period: default_connection_pool_cleanup_period(),
-      max_packet_size: usize::MAX,
+      // QUIC datagrams are limited by the path MTU. To avoid Quinn's local
+      // TooLarge rejection, we must account for the worst-case QUIC overhead:
+      //   - Minimum path MTU:                  1200 bytes
+      //   - QUIC header:                          1 byte
+      //   - Max Connection ID:                   20 bytes
+      //   - Max packet number:                    4 bytes
+      //   - Encryption tag (AEAE suffix):        16 bytes
+      //   - Quinn Datagram frame SIZE_BOUND:      9 bytes
+      // Net datagram payload = 1200 - (1+20+4+16) - 9 = 1150 bytes
+      max_packet_size: 1150,
       #[cfg(feature = "metrics")]
       metric_labels: None,
       packet_buffer_size: 1000,

--- a/memberlist-quic/src/processor.rs
+++ b/memberlist-quic/src/processor.rs
@@ -157,15 +157,16 @@ where
           match datagram_conn.recv_datagram().await {
             Ok(bytes) => {
               let start = <T::Runtime as RuntimeLite>::now();
+              let len = bytes.len();
               if let Err(e) = datagram_packet_tx
-                .send(Packet::new(remote_addr, start, bytes.clone()))
+                .send(Packet::new(remote_addr, start, bytes))
                 .await
               {
                 tracing::error!(local=%local_addr, from=%remote_addr, err = %e, "memberlist_quic.packet: failed to send packet from datagram");
               }
               #[cfg(feature = "metrics")]
               metrics::counter!("memberlist.packet.received", datagram_metric_labels.iter())
-                .increment(bytes.len() as u64);
+                .increment(len as u64);
             }
             Err(e) => {
               tracing::debug!(local=%local_addr, from=%remote_addr, err = %e, "memberlist_quic.packet: datagram stream closed");

--- a/memberlist-quic/src/processor.rs
+++ b/memberlist-quic/src/processor.rs
@@ -13,7 +13,6 @@ pub(super) struct Processor<
   pub(super) packet_tx: PacketProducer<T::ResolvedAddress, <T::Runtime as RuntimeLite>::Instant>,
   pub(super) stream_tx: StreamProducer<T::ResolvedAddress, T::Connection>,
   pub(super) shutdown_rx: async_channel::Receiver<()>,
-  pub(super) timeout: Option<Duration>,
   #[cfg(feature = "metrics")]
   pub(super) metric_labels: Arc<memberlist_core::proto::MetricLabels>,
 }
@@ -37,7 +36,6 @@ where
       stream_tx,
       shutdown_rx,
       local_addr,
-      timeout,
       #[cfg(feature = "metrics")]
       metric_labels,
     } = self;
@@ -48,7 +46,6 @@ where
       stream_tx,
       packet_tx,
       shutdown_rx,
-      timeout,
       #[cfg(feature = "metrics")]
       metric_labels,
     )
@@ -61,7 +58,6 @@ where
     stream_tx: StreamProducer<T::ResolvedAddress, T::Connection>,
     packet_tx: PacketProducer<T::ResolvedAddress, <T::Runtime as RuntimeLite>::Instant>,
     shutdown_rx: async_channel::Receiver<()>,
-    timeout: Option<Duration>,
     #[cfg(feature = "metrics")] metric_labels: Arc<memberlist_core::proto::MetricLabels>,
   ) {
     tracing::info!("memberlist.transport.quic: listening stream on {local_addr}");
@@ -95,7 +91,6 @@ where
               remote_addr,
               stream_tx,
               packet_tx,
-              timeout,
               shutdown_rx,
               #[cfg(feature = "metrics")]
               metric_labels,
@@ -146,10 +141,41 @@ where
     remote_addr: SocketAddr,
     stream_tx: StreamProducer<T::ResolvedAddress, T::Connection>,
     packet_tx: PacketProducer<T::ResolvedAddress, <T::Runtime as RuntimeLite>::Instant>,
-    timeout: Option<Duration>,
     shutdown_rx: async_channel::Receiver<()>,
     #[cfg(feature = "metrics")] metric_labels: Arc<memberlist_core::proto::MetricLabels>,
   ) {
+    // Spawn a detached task to listen for datagrams on this connection.
+    // Datagrams are a separate channel from streams in QUIC, so they
+    // arrive independently of bidirectional streams.
+    {
+      let datagram_packet_tx = packet_tx.clone();
+      let datagram_conn = conn.clone();
+      #[cfg(feature = "metrics")]
+      let datagram_metric_labels = metric_labels.clone();
+      <T::Runtime as RuntimeLite>::spawn_detach(async move {
+        loop {
+          match datagram_conn.recv_datagram().await {
+            Ok(bytes) => {
+              let start = <T::Runtime as RuntimeLite>::now();
+              if let Err(e) = datagram_packet_tx
+                .send(Packet::new(remote_addr, start, bytes.clone()))
+                .await
+              {
+                tracing::error!(local=%local_addr, from=%remote_addr, err = %e, "memberlist_quic.packet: failed to send packet from datagram");
+              }
+              #[cfg(feature = "metrics")]
+              metrics::counter!("memberlist.packet.received", datagram_metric_labels.iter())
+                .increment(bytes.len() as u64);
+            }
+            Err(e) => {
+              tracing::debug!(local=%local_addr, from=%remote_addr, err = %e, "memberlist_quic.packet: datagram stream closed");
+              return;
+            }
+          }
+        }
+      });
+    }
+
     // Listen for shutdown signal in a select with accept_bi() so that
     // accept_bi() does not block shutdown indefinitely.
     let shutdown_for_select = shutdown_rx.clone();
@@ -171,22 +197,15 @@ where
           };
 
           // Spawn a detached task to handle this single stream so that
-          // one slow/blocked stream does not prevent processing others.
-          let packet_tx = packet_tx.clone();
+          // one slow/blocked stream does not prevent accepting others.
           let stream_tx = stream_tx.clone();
-          #[cfg(feature = "metrics")]
-          let metric_labels = metric_labels.clone();
 
-          <T::Runtime as RuntimeLite>::spawn_detach(Self::handle_stream(
-            stream,
-            local_addr,
-            stream_remote_addr,
-            stream_tx,
-            packet_tx,
-            timeout,
-            #[cfg(feature = "metrics")]
-            metric_labels,
-          ));
+          <T::Runtime as RuntimeLite>::spawn_detach(async move {
+            if let Err(e) = stream_tx.send(stream_remote_addr, stream).await {
+              tracing::error!(local_addr=%local_addr, err = %e,
+                "memberlist.transport.quic: failed to send stream connection");
+            }
+          });
         }
       }
     }
@@ -195,93 +214,4 @@ where
     let _ = conn.close().await;
   }
 
-  #[allow(clippy::too_many_arguments)]
-  async fn handle_stream(
-    mut stream: S::Stream,
-    local_addr: SocketAddr,
-    remote_addr: SocketAddr,
-    stream_tx: StreamProducer<T::ResolvedAddress, T::Connection>,
-    packet_tx: PacketProducer<T::ResolvedAddress, <T::Runtime as RuntimeLite>::Instant>,
-    timeout: Option<Duration>,
-    #[cfg(feature = "metrics")] metric_labels: Arc<memberlist_core::proto::MetricLabels>,
-  ) {
-    let mut stream_kind_buf = [0; 1];
-    if let Err(e) = stream.peek_exact(&mut stream_kind_buf).await {
-      tracing::error!(local=%local_addr, from=%remote_addr, err = %e, "memberlist.transport.quic: failed to read stream kind");
-      return;
-    }
-    let stream_kind = stream_kind_buf[0];
-    match StreamType::try_from(stream_kind) {
-      Ok(StreamType::Stream) => {
-        if let Err(e) = stream_tx.send(remote_addr, stream).await {
-          tracing::error!(local_addr=%local_addr, err = %e, "memberlist.transport.quic: failed to send stream connection");
-        }
-      }
-      Ok(StreamType::Packet) => {
-        // Drain the stream type tag byte that was peeked in handle_stream().
-        // The processor peeked exactly 1 byte to determine whether this is a
-        // Stream or Packet stream, so we must consume it here before read_packet()
-        // reads the proto message payload from the stream.
-        let mut _tag = [0u8; 1];
-        if let Err(e) = stream.read_exact(&mut _tag).await {
-          tracing::error!(local=%local_addr, from=%remote_addr, err = %e, "memberlist.transport.quic: failed to consume stream tag");
-          return;
-        }
-
-        Self::handle_packet(
-          &mut stream,
-          local_addr,
-          remote_addr,
-          &packet_tx,
-          timeout,
-          #[cfg(feature = "metrics")]
-          &metric_labels,
-        )
-        .await;
-      }
-      Err(val) => {
-        tracing::error!(local=%local_addr, from=%remote_addr, tag=%val, "memberlist.transport.quic: unknown stream");
-        // Don't kill the connection, just drop this stream.
-      }
-    }
-  }
-
-  #[allow(clippy::too_many_arguments)]
-  async fn handle_packet(
-    stream: &mut S::Stream,
-    local_addr: SocketAddr,
-    remote_addr: SocketAddr,
-    packet_tx: &PacketProducer<T::ResolvedAddress, <T::Runtime as RuntimeLite>::Instant>,
-    timeout: Option<Duration>,
-    #[cfg(feature = "metrics")] metric_labels: &memberlist_core::proto::MetricLabels,
-  ) {
-    let start = <T::Runtime as RuntimeLite>::now();
-
-    let res = if let Some(timeout) = timeout {
-      match <T::Runtime as RuntimeLite>::timeout(timeout, stream.read_packet()).await {
-        Ok(Ok(bytes)) => Ok(bytes),
-        Ok(Err(e)) => Err(e),
-        Err(e) => Err(e.into()),
-      }
-    } else {
-      stream.read_packet().await
-    };
-
-    let msg = match res {
-      Ok(msg) => msg,
-      Err(e) => {
-        tracing::error!(local=%local_addr, from=%remote_addr, err = %e, "memberlist_quic.packet: fail to handle UDP packet");
-        return;
-      }
-    };
-    tracing::trace!(local=%local_addr, from=%remote_addr, len = %msg.len(), data=?msg.as_ref(), "memberlist_quic.packet: received packet");
-    let _read = msg.len();
-
-    if let Err(e) = packet_tx.send(Packet::new(remote_addr, start, msg)).await {
-      tracing::error!(local=%local_addr, from=%remote_addr, err = %e, "memberlist_quic.packet: failed to send packet");
-    }
-
-    #[cfg(feature = "metrics")]
-    metrics::counter!("memberlist.packet.received", metric_labels.iter()).increment(_read as u64);
-  }
 }

--- a/memberlist-quic/src/stream_layer.rs
+++ b/memberlist-quic/src/stream_layer.rs
@@ -99,7 +99,7 @@ pub trait QuicConnector: Send + Sync + 'static {
 
 /// A connection between local and remote peer.
 #[auto_impl::auto_impl(Box, Arc)]
-pub trait QuicConnection: Send + Sync + 'static {
+pub trait QuicConnection: Clone + Send + Sync + 'static {
   /// The bidirectional stream type.
   type Stream: QuicStream;
 
@@ -108,6 +108,12 @@ pub trait QuicConnection: Send + Sync + 'static {
 
   /// Opens a bidirectional stream to a remote peer.
   fn open_bi(&self) -> impl Future<Output = io::Result<(Self::Stream, SocketAddr)>> + Send;
+
+  /// Sends a datagram to the remote peer.
+  fn send_datagram(&self, data: Bytes) -> impl Future<Output = io::Result<()>> + Send;
+
+  /// Receives a datagram from the remote peer.
+  fn recv_datagram(&self) -> impl Future<Output = io::Result<Bytes>> + Send;
 
   /// Closes the connection.
   fn close(&self) -> impl Future<Output = io::Result<()>> + Send;

--- a/memberlist-quic/src/stream_layer.rs
+++ b/memberlist-quic/src/stream_layer.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, io, net::SocketAddr};
+use std::{io, net::SocketAddr};
 
 use agnostic_lite::RuntimeLite;
 use bytes::Bytes;
@@ -14,9 +14,6 @@ pub trait QuicStream:
 {
   /// The send stream type.
   type SendStream: memberlist_core::proto::ProtoWriter;
-
-  /// Read a packet from the the stream.
-  fn read_packet(&mut self) -> impl Future<Output = std::io::Result<Bytes>> + Send;
 }
 
 /// A trait for QUIC stream layers.

--- a/memberlist-quic/src/stream_layer/quinn.rs
+++ b/memberlist-quic/src/stream_layer/quinn.rs
@@ -18,24 +18,24 @@ use super::{QuicAcceptor, QuicConnection, QuicConnector, QuicStream, StreamLayer
 struct SharedEndpoint(Arc<Endpoint>);
 
 impl Clone for SharedEndpoint {
-    fn clone(&self) -> Self {
-        Self(Arc::clone(&self.0))
-    }
+  fn clone(&self) -> Self {
+    Self(Arc::clone(&self.0))
+  }
 }
 
 impl Deref for SharedEndpoint {
-    type Target = Endpoint;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+  type Target = Endpoint;
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
 }
 
 impl Drop for SharedEndpoint {
-    fn drop(&mut self) {
-        if Arc::strong_count(&self.0) == 1 {
-            Endpoint::close(&self.0, VarInt::from(0u32), b"endpoint shutdown");
-        }
+  fn drop(&mut self) {
+    if Arc::strong_count(&self.0) == 1 {
+      Endpoint::close(&self.0, VarInt::from(0u32), b"endpoint shutdown");
     }
+  }
 }
 
 /// [`Quinn`] is an implementation of [`StreamLayer`] based on [`quinn`].
@@ -183,7 +183,12 @@ where
     let conn = R::timeout(self.connect_timeout, connecting)
       .await
       .map_err(io::Error::from)??;
-    Ok(QuinnConnection::new(conn, self.local_addr, addr, self.max_packet_size))
+    Ok(QuinnConnection::new(
+      conn,
+      self.local_addr,
+      addr,
+      self.max_packet_size,
+    ))
   }
 
   async fn close(&self) -> io::Result<()> {
@@ -306,7 +311,12 @@ impl Clone for QuinnConnection {
 
 impl QuinnConnection {
   #[inline]
-  fn new(conn: Connection, local_addr: SocketAddr, remote_addr: SocketAddr, max_packet_size: usize) -> Self {
+  fn new(
+    conn: Connection,
+    local_addr: SocketAddr,
+    remote_addr: SocketAddr,
+    max_packet_size: usize,
+  ) -> Self {
     Self {
       conn,
       local_addr,
@@ -321,12 +331,35 @@ impl QuicConnection for QuinnConnection {
 
   async fn accept_bi(&self) -> io::Result<(Self::Stream, SocketAddr)> {
     let (send, recv) = self.conn.accept_bi().await?;
-    Ok((QuinnStream::new(send, recv, self.max_packet_size), self.remote_addr))
+    Ok((
+      QuinnStream::new(send, recv, self.max_packet_size),
+      self.remote_addr,
+    ))
   }
 
   async fn open_bi(&self) -> io::Result<(Self::Stream, SocketAddr)> {
     let (send, recv) = self.conn.open_bi().await?;
-    Ok((QuinnStream::new(send, recv, self.max_packet_size), self.remote_addr))
+    Ok((
+      QuinnStream::new(send, recv, self.max_packet_size),
+      self.remote_addr,
+    ))
+  }
+
+  async fn send_datagram(&self, data: bytes::Bytes) -> io::Result<()> {
+    self.conn.send_datagram_wait(data).await.map_err(|e| {
+      io::Error::new(
+        io::ErrorKind::Other,
+        format!("failed to send datagram: {e}"),
+      )
+    })
+  }
+
+  async fn recv_datagram(&self) -> io::Result<bytes::Bytes> {
+    self
+      .conn
+      .read_datagram()
+      .await
+      .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("datagram read error: {e}")))
   }
 
   async fn close(&self) -> io::Result<()> {

--- a/memberlist-quic/src/stream_layer/quinn.rs
+++ b/memberlist-quic/src/stream_layer/quinn.rs
@@ -2,7 +2,6 @@ use std::{io, marker::PhantomData, net::SocketAddr, ops::Deref, sync::Arc, time:
 
 use agnostic::Runtime;
 use futures::AsyncWriteExt;
-use futures::io::AsyncReadExt;
 use peekable::future::AsyncPeekable;
 use quinn::{ClientConfig, Connection, Endpoint, RecvStream, SendStream, VarInt};
 use smol_str::SmolStr;
@@ -97,7 +96,6 @@ impl<R: Runtime> StreamLayer for Quinn<R> {
     let acceptor = Self::Acceptor {
       endpoint: shared_ep.clone(),
       local_addr,
-      max_packet_size: self.opts.max_packet_size,
     };
 
     let connector = Self::Connector {
@@ -107,7 +105,6 @@ impl<R: Runtime> StreamLayer for Quinn<R> {
       client_config,
       connect_timeout: self.opts.connect_timeout,
       _marker: PhantomData,
-      max_packet_size: self.opts.max_packet_size,
     };
     Ok((local_addr, acceptor, connector))
   }
@@ -117,7 +114,6 @@ impl<R: Runtime> StreamLayer for Quinn<R> {
 pub struct QuinnAcceptor {
   endpoint: SharedEndpoint,
   local_addr: SocketAddr,
-  max_packet_size: usize,
 }
 
 impl Clone for QuinnAcceptor {
@@ -125,7 +121,6 @@ impl Clone for QuinnAcceptor {
     Self {
       endpoint: self.endpoint.clone(),
       local_addr: self.local_addr,
-      max_packet_size: self.max_packet_size,
     }
   }
 }
@@ -142,10 +137,7 @@ impl QuicAcceptor for QuinnAcceptor {
       .await?;
     let remote_addr = conn.remote_address();
 
-    Ok((
-      QuinnConnection::new(conn, self.local_addr, remote_addr, self.max_packet_size),
-      remote_addr,
-    ))
+    Ok((QuinnConnection::new(conn, self.local_addr, remote_addr), remote_addr))
   }
 
   async fn close(&mut self) -> io::Result<()> {
@@ -166,7 +158,6 @@ pub struct QuinnConnector<R> {
   connect_timeout: Duration,
   local_addr: SocketAddr,
   _marker: PhantomData<R>,
-  max_packet_size: usize,
 }
 
 impl<R> QuicConnector for QuinnConnector<R>
@@ -183,12 +174,7 @@ where
     let conn = R::timeout(self.connect_timeout, connecting)
       .await
       .map_err(io::Error::from)??;
-    Ok(QuinnConnection::new(
-      conn,
-      self.local_addr,
-      addr,
-      self.max_packet_size,
-    ))
+    Ok(QuinnConnection::new(conn, self.local_addr, addr))
   }
 
   async fn close(&self) -> io::Result<()> {
@@ -212,16 +198,14 @@ where
 pub struct QuinnStream {
   send: SendStream,
   recv: AsyncPeekable<RecvStream>,
-  max_packet_size: usize,
 }
 
 impl QuinnStream {
   #[inline]
-  fn new(send: SendStream, recv: RecvStream, max_packet_size: usize) -> Self {
+  fn new(send: SendStream, recv: RecvStream) -> Self {
     Self {
       send,
       recv: AsyncPeekable::from(recv),
-      max_packet_size,
     }
   }
 }
@@ -265,29 +249,6 @@ impl memberlist_core::transport::Connection for QuinnStream {
 
 impl QuicStream for QuinnStream {
   type SendStream = SendStream;
-
-  async fn read_packet(&mut self) -> std::io::Result<bytes::Bytes> {
-    // AsyncPeekable implements AsyncRead. Read in a loop until EOF,
-    // enforcing the max_packet_size limit.
-    let mut buf = bytes::BytesMut::with_capacity(4096);
-    loop {
-      let len = buf.len();
-      buf.resize(len + 4096, 0);
-      let n = self.recv.read(&mut buf[len..]).await?;
-      if n == 0 {
-        buf.truncate(len);
-        break;
-      }
-      buf.truncate(len + n);
-      if buf.len() > self.max_packet_size {
-        return Err(std::io::Error::new(
-          std::io::ErrorKind::InvalidData,
-          "packet too large",
-        ));
-      }
-    }
-    Ok(buf.freeze())
-  }
 }
 
 /// A connection based on [`quinn`].
@@ -295,7 +256,6 @@ pub struct QuinnConnection {
   conn: Connection,
   local_addr: SocketAddr,
   remote_addr: SocketAddr,
-  max_packet_size: usize,
 }
 
 impl Clone for QuinnConnection {
@@ -304,24 +264,17 @@ impl Clone for QuinnConnection {
       conn: self.conn.clone(),
       local_addr: self.local_addr,
       remote_addr: self.remote_addr,
-      max_packet_size: self.max_packet_size,
     }
   }
 }
 
 impl QuinnConnection {
   #[inline]
-  fn new(
-    conn: Connection,
-    local_addr: SocketAddr,
-    remote_addr: SocketAddr,
-    max_packet_size: usize,
-  ) -> Self {
+  fn new(conn: Connection, local_addr: SocketAddr, remote_addr: SocketAddr) -> Self {
     Self {
       conn,
       local_addr,
       remote_addr,
-      max_packet_size,
     }
   }
 }
@@ -331,18 +284,12 @@ impl QuicConnection for QuinnConnection {
 
   async fn accept_bi(&self) -> io::Result<(Self::Stream, SocketAddr)> {
     let (send, recv) = self.conn.accept_bi().await?;
-    Ok((
-      QuinnStream::new(send, recv, self.max_packet_size),
-      self.remote_addr,
-    ))
+    Ok((QuinnStream::new(send, recv), self.remote_addr))
   }
 
   async fn open_bi(&self) -> io::Result<(Self::Stream, SocketAddr)> {
     let (send, recv) = self.conn.open_bi().await?;
-    Ok((
-      QuinnStream::new(send, recv, self.max_packet_size),
-      self.remote_addr,
-    ))
+    Ok((QuinnStream::new(send, recv), self.remote_addr))
   }
 
   async fn send_datagram(&self, data: bytes::Bytes) -> io::Result<()> {

--- a/memberlist-quic/src/stream_layer/quinn.rs
+++ b/memberlist-quic/src/stream_layer/quinn.rs
@@ -346,12 +346,11 @@ impl QuicConnection for QuinnConnection {
   }
 
   async fn send_datagram(&self, data: bytes::Bytes) -> io::Result<()> {
-    self.conn.send_datagram_wait(data).await.map_err(|e| {
-      io::Error::new(
-        io::ErrorKind::Other,
-        format!("failed to send datagram: {e}"),
-      )
-    })
+    self
+      .conn
+      .send_datagram_wait(data)
+      .await
+      .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
   }
 
   async fn recv_datagram(&self) -> io::Result<bytes::Bytes> {
@@ -359,7 +358,7 @@ impl QuicConnection for QuinnConnection {
       .conn
       .read_datagram()
       .await
-      .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("datagram read error: {e}")))
+      .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
   }
 
   async fn close(&self) -> io::Result<()> {

--- a/memberlist-quic/src/stream_layer/quinn/options.rs
+++ b/memberlist-quic/src/stream_layer/quinn/options.rs
@@ -133,9 +133,7 @@ pub struct Options {
       const,
       attrs(doc = "Gets the maximum packet size in bytes for `read_packet()`.")
     ),
-    setter(attrs(
-      doc = "Sets the maximum packet size in bytes for `read_packet()`."
-    ))
+    setter(attrs(doc = "Sets the maximum packet size in bytes for `read_packet()`."))
   )]
   max_packet_size: u32,
 
@@ -233,8 +231,10 @@ impl From<Options> for QuinnOptions {
     let mut transport = quinn::TransportConfig::default();
     transport.max_concurrent_uni_streams(max_concurrent_stream_limit.into());
     transport.max_concurrent_bidi_streams(max_concurrent_stream_limit.into());
-    // Disable datagrams.
-    transport.datagram_receive_buffer_size(None);
+    // Enable datagrams for packet transport. 65536 bytes is the maximum
+    // allowed by the QUIC datagram protocol (RFC 9221, 16-bit length field),
+    // so hardcoding this value is correct.
+    transport.datagram_receive_buffer_size(Some(65536));
     transport.keep_alive_interval(Some(keep_alive_interval));
     transport.max_idle_timeout(Some(VarInt::from_u32(max_idle_timeout).into()));
     transport.allow_spin(false);

--- a/memberlist-quic/src/stream_layer/quinn/options.rs
+++ b/memberlist-quic/src/stream_layer/quinn/options.rs
@@ -124,19 +124,6 @@ pub struct Options {
   )]
   max_connection_data: u32,
 
-  /// Maximum packet size in bytes for `read_packet()`.
-  /// A malicious peer cannot force allocation beyond this limit.
-  ///
-  /// Default is 10MB.
-  #[viewit(
-    getter(
-      const,
-      attrs(doc = "Gets the maximum packet size in bytes for `read_packet()`.")
-    ),
-    setter(attrs(doc = "Sets the maximum packet size in bytes for `read_packet()`."))
-  )]
-  max_packet_size: u32,
-
   /// TLS client config for the inner [`quinn::ClientConfig`].
   #[viewit(
     getter(
@@ -193,7 +180,6 @@ impl Options {
       // Ensure that one stream is not consuming the whole connection.
       max_stream_data: 10_000_000,
       mtu_discovery_config: Some(Default::default()),
-      max_packet_size: 10_000_000,
     }
   }
 }
@@ -209,7 +195,6 @@ pub(super) struct QuinnOptions {
   connect_timeout: Duration,
   max_stream_data: usize,
   max_connection_data: usize,
-  max_packet_size: usize,
 }
 
 impl From<Options> for QuinnOptions {
@@ -226,7 +211,6 @@ impl From<Options> for QuinnOptions {
       endpoint_config,
       mtu_discovery_config,
       connect_timeout,
-      max_packet_size,
     } = config;
     let mut transport = quinn::TransportConfig::default();
     transport.max_concurrent_uni_streams(max_concurrent_stream_limit.into());
@@ -258,7 +242,6 @@ impl From<Options> for QuinnOptions {
       max_stream_data: max_stream_data as usize,
       max_connection_data: max_connection_data as usize,
       connect_timeout,
-      max_packet_size: max_packet_size as usize,
     }
   }
 }

--- a/memberlist-quic/src/stream_layer/quinn/options.rs
+++ b/memberlist-quic/src/stream_layer/quinn/options.rs
@@ -231,10 +231,10 @@ impl From<Options> for QuinnOptions {
     let mut transport = quinn::TransportConfig::default();
     transport.max_concurrent_uni_streams(max_concurrent_stream_limit.into());
     transport.max_concurrent_bidi_streams(max_concurrent_stream_limit.into());
-    // Enable datagrams for packet transport. 65536 bytes is the maximum
-    // allowed by the QUIC datagram protocol (RFC 9221, 16-bit length field),
-    // so hardcoding this value is correct.
-    transport.datagram_receive_buffer_size(Some(65536));
+    // Enable datagram reception for packet transport.
+    // This sets the size (in bytes) of quinn's internal queue for received
+    // datagrams; it does not impose a protocol-level maximum datagram size.
+    transport.datagram_receive_buffer_size(Some(65_536));
     transport.keep_alive_interval(Some(keep_alive_interval));
     transport.max_idle_timeout(Some(VarInt::from_u32(max_idle_timeout).into()));
     transport.allow_spin(false);

--- a/memberlist-quic/src/tests.rs
+++ b/memberlist-quic/src/tests.rs
@@ -230,10 +230,6 @@ mod unit_tests {
 
   impl crate::QuicStream for NoopStream {
     type SendStream = futures::io::Cursor<Vec<u8>>;
-
-    async fn read_packet(&mut self) -> io::Result<Bytes> {
-      Ok(Bytes::new())
-    }
   }
 
   impl crate::QuicConnection for NoopConn {
@@ -438,14 +434,12 @@ mod unit_tests {
       assert_eq!(*opts.max_concurrent_stream_limit(), 256);
       assert_eq!(*opts.max_stream_data(), 10_000_000);
       assert_eq!(*opts.max_connection_data(), 15_000_000);
-      assert_eq!(*opts.max_packet_size(), 10_000_000);
 
       let layer = TestLayer::new(
         opts
           .clone()
           .with_max_stream_data(64)
-          .with_max_connection_data(32)
-          .with_max_packet_size(128),
+          .with_max_connection_data(32),
       )
       .await
       .unwrap();
@@ -622,15 +616,17 @@ mod unit_tests {
       );
       writer.close().await.unwrap();
 
-      let (from, mut inbound) = TokioRuntime::timeout(Duration::from_secs(2), t2.stream().recv())
+      let (from, inbound) = TokioRuntime::timeout(Duration::from_secs(2), t2.stream().recv())
         .await
         .unwrap()
         .unwrap();
       assert_eq!(from, *t1.advertise_address());
-      assert_eq!(
-        inbound.read_packet().await.unwrap(),
-        Bytes::from_static(b"stream-data")
-      );
+
+      let (mut reader, _) = inbound.split();
+      use futures::io::AsyncReadExt;
+      let mut buf = Vec::new();
+      reader.read_to_end(&mut buf).await.unwrap();
+      assert_eq!(&buf, b"stream-data");
 
       let mut outbound = t1.open(t2.advertise_address(), deadline).await.unwrap();
       outbound.write_all(b"abcdef").await.unwrap();
@@ -692,7 +688,7 @@ mod unit_tests {
       let t1 = transport("cleaner-1").await;
       let t2 = transport("cleaner-2").await;
       let addr = *t2.advertise_address();
-      let conn = t1.fetch_connection(addr).await.unwrap();
+      let conn = t1.fetch_connection(addr, None).await.unwrap();
       assert_eq!(t1.connection_pool.len(), 1);
 
       conn.close().await.unwrap();
@@ -775,12 +771,14 @@ mod unit_tests {
       client_stream.flush().await.unwrap();
       client_stream.close().await.unwrap();
 
-      let (mut server_stream, stream_addr) = server_conn.accept_bi().await.unwrap();
+      let (server_stream, stream_addr) = server_conn.accept_bi().await.unwrap();
       assert_eq!(stream_addr, addr1);
-      assert_eq!(
-        server_stream.read_packet().await.unwrap(),
-        Bytes::from_static(b"direct-stream")
-      );
+
+      let (mut reader, _) = server_stream.split();
+      use futures::io::AsyncReadExt;
+      let mut buf = Vec::new();
+      reader.read_to_end(&mut buf).await.unwrap();
+      assert_eq!(&buf, b"direct-stream");
 
       client_conn.close().await.unwrap();
       server_conn.close().await.unwrap();

--- a/memberlist-quic/src/tests.rs
+++ b/memberlist-quic/src/tests.rs
@@ -157,3 +157,636 @@ mod quinn_stream_layer {
     .with_connect_timeout(timeout)
   }
 }
+
+#[cfg(all(test, feature = "tokio", feature = "quinn"))]
+mod unit_tests {
+  use std::{borrow::Cow, io, net::SocketAddr, time::Duration};
+
+  use agnostic_lite::{RuntimeLite, tokio::TokioRuntime};
+  use bytes::Bytes;
+  use memberlist_core::{
+    proto::{CIDRsPolicy, Payload, ProtoWriter as _},
+    transport::{Connection as _, Transport as _, TransportError as _},
+  };
+  use nodecraft::resolver::socket_addr::SocketAddrResolver;
+  use smol_str::SmolStr;
+
+  use crate::{
+    QuicAcceptor as _, QuicConnection as _, QuicConnector as _, QuicStream as _, QuicTransport,
+    QuicTransportError, QuicTransportOptions, StreamLayer as _, stream_layer::quinn::Quinn,
+  };
+
+  type TestResolver = SocketAddrResolver<TokioRuntime>;
+  type TestLayer = Quinn<TokioRuntime>;
+  type TestTransport = QuicTransport<SmolStr, TestResolver, TestLayer, TokioRuntime>;
+  type DefaultOptionsTransport = QuicTransport<SmolStr, TestResolver, NoopLayer, TokioRuntime>;
+
+  struct NoopLayer;
+  struct NoopAcceptor;
+  struct NoopConnector;
+  #[derive(Clone)]
+  struct NoopConn;
+  struct NoopStream;
+
+  impl memberlist_core::transport::Connection for NoopStream {
+    type Reader = peekable::future::AsyncPeekable<futures::io::Cursor<Vec<u8>>>;
+    type Writer = futures::io::Cursor<Vec<u8>>;
+
+    fn split(self) -> (Self::Reader, Self::Writer) {
+      (
+        peekable::future::AsyncPeekable::from(futures::io::Cursor::new(Vec::new())),
+        futures::io::Cursor::new(Vec::new()),
+      )
+    }
+
+    async fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+      Ok(0)
+    }
+
+    async fn read_exact(&mut self, _buf: &mut [u8]) -> io::Result<()> {
+      Ok(())
+    }
+
+    async fn peek(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+      Ok(0)
+    }
+
+    async fn peek_exact(&mut self, _buf: &mut [u8]) -> io::Result<()> {
+      Ok(())
+    }
+
+    async fn write_all(&mut self, _payload: &[u8]) -> io::Result<()> {
+      Ok(())
+    }
+
+    async fn flush(&mut self) -> io::Result<()> {
+      Ok(())
+    }
+
+    async fn close(&mut self) -> io::Result<()> {
+      Ok(())
+    }
+  }
+
+  impl crate::QuicStream for NoopStream {
+    type SendStream = futures::io::Cursor<Vec<u8>>;
+
+    async fn read_packet(&mut self) -> io::Result<Bytes> {
+      Ok(Bytes::new())
+    }
+  }
+
+  impl crate::QuicConnection for NoopConn {
+    type Stream = NoopStream;
+
+    async fn accept_bi(&self) -> io::Result<(Self::Stream, SocketAddr)> {
+      Ok((NoopStream, loopback(0)))
+    }
+
+    async fn open_bi(&self) -> io::Result<(Self::Stream, SocketAddr)> {
+      Ok((NoopStream, loopback(0)))
+    }
+
+    async fn send_datagram(&self, _data: Bytes) -> io::Result<()> {
+      Ok(())
+    }
+
+    async fn recv_datagram(&self) -> io::Result<Bytes> {
+      Ok(Bytes::new())
+    }
+
+    async fn close(&self) -> io::Result<()> {
+      Ok(())
+    }
+
+    async fn is_closed(&self) -> bool {
+      false
+    }
+
+    fn local_addr(&self) -> SocketAddr {
+      loopback(0)
+    }
+  }
+
+  impl crate::QuicAcceptor for NoopAcceptor {
+    type Connection = NoopConn;
+
+    async fn accept(&mut self) -> io::Result<(Self::Connection, SocketAddr)> {
+      Ok((NoopConn, loopback(0)))
+    }
+
+    async fn close(&mut self) -> io::Result<()> {
+      Ok(())
+    }
+
+    fn local_addr(&self) -> SocketAddr {
+      loopback(0)
+    }
+  }
+
+  impl crate::QuicConnector for NoopConnector {
+    type Connection = NoopConn;
+
+    async fn connect(&self, _addr: SocketAddr) -> io::Result<Self::Connection> {
+      Ok(NoopConn)
+    }
+
+    async fn close(&self) -> io::Result<()> {
+      Ok(())
+    }
+
+    async fn wait_idle(&self) -> io::Result<()> {
+      Ok(())
+    }
+
+    fn local_addr(&self) -> SocketAddr {
+      loopback(0)
+    }
+  }
+
+  impl crate::StreamLayer for NoopLayer {
+    type Runtime = TokioRuntime;
+    type Acceptor = NoopAcceptor;
+    type Connector = NoopConnector;
+    type Stream = NoopStream;
+    type Connection = NoopConn;
+    type Options = ();
+
+    fn max_stream_data(&self) -> usize {
+      usize::MAX
+    }
+
+    async fn new(_options: Self::Options) -> io::Result<Self> {
+      Ok(Self)
+    }
+
+    async fn bind(
+      &self,
+      addr: SocketAddr,
+    ) -> io::Result<(SocketAddr, Self::Acceptor, Self::Connector)> {
+      Ok((addr, NoopAcceptor, NoopConnector))
+    }
+  }
+
+  fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+      .enable_all()
+      .build()
+      .unwrap()
+  }
+
+  fn payload(bytes: &[u8]) -> Payload {
+    let mut payload = Payload::new(0, bytes.len());
+    payload.data_mut().copy_from_slice(bytes);
+    payload
+  }
+
+  fn payload_with_header(header: &[u8], data: &[u8]) -> Payload {
+    let mut payload = Payload::new(header.len(), data.len());
+    payload.header_mut().copy_from_slice(header);
+    payload.data_mut().copy_from_slice(data);
+    payload
+  }
+
+  fn loopback(port: u16) -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], port))
+  }
+
+  async fn transport(id: &str) -> TestTransport {
+    transport_with(id, None, None, loopback(0)).await
+  }
+
+  async fn transport_with(
+    id: &str,
+    timeout: Option<Duration>,
+    advertise: Option<SocketAddr>,
+    bind_addr: SocketAddr,
+  ) -> TestTransport {
+    let mut opts =
+      QuicTransportOptions::<SmolStr, TestResolver, TestLayer>::with_stream_layer_options(
+        id.into(),
+        super::quinn_stream_layer::<TokioRuntime>().await,
+      );
+    opts.add_bind_address(bind_addr);
+    if let Some(timeout) = timeout {
+      opts = opts.with_timeout(Some(timeout));
+    }
+    if let Some(advertise) = advertise {
+      opts = opts.with_advertise_address(advertise);
+    }
+    TestTransport::new(opts).await.unwrap()
+  }
+
+  fn unused_loopback_addr() -> SocketAddr {
+    let sock = std::net::UdpSocket::bind(loopback(0)).unwrap();
+    sock.local_addr().unwrap()
+  }
+
+  #[test]
+  fn options_defaults_clone_and_into_parts() {
+    let _default_opts =
+      <DefaultOptionsTransport as memberlist_core::transport::Transport>::Options::new(
+        "node-default".into(),
+      );
+    let _resolver_opts =
+      <DefaultOptionsTransport as memberlist_core::transport::Transport>::Options::with_resolver_options(
+        "node-resolver".into(),
+        (),
+      );
+
+    let opts =
+      QuicTransportOptions::<SmolStr, TestResolver, TestLayer>::with_resolver_options_and_stream_layer_options(
+        "node-a".into(),
+        (),
+        rt().block_on(super::quinn_stream_layer::<TokioRuntime>()),
+      )
+      .with_timeout(Some(Duration::from_millis(250)))
+      .with_connection_ttl(Some(Duration::from_millis(500)))
+      .with_connection_pool_cleanup_period(Duration::from_millis(750))
+      .with_max_packet_size(512)
+      .with_cidrs_policy(CIDRsPolicy::block_all())
+      .with_advertise_address(loopback(9000));
+
+    let mut cloned = opts.clone();
+    cloned.add_bind_address(loopback(0));
+    cloned.add_bind_address(loopback(0));
+
+    assert_eq!(cloned.id(), "node-a");
+    assert_eq!(cloned.bind_addresses().len(), 1);
+    assert_eq!(cloned.advertise_address(), Some(&loopback(9000)));
+    assert_eq!(cloned.timeout(), Some(Duration::from_millis(250)));
+    assert_eq!(cloned.connection_ttl(), Some(Duration::from_millis(500)));
+    assert_eq!(
+      cloned.connection_pool_cleanup_period(),
+      Duration::from_millis(750)
+    );
+    assert_eq!(cloned.max_packet_size(), 512);
+    assert!(cloned.cidrs_policy().is_block_all());
+  }
+
+  #[test]
+  fn quinn_options_defaults_and_stream_data_limit() {
+    rt().block_on(async {
+      let opts = super::quinn_stream_layer::<TokioRuntime>().await;
+      assert_eq!(opts.server_name(), "localhost");
+      assert_eq!(*opts.connect_timeout(), Duration::from_secs(10));
+      assert_eq!(
+        *opts.max_idle_timeout(),
+        Duration::from_secs(10).as_millis() as u32
+      );
+      assert_eq!(*opts.keep_alive_interval(), Duration::from_secs(8));
+      assert_eq!(*opts.max_concurrent_stream_limit(), 256);
+      assert_eq!(*opts.max_stream_data(), 10_000_000);
+      assert_eq!(*opts.max_connection_data(), 15_000_000);
+      assert_eq!(*opts.max_packet_size(), 10_000_000);
+
+      let layer = TestLayer::new(
+        opts
+          .clone()
+          .with_max_stream_data(64)
+          .with_max_connection_data(32)
+          .with_max_packet_size(128),
+      )
+      .await
+      .unwrap();
+      assert_eq!(layer.max_stream_data(), 32);
+    });
+  }
+
+  #[test]
+  fn transport_error_classifies_remote_failures() {
+    let remote_kinds = [
+      io::ErrorKind::ConnectionRefused,
+      io::ErrorKind::ConnectionReset,
+      io::ErrorKind::ConnectionAborted,
+      io::ErrorKind::BrokenPipe,
+      io::ErrorKind::TimedOut,
+      io::ErrorKind::NotConnected,
+    ];
+
+    for kind in remote_kinds {
+      let err = QuicTransportError::<TestResolver>::Io(io::Error::from(kind));
+      assert!(err.is_remote_failure(), "{kind:?}");
+    }
+
+    assert!(!QuicTransportError::<TestResolver>::PacketTooLarge(1024).is_remote_failure());
+    assert!(!QuicTransportError::<TestResolver>::NoPrivateIP.is_remote_failure());
+    assert!(!QuicTransportError::<TestResolver>::EmptyBindAddresses.is_remote_failure());
+    assert!(
+      !QuicTransportError::<TestResolver>::Custom(Cow::Borrowed("custom")).is_remote_failure()
+    );
+    assert!(matches!(
+      QuicTransportError::<TestResolver>::custom(Cow::Borrowed("via-trait")),
+      QuicTransportError::Custom(Cow::Borrowed("via-trait"))
+    ));
+  }
+
+  #[test]
+  fn advertise_address_index_prefers_specific_addresses() {
+    let unspecified_v4 = SocketAddr::from(([0, 0, 0, 0], 1));
+    let specific_v4 = loopback(2);
+    let unspecified_v6 = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0], 3));
+    let specific_v6 = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 4));
+
+    assert_eq!(
+      TestTransport::find_advertise_addr_index(&[unspecified_v4, specific_v4]),
+      1
+    );
+    assert_eq!(
+      TestTransport::find_advertise_addr_index(&[unspecified_v4, unspecified_v6]),
+      0
+    );
+    assert_eq!(
+      TestTransport::find_advertise_addr_index(&[unspecified_v4, specific_v6]),
+      1
+    );
+  }
+
+  #[test]
+  fn empty_bind_addresses_are_rejected() {
+    rt().block_on(async {
+      let opts =
+        QuicTransportOptions::<SmolStr, TestResolver, TestLayer>::with_stream_layer_options(
+          "empty".into(),
+          super::quinn_stream_layer::<TokioRuntime>().await,
+        );
+
+      let err = match TestTransport::new(opts).await {
+        Ok(_) => panic!("transport creation should fail without bind addresses"),
+        Err(err) => err,
+      };
+      assert!(matches!(err, QuicTransportError::EmptyBindAddresses));
+    });
+  }
+
+  #[test]
+  fn non_zero_bind_and_advertise_address_are_used() {
+    rt().block_on(async {
+      let advertise = loopback(9191);
+      let bind_addr = unused_loopback_addr();
+      let transport = transport_with("non-zero", None, Some(advertise), bind_addr).await;
+
+      assert_eq!(*transport.advertise_address(), advertise);
+      assert_eq!(*transport.local_address(), bind_addr);
+      assert_eq!(
+        transport.resolve(transport.local_address()).await.unwrap(),
+        bind_addr
+      );
+      assert!(transport.blocked_address(&bind_addr).is_ok());
+
+      transport.shutdown().await.unwrap();
+    });
+  }
+
+  #[test]
+  fn new_transport_exposes_local_metadata_and_blocks_disallowed_ips() {
+    rt().block_on(async {
+      let mut opts =
+        QuicTransportOptions::<SmolStr, TestResolver, TestLayer>::with_stream_layer_options(
+          "metadata".into(),
+          super::quinn_stream_layer::<TokioRuntime>().await,
+        )
+        .with_max_packet_size(1024)
+        .with_cidrs_policy(CIDRsPolicy::block_all());
+      opts.add_bind_address(loopback(0));
+      let transport = TestTransport::new(opts).await.unwrap();
+
+      assert_eq!(transport.local_id(), "metadata");
+      assert_eq!(transport.header_overhead(), 0);
+      assert!(!transport.packet_reliable());
+      assert!(transport.packet_secure());
+      assert!(transport.stream_secure());
+      assert!(transport.max_packet_size() <= 1024);
+      assert_eq!(transport.local_address().ip(), loopback(0).ip());
+      assert_eq!(transport.advertise_address().ip(), loopback(0).ip());
+      assert!(matches!(
+        transport.blocked_address(&loopback(8080)),
+        Err(QuicTransportError::BlockedIp(_))
+      ));
+
+      transport.shutdown().await.unwrap();
+      transport.shutdown().await.unwrap();
+    });
+  }
+
+  #[test]
+  fn datagrams_are_sent_to_packet_subscriber() {
+    rt().block_on(async {
+      let t1 = transport_with(
+        "datagram-1",
+        Some(Duration::from_secs(2)),
+        None,
+        loopback(0),
+      )
+      .await;
+      let t2 = transport("datagram-2").await;
+      let sent_at = TokioRuntime::now();
+
+      let (len, timestamp) = t1
+        .send_to(
+          t2.advertise_address(),
+          payload_with_header(b"ignored", b"hello"),
+        )
+        .await
+        .unwrap();
+      assert_eq!(len, 12);
+      assert!(timestamp >= sent_at);
+
+      let packet = TokioRuntime::timeout(Duration::from_secs(2), t2.packet().recv())
+        .await
+        .unwrap()
+        .unwrap();
+      let (from, _, bytes) = packet.into_components();
+      assert_eq!(from, *t1.advertise_address());
+      assert_eq!(bytes, Bytes::from_static(b"ignoredhello"));
+
+      t1.shutdown().await.unwrap();
+      t2.shutdown().await.unwrap();
+    });
+  }
+
+  #[test]
+  fn bidirectional_streams_are_delivered_to_stream_subscriber() {
+    rt().block_on(async {
+      let t1 = transport_with("stream-1", Some(Duration::from_secs(2)), None, loopback(0)).await;
+      let t2 = transport("stream-2").await;
+      let deadline = TokioRuntime::now() + Duration::from_secs(2);
+
+      let outbound = t1.open(t2.advertise_address(), deadline).await.unwrap();
+      let (_, mut writer) = outbound.split();
+      assert_eq!(
+        t1.write(&mut writer, payload(b"stream-data"))
+          .await
+          .unwrap(),
+        11
+      );
+      writer.close().await.unwrap();
+
+      let (from, mut inbound) = TokioRuntime::timeout(Duration::from_secs(2), t2.stream().recv())
+        .await
+        .unwrap()
+        .unwrap();
+      assert_eq!(from, *t1.advertise_address());
+      assert_eq!(
+        inbound.read_packet().await.unwrap(),
+        Bytes::from_static(b"stream-data")
+      );
+
+      let mut outbound = t1.open(t2.advertise_address(), deadline).await.unwrap();
+      outbound.write_all(b"abcdef").await.unwrap();
+      outbound.flush().await.unwrap();
+      outbound.close().await.unwrap();
+
+      let (_, mut inbound) = TokioRuntime::timeout(Duration::from_secs(2), t2.stream().recv())
+        .await
+        .unwrap()
+        .unwrap();
+      let mut reader = [0; 3];
+      assert_eq!(inbound.peek(&mut reader[..2]).await.unwrap(), 2);
+      assert_eq!(&reader[..2], b"ab");
+      inbound.peek_exact(&mut reader).await.unwrap();
+      assert_eq!(&reader, b"abc");
+      assert_eq!(inbound.read(&mut reader[..2]).await.unwrap(), 2);
+      assert_eq!(&reader[..2], b"ab");
+      let mut rest = [0; 4];
+      inbound.read_exact(&mut rest).await.unwrap();
+      assert_eq!(&rest, b"cdef");
+
+      let (mut empty_reader, _) = t1
+        .open(t2.advertise_address(), deadline)
+        .await
+        .unwrap()
+        .split();
+      assert_eq!(
+        t1.read(t2.advertise_address(), &mut empty_reader)
+          .await
+          .unwrap(),
+        0
+      );
+
+      t1.shutdown().await.unwrap();
+      t2.shutdown().await.unwrap();
+    });
+  }
+
+  #[test]
+  fn connection_pool_reuses_open_connections() {
+    rt().block_on(async {
+      let t1 = transport("pool-1").await;
+      let t2 = transport("pool-2").await;
+      let addr = *t2.advertise_address();
+
+      let first = t1.send_to(&addr, payload(b"one")).await.unwrap();
+      let second = t1.send_to(&addr, payload(b"two")).await.unwrap();
+      assert_eq!(first.0, 3);
+      assert_eq!(second.0, 3);
+
+      t1.shutdown().await.unwrap();
+      t2.shutdown().await.unwrap();
+    });
+  }
+
+  #[test]
+  fn connection_pool_cleaner_removes_closed_connections() {
+    rt().block_on(async {
+      let t1 = transport("cleaner-1").await;
+      let t2 = transport("cleaner-2").await;
+      let addr = *t2.advertise_address();
+      let conn = t1.fetch_connection(addr).await.unwrap();
+      assert_eq!(t1.connection_pool.len(), 1);
+
+      conn.close().await.unwrap();
+      let (_shutdown_tx, shutdown_rx) = async_channel::bounded(1);
+      TokioRuntime::timeout(
+        Duration::from_millis(100),
+        TestTransport::connection_pool_cleaner(
+          t1.connection_pool.clone(),
+          TokioRuntime::interval(Duration::from_millis(1)),
+          shutdown_rx,
+          Duration::ZERO,
+        ),
+      )
+      .await
+      .unwrap_err();
+      assert_eq!(t1.connection_pool.len(), 0);
+
+      t1.shutdown().await.unwrap();
+      t2.shutdown().await.unwrap();
+    });
+  }
+
+  #[test]
+  fn quinn_layer_bind_acceptor_and_connector_accessors() {
+    rt().block_on(async {
+      let layer = TestLayer::new(super::quinn_stream_layer::<TokioRuntime>().await)
+        .await
+        .unwrap();
+      let (local_addr, mut acceptor, connector) = layer.bind(loopback(0)).await.unwrap();
+      let cloned = acceptor.clone();
+
+      assert_eq!(acceptor.local_addr(), local_addr);
+      assert_eq!(cloned.local_addr(), local_addr);
+      assert_eq!(connector.local_addr(), local_addr);
+
+      connector.close().await.unwrap();
+      connector.wait_idle().await.unwrap();
+      acceptor.close().await.unwrap();
+    });
+  }
+
+  #[test]
+  fn quinn_connection_direct_datagram_and_stream_round_trip() {
+    rt().block_on(async {
+      let layer1 = TestLayer::new(super::quinn_stream_layer::<TokioRuntime>().await)
+        .await
+        .unwrap();
+      let layer2 = TestLayer::new(super::quinn_stream_layer::<TokioRuntime>().await)
+        .await
+        .unwrap();
+      let (addr1, _acceptor1, connector1) = layer1.bind(loopback(0)).await.unwrap();
+      let (addr2, mut acceptor2, _connector2) = layer2.bind(loopback(0)).await.unwrap();
+
+      let connect = connector1.connect(addr2);
+      let accept = acceptor2.accept();
+      let (client_conn, accepted) = TokioRuntime::timeout(Duration::from_secs(2), async {
+        futures::join!(connect, accept)
+      })
+      .await
+      .unwrap();
+      let client_conn = client_conn.unwrap();
+      let (server_conn, remote_addr) = accepted.unwrap();
+      assert_eq!(remote_addr, addr1);
+      assert_eq!(client_conn.local_addr(), addr1);
+      assert_eq!(server_conn.local_addr(), addr2);
+      assert!(!client_conn.is_closed().await);
+
+      client_conn
+        .send_datagram(Bytes::from_static(b"direct-datagram"))
+        .await
+        .unwrap();
+      assert_eq!(
+        server_conn.recv_datagram().await.unwrap(),
+        Bytes::from_static(b"direct-datagram")
+      );
+
+      let (mut client_stream, stream_addr) = client_conn.open_bi().await.unwrap();
+      assert_eq!(stream_addr, addr2);
+      client_stream.write_all(b"direct-stream").await.unwrap();
+      client_stream.flush().await.unwrap();
+      client_stream.close().await.unwrap();
+
+      let (mut server_stream, stream_addr) = server_conn.accept_bi().await.unwrap();
+      assert_eq!(stream_addr, addr1);
+      assert_eq!(
+        server_stream.read_packet().await.unwrap(),
+        Bytes::from_static(b"direct-stream")
+      );
+
+      client_conn.close().await.unwrap();
+      server_conn.close().await.unwrap();
+      assert!(client_conn.is_closed().await);
+      connector1.close().await.unwrap();
+      acceptor2.close().await.unwrap();
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Switches `memberlist-quic` from using per-packet bidirectional streams to QUIC's datagram API (`send_datagram` / `recv_datagram`) for sending unreliable messages, as proposed in [#119](https://github.com/al8n/memberlist/issues/119).

Key changes:

- **QUIC datagrams replace bidirectional streams for packet transport** — previously each packet opened a new `open_bi → write_all → flush → close` stream, incurring per-packet setup overhead and not matching memberlist's best-effort probe semantics. Datagrams provide true best-effort delivery over the same connection with no stream setup overhead and correct drop semantics for probes.

- **Removes `StreamType` routing tag** — datagrams are a separate channel from streams, so no `PACKET_TAG` / `STREAM_TAG` byte needed. The `StreamType` enum and related stream routing code are removed.

- **Per-connection datagram listener** — a detached task calls `recv_datagram()` on each accepted connection to forward datagram payloads to the `packet_tx` channel.

- **Header overhead drops from 1 to 0** — `header_overhead()` returns 0 since no synthetic header byte is prepended.

- **Connection pool returns `Connection` instead of `Stream`** — `fetch_connection()` now caches connections at the `Connection` level; streams are opened separately via `open_stream()` for reliable message paths.

## Additional fixes included

This PR also includes prerequisite fixes accumulated on the working branch:

- Replace `QuinnProtoReader` with `peekable::AsyncPeekable<RecvStream>` to eliminate ~150 lines of hand-rolled peek buffer management
- Remove `consume_peek()` from `Connection` trait (unsafe semantics)
- Add `SharedEndpoint` wrapper to prevent acceptor/connector from killing each other's `Endpoint` on drop
- Add dedicated error variants (`ConnectionClosed`, `StreamClosed`, `PacketTooLarge`) for proper `is_remote_failure()` classification
- Make `max_packet_size` configurable in transport and stream layer options
- Dispatch incoming streams to per-stream handlers instead of serial processing
- Bound `read_packet` to 10MB and packet channel capacity to 1000
- Fix exponential backoff reset on successful accept
- Align packet transport semantics (no bogus header byte, respect datagram capacity)
- Fix `send_many` to wait for every packet batch
- Comprehensive unit tests for `memberlist-quic` (13 tests)
