### PR TITLE
fix(quic): stability, DoS hardening, and concurrency improvements

### DIFF
--- a/memberlist-core/src/api.rs
+++ b/memberlist-core/src/api.rs
@@ -498,10 +498,23 @@ where
       .transport_send_packets(to, msgs.map(Message::UserData).collect::<OneOrMore<_>>())
       .await;
     futures::pin_mut!(stream);
-    match stream.next().await {
-      None => Ok(()),
-      Some(Ok(_)) => Ok(()),
-      Some(Err(e)) => Err(e),
+
+    let errs = stream
+      .filter_map(|res| async move {
+        match res {
+          Ok(()) => None,
+          Err(e) => Some(e),
+        }
+      })
+      .collect::<OneOrMore<_>>()
+      .await;
+
+    match errs.len() {
+      0 => Ok(()),
+      _ => match errs.into_either() {
+        either::Either::Left([e]) => Err(e),
+        either::Either::Right(e) => Err(Error::Multiple(e.into_vec().into())),
+      },
     }
   }
 

--- a/memberlist-core/src/base/tests.rs
+++ b/memberlist-core/src/base/tests.rs
@@ -893,6 +893,54 @@ pub async fn memberlist_send<T, R>(
   .await;
 }
 
+/// Unit test for sending multiple packet batches.
+pub async fn memberlist_send_many<T, R>(
+  t1: T::Options,
+  t1_opts: Options,
+  t2: T::Options,
+  t2_opts: Options,
+) where
+  T: Transport<Runtime = R>,
+  R: RuntimeLite,
+{
+  let m1 = Memberlist::<T, _>::with_delegate(
+    CompositeDelegate::new().with_node_delegate(MockDelegate::<T::Id, T::ResolvedAddress>::new()),
+    t1,
+    t1_opts,
+  )
+  .await
+  .unwrap();
+
+  let m2 = Memberlist::<T, _>::new(t2, t2_opts).await.unwrap();
+
+  m2.join(MaybeResolvedAddress::resolved(
+    m1.advertise_address().clone(),
+  ))
+  .await
+  .unwrap();
+
+  wait_until_size::<_, _, R>(&m1, 2).await;
+  wait_until_size::<_, _, R>(&m2, 2).await;
+
+  let mut expected = (0..8u8)
+    .map(|idx| Bytes::from(vec![idx; 384]))
+    .collect::<Vec<_>>();
+
+  m2.send_many(m1.advertise_address(), expected.clone().into_iter())
+    .await
+    .expect("m2 send_many failed");
+
+  R::sleep(Duration::from_secs(2)).await;
+
+  let mut actual = m1.delegate().unwrap().node_delegate().get_messages().await;
+  actual.sort();
+  expected.sort();
+  assert_eq!(actual, expected);
+
+  m1.shutdown().await.unwrap();
+  m2.shutdown().await.unwrap();
+}
+
 /// Unit tests for leave
 pub async fn memberlist_leave<T, R>(
   t1: T::Options,

--- a/memberlist-core/src/transport.rs
+++ b/memberlist-core/src/transport.rs
@@ -24,24 +24,30 @@ pub trait Connection: Send + Sync {
   /// Splits the connection into a reader and a writer
   fn split(self) -> (Self::Reader, Self::Writer);
 
-  /// Read the payload from the proto reader to the buffer
+  /// Read up to `buf.len()` bytes from the connection's reader.
   ///
-  /// Returns the number of bytes read
+  /// Best-effort: returns the actual number of bytes read, which may be less
+  /// than `buf.len()`. Callers that need exactly `buf.len()` bytes should use
+  /// `read_exact()`.
   fn read(&mut self, buf: &mut [u8]) -> impl Future<Output = std::io::Result<usize>> + Send;
 
-  /// Read exactly the payload from the proto reader to the buffer
+  /// Read exactly `buf.len()` bytes from the connection's reader.
+  ///
+  /// Returns `UnexpectedEof` if the stream closes before the buffer is full.
   fn read_exact(&mut self, buf: &mut [u8]) -> impl Future<Output = std::io::Result<()>> + Send;
 
-  /// Peek the payload from the proto reader to the buffer
+  /// Peek up to `buf.len()` bytes from the connection's reader without
+  /// consuming them.
   ///
-  /// Returns the number of bytes peeked
+  /// Best-effort: returns the actual number of bytes peeked. Callers that
+  /// need exactly `buf.len()` bytes should use `peek_exact()`.
   fn peek(&mut self, buf: &mut [u8]) -> impl Future<Output = std::io::Result<usize>> + Send;
 
-  /// Peek exactly the payload from the proto reader to the buffer
+  /// Peek exactly `buf.len()` bytes from the connection's reader without
+  /// consuming them.
+  ///
+  /// Returns `UnexpectedEof` if the stream closes before the buffer is full.
   fn peek_exact(&mut self, buf: &mut [u8]) -> impl Future<Output = std::io::Result<()>> + Send;
-
-  /// Consume the content in peek buffer
-  fn consume_peek(&mut self);
 
   /// Write the payload to the proto writer
   fn write_all(&mut self, payload: &[u8]) -> impl Future<Output = std::io::Result<()>> + Send;

--- a/memberlist-core/src/transport/stream.rs
+++ b/memberlist-core/src/transport/stream.rs
@@ -109,7 +109,7 @@ pub fn packet_stream<T: Transport>() -> (
   PacketProducer<T::ResolvedAddress, <T::Runtime as RuntimeLite>::Instant>,
   PacketSubscriber<T::ResolvedAddress, <T::Runtime as RuntimeLite>::Instant>,
 ) {
-  let (sender, receiver) = async_channel::unbounded();
+  let (sender, receiver) = async_channel::bounded(1000);
   (PacketProducer { sender }, PacketSubscriber { receiver })
 }
 

--- a/memberlist-core/src/transport/stream.rs
+++ b/memberlist-core/src/transport/stream.rs
@@ -105,11 +105,11 @@ pub struct PacketSubscriber<A, T> {
 }
 
 /// Returns producer and subscriber for packet.
-pub fn packet_stream<T: Transport>() -> (
+pub fn packet_stream<T: Transport>(capacity: usize) -> (
   PacketProducer<T::ResolvedAddress, <T::Runtime as RuntimeLite>::Instant>,
   PacketSubscriber<T::ResolvedAddress, <T::Runtime as RuntimeLite>::Instant>,
 ) {
-  let (sender, receiver) = async_channel::bounded(1000);
+  let (sender, receiver) = async_channel::bounded(capacity);
   (PacketProducer { sender }, PacketSubscriber { receiver })
 }
 

--- a/memberlist-core/src/transport/unimplemented.rs
+++ b/memberlist-core/src/transport/unimplemented.rs
@@ -95,10 +95,6 @@ impl Connection for UnimplementedConnection {
     unimplemented!()
   }
 
-  fn consume_peek(&mut self) {
-    unimplemented!()
-  }
-
   async fn write_all(&mut self, _: &[u8]) -> std::io::Result<()> {
     unimplemented!()
   }

--- a/memberlist-net/src/lib.rs
+++ b/memberlist-net/src/lib.rs
@@ -142,14 +142,14 @@ where
     match kind {
       Kind::V4(idx) => {
         if let Ok(sockets) = self.v4_sockets.try_borrow() {
-          Some(sockets[idx].clone())
+          sockets.get(idx).cloned()
         } else {
           None
         }
       }
       Kind::V6(idx) => {
         if let Ok(sockets) = self.v6_sockets.try_borrow() {
-          Some(sockets[idx].clone())
+          sockets.get(idx).cloned()
         } else {
           None
         }

--- a/memberlist-net/src/lib.rs
+++ b/memberlist-net/src/lib.rs
@@ -197,7 +197,7 @@ where
     }
 
     let (stream_tx, stream_rx) = promised_stream::<Self>();
-    let (packet_tx, packet_rx) = packet_stream::<Self>();
+    let (packet_tx, packet_rx) = packet_stream::<Self>(opts.packet_buffer_size);
     let (shutdown_tx, shutdown_rx) = async_channel::bounded(1);
 
     let mut v4_promised_listeners = Vec::with_capacity(opts.bind_addresses.len());

--- a/memberlist-net/src/options.rs
+++ b/memberlist-net/src/options.rs
@@ -143,6 +143,17 @@ pub struct NetTransportOptions<I, A: AddressResolver<ResolvedAddress = SocketAdd
     serde(default, skip_serializing_if = "Option::is_none")
   )]
   metric_labels: Option<std::sync::Arc<memberlist_core::proto::MetricLabels>>,
+
+  /// The capacity of the packet receiving channel, i.e., the maximum number of
+  /// packets that can be buffered before backpressure is applied.
+  /// This is NOT a byte size.
+  ///
+  /// Default is `1000`.
+  #[viewit(
+    getter(const, attrs(doc = "Get the packet buffer capacity (number of packets, not bytes). Default is `1000`."),),
+    setter(attrs(doc = "Set the packet buffer capacity (number of packets, not bytes). Default is `1000`. (Builder pattern)"),)
+  )]
+  packet_buffer_size: usize,
 }
 
 impl<I, A: AddressResolver<ResolvedAddress = SocketAddr>, S: StreamLayer> Clone
@@ -165,6 +176,7 @@ where
       recv_buffer_size: self.recv_buffer_size,
       #[cfg(feature = "metrics")]
       metric_labels: self.metric_labels.clone(),
+      packet_buffer_size: self.packet_buffer_size,
     }
   }
 }
@@ -230,6 +242,7 @@ impl<I, A: AddressResolver<ResolvedAddress = SocketAddr>, S: StreamLayer>
       recv_buffer_size: super::DEFAULT_UDP_RECV_BUF_SIZE,
       #[cfg(feature = "metrics")]
       metric_labels: None,
+      packet_buffer_size: 1000,
     }
   }
 
@@ -263,6 +276,7 @@ impl<I, A: AddressResolver<ResolvedAddress = SocketAddr>, S: StreamLayer>
         recv_buffer_size: opts.recv_buffer_size,
         #[cfg(feature = "metrics")]
         metric_labels: opts.metric_labels,
+        packet_buffer_size: opts.packet_buffer_size,
       },
     )
   }
@@ -278,4 +292,5 @@ pub(crate) struct Options<I, A: AddressResolver<ResolvedAddress = SocketAddr>> {
   recv_buffer_size: usize,
   #[cfg(feature = "metrics")]
   metric_labels: Option<std::sync::Arc<memberlist_core::proto::MetricLabels>>,
+  packet_buffer_size: usize,
 }

--- a/memberlist-net/src/stream_layer/tcp.rs
+++ b/memberlist-net/src/stream_layer/tcp.rs
@@ -161,10 +161,6 @@ impl<R: Runtime> memberlist_core::transport::Connection for TcpStream<R> {
   async fn peek_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
     self.reader.peek_exact(buf).await
   }
-
-  fn consume_peek(&mut self) {
-    self.reader.consume();
-  }
 }
 
 impl<R: Runtime> PromisedStream for TcpStream<R> {

--- a/memberlist-net/src/stream_layer/tls.rs
+++ b/memberlist-net/src/stream_layer/tls.rs
@@ -370,11 +370,11 @@ impl<R: Runtime> memberlist_core::transport::Connection for TlsStream<R> {
     }
   }
 
-  fn consume_peek(&mut self) {
-    let _ = match &mut self.stream {
-      TlsStreamKind::Client { stream } => stream.consume(),
-      TlsStreamKind::Server { stream } => stream.consume(),
-    };
+  async fn peek_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
+    match &mut self.stream {
+      TlsStreamKind::Client { stream } => stream.peek_exact(buf).await,
+      TlsStreamKind::Server { stream } => stream.peek_exact(buf).await,
+    }
   }
 
   async fn read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
@@ -383,13 +383,6 @@ impl<R: Runtime> memberlist_core::transport::Connection for TlsStream<R> {
 
   async fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
     AsyncReadExt::read(self, buf).await
-  }
-
-  async fn peek_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
-    match &mut self.stream {
-      TlsStreamKind::Client { stream } => stream.peek_exact(buf).await,
-      TlsStreamKind::Server { stream } => stream.peek_exact(buf).await,
-    }
   }
 }
 

--- a/memberlist-proto/src/proto.rs
+++ b/memberlist-proto/src/proto.rs
@@ -84,20 +84,36 @@ const fn is_plain_message_tag(tag: u8) -> bool {
 
 /// The reader used in the memberlist proto
 pub trait ProtoReader: Send + Sync {
-  /// Read the payload from the proto reader to the buffer
+  /// Reads up to `buf.len()` bytes from the stream into `buf`.
   ///
-  /// Returns the number of bytes read
+  /// This is a best-effort read: it performs a single `read()` call and
+  /// returns the actual number of bytes read, which may be less than
+  /// `buf.len()`. On EOF with no data read, returns `Ok(0)`. On EOF after
+  /// some data, returns `Ok(partial_bytes)`. IO errors are propagated.
+  ///
+  /// Callers that need exactly `buf.len()` bytes should use `read_exact()`.
   fn read(&mut self, buf: &mut [u8]) -> impl Future<Output = std::io::Result<usize>> + Send;
 
-  /// Read exactly the payload from the proto reader to the buffer
+  /// Reads exactly `buf.len()` bytes from the stream into `buf`.
+  ///
+  /// Loops until the buffer is full. Returns `UnexpectedEof` if the stream
+  /// closes before the buffer is full — partial data is discarded.
   fn read_exact(&mut self, buf: &mut [u8]) -> impl Future<Output = std::io::Result<()>> + Send;
 
-  /// Peek the payload from the proto reader to the buffer
+  /// Peeks up to `buf.len()` bytes from the stream into `buf` without
+  /// consuming the data.
   ///
-  /// Returns the number of bytes peeked
+  /// This is a best-effort peek: it performs a single `read()` call and
+  /// returns the actual number of bytes peeked. On EOF, returns
+  /// `Ok(partial_bytes)` with whatever data was available in the peek buffer.
+  /// IO errors are propagated.
   fn peek(&mut self, buf: &mut [u8]) -> impl Future<Output = std::io::Result<usize>> + Send;
 
-  /// Peek exactly the payload from the proto reader to the buffer
+  /// Peeks exactly `buf.len()` bytes from the stream into `buf` without
+  /// consuming the data.
+  ///
+  /// Loops until the buffer is full. Returns `UnexpectedEof` if the stream
+  /// closes before the buffer is full.
   fn peek_exact(&mut self, buf: &mut [u8]) -> impl Future<Output = std::io::Result<()>> + Send;
 }
 

--- a/memberlist-proto/src/proto/decoder.rs
+++ b/memberlist-proto/src/proto/decoder.rs
@@ -424,10 +424,27 @@ impl ProtoDecoder {
       return Ok(buf.freeze());
     }
 
+    // The header is varint-encoded: 1 byte tag + 1-5 bytes varint.
+    // Loop with peek() until we have enough bytes to decode the varint.
     let mut header = [0u8; super::MAX_PLAIN_MESSAGE_HEADER_SIZE];
-    reader.peek(&mut header).await?;
-    let (length_delimited_size, total_len) =
-      varing::decode_u32_varint(&header[1..]).map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
+    let mut peeked = 0;
+    let (length_delimited_size, total_len) = loop {
+      let n = reader.peek(&mut header[peeked..]).await?;
+      if n == 0 {
+        return Err(Error::new(ErrorKind::UnexpectedEof, "stream closed during header peek"));
+      }
+      peeked += n;
+      match varing::decode_u32_varint(&header[1..peeked]) {
+        Ok((len_bytes, total_len)) => {
+          let total_header = 1 + len_bytes.get();
+          if total_header as usize <= peeked {
+            break (len_bytes, total_len);
+          }
+        }
+        Err(varing::ConstDecodeError::InsufficientData(_)) => {} // need more bytes
+        Err(e) => return Err(Error::new(ErrorKind::InvalidData, e)),
+      }
+    };
     let mut buf = BytesMut::zeroed(1 + length_delimited_size.get() + total_len as usize);
     reader.read_exact(&mut buf).await?;
     let _ = auth_data;

--- a/memberlist-proto/src/proto/decoder.rs
+++ b/memberlist-proto/src/proto/decoder.rs
@@ -425,19 +425,19 @@ impl ProtoDecoder {
     }
 
     // The header is varint-encoded: 1 byte tag + 1-5 bytes varint.
-    // Loop with peek() until we have enough bytes to decode the varint.
+    // Repeated peek() calls copy from the start of the unread stream,
+    // so we peek into the full buffer each time and track `available`
+    // as the total bytes returned rather than accumulating as a delta.
     let mut header = [0u8; super::MAX_PLAIN_MESSAGE_HEADER_SIZE];
-    let mut peeked = 0;
     let (length_delimited_size, total_len) = loop {
-      let n = reader.peek(&mut header[peeked..]).await?;
-      if n == 0 {
+      let available = reader.peek(&mut header).await?;
+      if available == 0 {
         return Err(Error::new(ErrorKind::UnexpectedEof, "stream closed during header peek"));
       }
-      peeked += n;
-      match varing::decode_u32_varint(&header[1..peeked]) {
+      match varing::decode_u32_varint(&header[1..available]) {
         Ok((len_bytes, total_len)) => {
           let total_header = 1 + len_bytes.get();
-          if total_header as usize <= peeked {
+          if total_header as usize <= available {
             break (len_bytes, total_len);
           }
         }

--- a/memberlist-quic/src/lib.rs
+++ b/memberlist-quic/src/lib.rs
@@ -446,6 +446,10 @@ where
     from: &Self::ResolvedAddress,
     conn: &mut <Self::Connection as Connection>::Reader,
   ) -> Result<usize, Self::Error> {
+    // Consume the stream type tag byte that was peeked by the processor
+    // in handle_stream(). The processor peeked exactly 1 byte to determine
+    // whether this is a Stream or Packet stream, so we must consume it here
+    // before the decoder reads the proto message payload.
     let mut buf = [0; 1];
     conn.read_exact(&mut buf).await?;
     match StreamType::try_from(buf[0]) {

--- a/memberlist-quic/src/lib.rs
+++ b/memberlist-quic/src/lib.rs
@@ -41,8 +41,6 @@ pub use options::*;
 pub mod stream_layer;
 use stream_layer::*;
 
-const MAX_MESSAGE_SIZE: usize = u32::MAX as usize;
-
 const PACKET_TAG: u8 = 254;
 const STREAM_TAG: u8 = 255;
 
@@ -231,7 +229,7 @@ where
       advertise_addr: final_advertise_addr,
       connection_pool,
       local_addr: self_addr,
-      max_packet_size: MAX_MESSAGE_SIZE.min(stream_layer.max_stream_data()),
+      max_packet_size: opts.max_packet_size.min(stream_layer.max_stream_data()),
       opts,
       packet_rx,
       stream_rx,

--- a/memberlist-quic/src/lib.rs
+++ b/memberlist-quic/src/lib.rs
@@ -118,7 +118,7 @@ where
     }
 
     let (stream_tx, stream_rx) = promised_stream::<Self>();
-    let (packet_tx, packet_rx) = packet_stream::<Self>();
+    let (packet_tx, packet_rx) = packet_stream::<Self>(opts.packet_buffer_size);
     let (shutdown_tx, shutdown_rx) = async_channel::bounded(1);
 
     let mut v4_connectors = SmallVec::with_capacity(opts.bind_addresses.len());

--- a/memberlist-quic/src/options.rs
+++ b/memberlist-quic/src/options.rs
@@ -102,7 +102,7 @@ pub struct QuicTransportOptions<I, A: AddressResolver<ResolvedAddress = SocketAd
   )]
   connection_pool_cleanup_period: Duration,
 
-  /// The time to live for each connection in the connection pool. Default is `None`.
+  /// The time to live for each connection in the connection pool. Default is 30 seconds.
   #[viewit(
     getter(
       const,
@@ -245,7 +245,7 @@ impl<I, A: AddressResolver<ResolvedAddress = SocketAddr>, S: StreamLayer>
       timeout: None,
       bind_addresses: IndexSet::new(),
       advertise_address: None,
-      connection_ttl: None,
+      connection_ttl: Some(Duration::from_secs(30)),
       resolver: resolver_options,
       stream_layer: stream_layer_opts,
       cidrs_policy: CIDRsPolicy::allow_all(),

--- a/memberlist-quic/src/options.rs
+++ b/memberlist-quic/src/options.rs
@@ -88,6 +88,16 @@ pub struct QuicTransportOptions<I, A: AddressResolver<ResolvedAddress = SocketAd
   )]
   timeout: Option<Duration>,
 
+  /// Maximum packet size in bytes. Used as an upper bound when computing
+  /// the effective `max_packet_size` for the transport.
+  ///
+  /// Default is `u32::MAX`.
+  #[viewit(
+    getter(const, attrs(doc = "Get the maximum packet size in bytes.")),
+    setter(attrs(doc = "Set the maximum packet size in bytes. (Builder pattern)"))
+  )]
+  max_packet_size: usize,
+
   /// The period of time to cleanup the connection pool.
   #[cfg_attr(
     feature = "serde",
@@ -183,6 +193,7 @@ where
       stream_layer: self.stream_layer.clone(),
       timeout: self.timeout,
       connection_pool_cleanup_period: self.connection_pool_cleanup_period,
+      max_packet_size: self.max_packet_size,
       cidrs_policy: self.cidrs_policy.clone(),
       #[cfg(feature = "metrics")]
       metric_labels: self.metric_labels.clone(),
@@ -250,6 +261,7 @@ impl<I, A: AddressResolver<ResolvedAddress = SocketAddr>, S: StreamLayer>
       stream_layer: stream_layer_opts,
       cidrs_policy: CIDRsPolicy::allow_all(),
       connection_pool_cleanup_period: default_connection_pool_cleanup_period(),
+      max_packet_size: usize::MAX,
       #[cfg(feature = "metrics")]
       metric_labels: None,
     }
@@ -289,6 +301,7 @@ impl<I, A: AddressResolver<ResolvedAddress = SocketAddr>, S: StreamLayer>
         timeout: opts.timeout,
         connection_pool_cleanup_period: opts.connection_pool_cleanup_period,
         cidrs_policy: opts.cidrs_policy,
+        max_packet_size: opts.max_packet_size,
         #[cfg(feature = "metrics")]
         metric_labels: opts.metric_labels,
       },
@@ -305,6 +318,7 @@ pub(crate) struct Options<I, A: AddressResolver<ResolvedAddress = SocketAddr>> {
   connection_pool_cleanup_period: Duration,
   connection_ttl: Option<Duration>,
   cidrs_policy: CIDRsPolicy,
+  max_packet_size: usize,
   #[cfg(feature = "metrics")]
   metric_labels: Option<Arc<memberlist_core::proto::MetricLabels>>,
 }

--- a/memberlist-quic/src/options.rs
+++ b/memberlist-quic/src/options.rs
@@ -91,7 +91,7 @@ pub struct QuicTransportOptions<I, A: AddressResolver<ResolvedAddress = SocketAd
   /// Maximum packet size in bytes. Used as an upper bound when computing
   /// the effective `max_packet_size` for the transport.
   ///
-  /// Default is `u32::MAX`.
+  /// Default is `usize::MAX`.
   #[viewit(
     getter(const, attrs(doc = "Get the maximum packet size in bytes.")),
     setter(attrs(doc = "Set the maximum packet size in bytes. (Builder pattern)"))

--- a/memberlist-quic/src/options.rs
+++ b/memberlist-quic/src/options.rs
@@ -173,6 +173,17 @@ pub struct QuicTransportOptions<I, A: AddressResolver<ResolvedAddress = SocketAd
     serde(default, skip_serializing_if = "Option::is_none")
   )]
   metric_labels: Option<Arc<memberlist_core::proto::MetricLabels>>,
+
+  /// The capacity of the packet receiving channel, i.e., the maximum number of
+  /// packets that can be buffered before backpressure is applied.
+  /// This is NOT a byte size.
+  ///
+  /// Default is `1000`.
+  #[viewit(
+    getter(const, attrs(doc = "Get the packet buffer capacity (number of packets, not bytes). Default is `1000`."),),
+    setter(attrs(doc = "Set the packet buffer capacity (number of packets, not bytes). Default is `1000`. (Builder pattern)"),)
+  )]
+  packet_buffer_size: usize,
 }
 
 impl<I, A: AddressResolver<ResolvedAddress = SocketAddr>, S: StreamLayer> Clone
@@ -197,6 +208,7 @@ where
       cidrs_policy: self.cidrs_policy.clone(),
       #[cfg(feature = "metrics")]
       metric_labels: self.metric_labels.clone(),
+      packet_buffer_size: self.packet_buffer_size,
     }
   }
 }
@@ -264,6 +276,7 @@ impl<I, A: AddressResolver<ResolvedAddress = SocketAddr>, S: StreamLayer>
       max_packet_size: usize::MAX,
       #[cfg(feature = "metrics")]
       metric_labels: None,
+      packet_buffer_size: 1000,
     }
   }
 
@@ -304,6 +317,7 @@ impl<I, A: AddressResolver<ResolvedAddress = SocketAddr>, S: StreamLayer>
         max_packet_size: opts.max_packet_size,
         #[cfg(feature = "metrics")]
         metric_labels: opts.metric_labels,
+        packet_buffer_size: opts.packet_buffer_size,
       },
     )
   }
@@ -321,4 +335,5 @@ pub(crate) struct Options<I, A: AddressResolver<ResolvedAddress = SocketAddr>> {
   max_packet_size: usize,
   #[cfg(feature = "metrics")]
   metric_labels: Option<Arc<memberlist_core::proto::MetricLabels>>,
+  packet_buffer_size: usize,
 }

--- a/memberlist-quic/src/processor.rs
+++ b/memberlist-quic/src/processor.rs
@@ -147,65 +147,91 @@ where
     shutdown_rx: async_channel::Receiver<()>,
     #[cfg(feature = "metrics")] metric_labels: Arc<memberlist_core::proto::MetricLabels>,
   ) {
+    // Listen for shutdown signal in a select with accept_bi() so that
+    // accept_bi() does not block shutdown indefinitely.
+    let shutdown_for_select = shutdown_rx.clone();
     loop {
-      let fut1 = shutdown_rx.recv();
-      let fut2 = async {
-        match conn.accept_bi().await {
-          Ok((mut stream, remote_addr)) => {
-            let mut stream_kind_buf = [0; 1];
-            if let Err(e) = stream.peek_exact(&mut stream_kind_buf).await {
-              tracing::error!(local=%local_addr, from=%remote_addr, err = %e, "memberlist.transport.quic: failed to read stream kind");
-              return ControlFlow::Continue(());
-            }
-            let stream_kind = stream_kind_buf[0];
-            match StreamType::try_from(stream_kind) {
-              Ok(StreamType::Stream) => {
-                if let Err(e) = stream_tx.send(remote_addr, stream).await {
-                  tracing::error!(local_addr=%local_addr, err = %e, "memberlist.transport.quic: failed to send stream connection");
-                }
-                ControlFlow::Continue(())
-              }
-              Ok(StreamType::Packet) => {
-                stream.consume_peek();
-
-                Self::handle_packet(
-                  &mut stream,
-                  local_addr,
-                  remote_addr,
-                  &packet_tx,
-                  timeout,
-                  #[cfg(feature = "metrics")]
-                  &metric_labels,
-                )
-                .await;
-                ControlFlow::Continue(())
-              }
-              Err(val) => {
-                tracing::error!(local=%local_addr, from=%remote_addr, tag=%val, "memberlist.transport.quic: unknown stream");
-                ControlFlow::Break(())
-              }
-            }
-          }
-          Err(e) => {
-            tracing::debug!(local=%local_addr, from=%remote_addr, err = %e, "memberlist.transport.quic: failed to accept stream, shutting down the connection handler");
-            ControlFlow::Break(())
-          }
-        }
-      };
+      let fut1 = shutdown_for_select.recv();
+      let fut2 = conn.accept_bi();
 
       futures::pin_mut!(fut1, fut2);
 
       match futures::future::select(fut1, fut2).await {
         futures::future::Either::Left((_, _)) => break,
-        futures::future::Either::Right((flow, _)) => match flow {
-          ControlFlow::Continue(_) => continue,
-          ControlFlow::Break(_) => break,
-        },
+        futures::future::Either::Right((accept_result, _)) => {
+          let (stream, stream_remote_addr) = match accept_result {
+            Ok(pair) => pair,
+            Err(e) => {
+              tracing::debug!(local=%local_addr, from=%remote_addr, err = %e, "memberlist.transport.quic: failed to accept stream, shutting down the connection handler");
+              break;
+            }
+          };
+
+          // Spawn a detached task to handle this single stream so that
+          // one slow/blocked stream does not prevent processing others.
+          let packet_tx = packet_tx.clone();
+          let stream_tx = stream_tx.clone();
+          #[cfg(feature = "metrics")]
+          let metric_labels = metric_labels.clone();
+
+          <T::Runtime as RuntimeLite>::spawn_detach(Self::handle_stream(
+            stream,
+            local_addr,
+            stream_remote_addr,
+            stream_tx,
+            packet_tx,
+            timeout,
+            #[cfg(feature = "metrics")]
+            metric_labels,
+          ));
+        }
       }
     }
 
     tracing::debug!(local=%local_addr, remote=%remote_addr, "memberlist.transport.quic: connection handler exits");
     let _ = conn.close().await;
+  }
+
+  #[allow(clippy::too_many_arguments)]
+  async fn handle_stream(
+    mut stream: S::Stream,
+    local_addr: SocketAddr,
+    remote_addr: SocketAddr,
+    stream_tx: StreamProducer<T::ResolvedAddress, T::Connection>,
+    packet_tx: PacketProducer<T::ResolvedAddress, <T::Runtime as RuntimeLite>::Instant>,
+    timeout: Option<Duration>,
+    #[cfg(feature = "metrics")] metric_labels: Arc<memberlist_core::proto::MetricLabels>,
+  ) {
+    let mut stream_kind_buf = [0; 1];
+    if let Err(e) = stream.peek_exact(&mut stream_kind_buf).await {
+      tracing::error!(local=%local_addr, from=%remote_addr, err = %e, "memberlist.transport.quic: failed to read stream kind");
+      return;
+    }
+    let stream_kind = stream_kind_buf[0];
+    match StreamType::try_from(stream_kind) {
+      Ok(StreamType::Stream) => {
+        if let Err(e) = stream_tx.send(remote_addr, stream).await {
+          tracing::error!(local_addr=%local_addr, err = %e, "memberlist.transport.quic: failed to send stream connection");
+        }
+      }
+      Ok(StreamType::Packet) => {
+        stream.consume_peek();
+        Self::handle_packet(
+          &mut stream,
+          local_addr,
+          remote_addr,
+          &packet_tx,
+          timeout,
+          #[cfg(feature = "metrics")]
+          &metric_labels,
+        )
+        .await;
+      }
+      Err(val) => {
+        tracing::error!(local=%local_addr, from=%remote_addr, tag=%val, "memberlist.transport.quic: unknown stream");
+        // Don't kill the connection, just drop this stream.
+      }
+    }
   }
 
   #[allow(clippy::too_many_arguments)]

--- a/memberlist-quic/src/processor.rs
+++ b/memberlist-quic/src/processor.rs
@@ -218,7 +218,16 @@ where
         }
       }
       Ok(StreamType::Packet) => {
-        stream.consume_peek();
+        // Drain the stream type tag byte that was peeked in handle_stream().
+        // The processor peeked exactly 1 byte to determine whether this is a
+        // Stream or Packet stream, so we must consume it here before read_packet()
+        // reads the proto message payload from the stream.
+        let mut _tag = [0u8; 1];
+        if let Err(e) = stream.read_exact(&mut _tag).await {
+          tracing::error!(local=%local_addr, from=%remote_addr, err = %e, "memberlist.transport.quic: failed to consume stream tag");
+          return;
+        }
+
         Self::handle_packet(
           &mut stream,
           local_addr,

--- a/memberlist-quic/src/processor.rs
+++ b/memberlist-quic/src/processor.rs
@@ -80,6 +80,9 @@ where
       let fut2 = async {
         match acceptor.accept().await {
           Ok((connection, remote_addr)) => {
+            // Reset backoff delay on successful accept
+            loop_delay = Duration::ZERO;
+
             let shutdown_rx = shutdown_rx.clone();
             let packet_tx = packet_tx.clone();
             let stream_tx = stream_tx.clone();

--- a/memberlist-quic/src/stream_layer/quinn.rs
+++ b/memberlist-quic/src/stream_layer/quinn.rs
@@ -1,4 +1,4 @@
-use std::{cmp, io, marker::PhantomData, net::SocketAddr, sync::Arc, time::Duration};
+use std::{cmp, io, marker::PhantomData, net::SocketAddr, ops::Deref, sync::Arc, time::Duration};
 
 use agnostic::Runtime;
 use futures::AsyncWriteExt;
@@ -10,6 +10,32 @@ mod options;
 pub use options::*;
 
 use super::{QuicAcceptor, QuicConnection, QuicConnector, QuicStream, StreamLayer};
+
+/// Shared endpoint wrapper that closes the underlying `Endpoint` only
+/// when the last holder drops it, preventing an acceptor from killing
+/// a connector (or vice versa) when they share a single `Endpoint`.
+struct SharedEndpoint(Arc<Endpoint>);
+
+impl Clone for SharedEndpoint {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+impl Deref for SharedEndpoint {
+    type Target = Endpoint;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Drop for SharedEndpoint {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.0) == 1 {
+            Endpoint::close(&self.0, VarInt::from(0u32), b"endpoint shutdown");
+        }
+    }
+}
 
 /// [`Quinn`] is an implementation of [`StreamLayer`] based on [`quinn`].
 pub struct Quinn<R> {
@@ -53,14 +79,14 @@ impl<R: Runtime> StreamLayer for Quinn<R> {
     let sock = std::net::UdpSocket::bind(addr)?;
     let auto_port = addr.port() == 0;
 
-    let endpoint = Arc::new(Endpoint::new(
+    let shared_ep = SharedEndpoint(Arc::new(Endpoint::new(
       self.opts.endpoint_config.clone(),
       Some(self.opts.server_config.clone()),
       sock,
       Arc::new(R::quinn()),
-    )?);
+    )?));
 
-    let local_addr = endpoint.local_addr()?;
+    let local_addr = shared_ep.local_addr()?;
     if auto_port {
       tracing::info!(
         "memberlist_quic.endpoint: binding to dynamic addr {}",
@@ -69,13 +95,13 @@ impl<R: Runtime> StreamLayer for Quinn<R> {
     }
 
     let acceptor = Self::Acceptor {
-      endpoint: endpoint.clone(),
+      endpoint: shared_ep.clone(),
       local_addr,
     };
 
     let connector = Self::Connector {
       server_name,
-      endpoint,
+      endpoint: shared_ep,
       local_addr,
       client_config,
       connect_timeout: self.opts.connect_timeout,
@@ -87,7 +113,7 @@ impl<R: Runtime> StreamLayer for Quinn<R> {
 
 /// [`QuinnAcceptor`] is an implementation of [`QuicAcceptor`] based on [`quinn`].
 pub struct QuinnAcceptor {
-  endpoint: Arc<Endpoint>,
+  endpoint: SharedEndpoint,
   local_addr: SocketAddr,
 }
 
@@ -119,7 +145,7 @@ impl QuicAcceptor for QuinnAcceptor {
   }
 
   async fn close(&mut self) -> io::Result<()> {
-    Endpoint::close(&self.endpoint, VarInt::from(0u32), b"close acceptor");
+    self.endpoint.close(VarInt::from(0u32), b"close acceptor");
     Ok(())
   }
 
@@ -128,16 +154,10 @@ impl QuicAcceptor for QuinnAcceptor {
   }
 }
 
-impl Drop for QuinnAcceptor {
-  fn drop(&mut self) {
-    Endpoint::close(&self.endpoint, VarInt::from(0u32), b"close acceptor");
-  }
-}
-
 /// [`QuinnConnector`] is an implementation of [`QuicConnector`] based on [`quinn`].
 pub struct QuinnConnector<R> {
   server_name: SmolStr,
-  endpoint: Arc<Endpoint>,
+  endpoint: SharedEndpoint,
   client_config: ClientConfig,
   connect_timeout: Duration,
   local_addr: SocketAddr,
@@ -162,7 +182,7 @@ where
   }
 
   async fn close(&self) -> io::Result<()> {
-    Endpoint::close(&self.endpoint, VarInt::from(0u32), b"close connector");
+    self.endpoint.close(VarInt::from(0u32), b"close connector");
     Ok(())
   }
 
@@ -173,12 +193,6 @@ where
 
   fn local_addr(&self) -> SocketAddr {
     self.local_addr
-  }
-}
-
-impl<R> Drop for QuinnConnector<R> {
-  fn drop(&mut self) {
-    Endpoint::close(&self.endpoint, VarInt::from(0u32), b"close connector");
   }
 }
 

--- a/memberlist-quic/src/stream_layer/quinn.rs
+++ b/memberlist-quic/src/stream_layer/quinn.rs
@@ -431,6 +431,16 @@ pub struct QuinnConnection {
   remote_addr: SocketAddr,
 }
 
+impl Clone for QuinnConnection {
+  fn clone(&self) -> Self {
+    Self {
+      conn: self.conn.clone(),
+      local_addr: self.local_addr,
+      remote_addr: self.remote_addr,
+    }
+  }
+}
+
 impl QuinnConnection {
   #[inline]
   fn new(conn: Connection, local_addr: SocketAddr, remote_addr: SocketAddr) -> Self {

--- a/memberlist-quic/src/stream_layer/quinn.rs
+++ b/memberlist-quic/src/stream_layer/quinn.rs
@@ -1,8 +1,9 @@
-use std::{cmp, io, marker::PhantomData, net::SocketAddr, ops::Deref, sync::Arc, time::Duration};
+use std::{io, marker::PhantomData, net::SocketAddr, ops::Deref, sync::Arc, time::Duration};
 
 use agnostic::Runtime;
 use futures::AsyncWriteExt;
-use memberlist_core::proto::MediumVec;
+use futures::io::AsyncReadExt;
+use peekable::future::AsyncPeekable;
 use quinn::{ClientConfig, Connection, Endpoint, RecvStream, SendStream, VarInt};
 use smol_str::SmolStr;
 
@@ -74,7 +75,6 @@ impl<R: Runtime> StreamLayer for Quinn<R> {
     addr: SocketAddr,
   ) -> io::Result<(SocketAddr, Self::Acceptor, Self::Connector)> {
     let server_name = self.opts.server_name.clone();
-
     let client_config = self.opts.client_config.clone();
     let sock = std::net::UdpSocket::bind(addr)?;
     let auto_port = addr.port() == 0;
@@ -106,8 +106,8 @@ impl<R: Runtime> StreamLayer for Quinn<R> {
       local_addr,
       client_config,
       connect_timeout: self.opts.connect_timeout,
-      max_packet_size: self.opts.max_packet_size,
       _marker: PhantomData,
+      max_packet_size: self.opts.max_packet_size,
     };
     Ok((local_addr, acceptor, connector))
   }
@@ -201,153 +201,13 @@ where
   }
 }
 
-/// A [`ProtoReader`](memberlist_core::proto::ProtoReader) implementation for Quinn stream layer
-pub struct QuinnProtoReader {
-  stream: RecvStream,
-  peek_buf: MediumVec<u8>,
-  max_packet_size: usize,
-}
-
-impl QuinnProtoReader {
-  fn new(stream: RecvStream, max_packet_size: usize) -> Self {
-    Self {
-      stream,
-      peek_buf: MediumVec::new(),
-      max_packet_size,
-    }
-  }
-}
-
-impl memberlist_core::proto::ProtoReader for QuinnProtoReader {
-  async fn peek(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-    let dst_len = buf.len();
-    let peek_len = self.peek_buf.len();
-
-    match dst_len.cmp(&peek_len) {
-      cmp::Ordering::Less => {
-        buf.copy_from_slice(&self.peek_buf[..dst_len]);
-        Ok(dst_len)
-      }
-      cmp::Ordering::Equal => {
-        buf.copy_from_slice(&self.peek_buf);
-        Ok(peek_len)
-      }
-      cmp::Ordering::Greater => {
-        let want = dst_len - peek_len;
-        self.peek_buf.resize(dst_len, 0);
-        match self
-          .stream
-          .read(&mut self.peek_buf[peek_len..peek_len + want])
-          .await
-        {
-          Ok(Some(n)) => {
-            let has = peek_len + n;
-            if n < want {
-              self.peek_buf.truncate(has);
-            }
-            buf[..has].copy_from_slice(&self.peek_buf);
-            Ok(peek_len + n)
-          }
-          Ok(None) | Err(_) => {
-            self.peek_buf.truncate(peek_len);
-            buf[..peek_len].copy_from_slice(&self.peek_buf);
-            Ok(peek_len)
-          }
-        }
-      }
-    }
-  }
-
-  async fn peek_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
-    let dst_len = buf.len();
-    let peek_len = self.peek_buf.len();
-
-    match dst_len.cmp(&peek_len) {
-      cmp::Ordering::Less => {
-        buf.copy_from_slice(&self.peek_buf[..dst_len]);
-        Ok(())
-      }
-      cmp::Ordering::Equal => {
-        buf.copy_from_slice(&self.peek_buf);
-        Ok(())
-      }
-      cmp::Ordering::Greater => {
-        self.peek_buf.resize(dst_len, 0);
-        let mut total = peek_len;
-        while total < dst_len {
-          let n = self
-            .stream
-            .read(&mut self.peek_buf[total..])
-            .await?
-            .unwrap_or(0);
-          if n == 0 {
-            return Err(std::io::Error::new(
-              std::io::ErrorKind::UnexpectedEof,
-              "unexpected eof",
-            ));
-          }
-          total += n;
-        }
-        buf.copy_from_slice(&self.peek_buf);
-        Ok(())
-      }
-    }
-  }
-
-  async fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-    let dst_len = buf.len();
-    let peek_len = self.peek_buf.len();
-
-    if dst_len <= peek_len {
-      buf.copy_from_slice(&self.peek_buf[..dst_len]);
-      self.peek_buf.drain(..dst_len);
-      Ok(dst_len)
-    } else {
-      buf[..peek_len].copy_from_slice(&self.peek_buf);
-      self.peek_buf.clear();
-      let mut total = peek_len;
-      while total < dst_len {
-        let n = self.stream.read(&mut buf[total..]).await?.unwrap_or(0);
-        if n == 0 {
-          break;
-        }
-        total += n;
-      }
-      Ok(total)
-    }
-  }
-
-  async fn read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
-    let dst_len = buf.len();
-    let peek_len = self.peek_buf.len();
-
-    if dst_len <= peek_len {
-      buf.copy_from_slice(&self.peek_buf[..dst_len]);
-      self.peek_buf.drain(..dst_len);
-      Ok(())
-    } else {
-      buf[..peek_len].copy_from_slice(&self.peek_buf);
-      self.peek_buf.clear();
-      let mut total = peek_len;
-      while total < dst_len {
-        let n = self.stream.read(&mut buf[total..]).await?.unwrap_or(0);
-        if n == 0 {
-          return Err(std::io::Error::new(
-            std::io::ErrorKind::UnexpectedEof,
-            "unexpected eof",
-          ));
-        }
-        total += n;
-      }
-      Ok(())
-    }
-  }
-}
-
 /// [`QuinnStream`] is an implementation of [`QuicStream`] based on [`quinn`].
+/// Uses `AsyncPeekable` from the `peekable` crate for peek/read operations
+/// instead of a hand-rolled `QuinnProtoReader`.
 pub struct QuinnStream {
   send: SendStream,
-  recv: QuinnProtoReader,
+  recv: AsyncPeekable<RecvStream>,
+  max_packet_size: usize,
 }
 
 impl QuinnStream {
@@ -355,14 +215,14 @@ impl QuinnStream {
   fn new(send: SendStream, recv: RecvStream, max_packet_size: usize) -> Self {
     Self {
       send,
-      recv: QuinnProtoReader::new(recv, max_packet_size),
+      recv: AsyncPeekable::from(recv),
+      max_packet_size,
     }
   }
 }
 
 impl memberlist_core::transport::Connection for QuinnStream {
-  type Reader = QuinnProtoReader;
-
+  type Reader = AsyncPeekable<RecvStream>;
   type Writer = SendStream;
 
   fn split(self) -> (Self::Reader, Self::Writer) {
@@ -396,37 +256,32 @@ impl memberlist_core::transport::Connection for QuinnStream {
   async fn peek_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
     memberlist_core::proto::ProtoReader::peek_exact(&mut self.recv, buf).await
   }
-
-  fn consume_peek(&mut self) {
-    self.recv.peek_buf.clear();
-  }
 }
 
 impl QuicStream for QuinnStream {
   type SendStream = SendStream;
 
   async fn read_packet(&mut self) -> std::io::Result<bytes::Bytes> {
-    self
-      .recv
-      .stream
-      .read_to_end(self.recv.max_packet_size)
-      .await
-      .map(|data| {
-        if !self.recv.peek_buf.is_empty() {
-          let mut buf = bytes::BytesMut::with_capacity(self.recv.peek_buf.len() + data.len());
-          buf.extend_from_slice(&self.recv.peek_buf);
-          buf.extend_from_slice(&data);
-          buf.freeze()
-        } else {
-          data.into()
-        }
-      })
-      .map_err(|e| match e {
-        quinn::ReadToEndError::Read(e) => std::io::Error::from(e),
-        quinn::ReadToEndError::TooLong => {
-          std::io::Error::new(std::io::ErrorKind::InvalidData, "packet too large")
-        }
-      })
+    // AsyncPeekable implements AsyncRead. Read in a loop until EOF,
+    // enforcing the max_packet_size limit.
+    let mut buf = bytes::BytesMut::with_capacity(4096);
+    loop {
+      let len = buf.len();
+      buf.resize(len + 4096, 0);
+      let n = self.recv.read(&mut buf[len..]).await?;
+      if n == 0 {
+        buf.truncate(len);
+        break;
+      }
+      buf.truncate(len + n);
+      if buf.len() > self.max_packet_size {
+        return Err(std::io::Error::new(
+          std::io::ErrorKind::InvalidData,
+          "packet too large",
+        ));
+      }
+    }
+    Ok(buf.freeze())
   }
 }
 

--- a/memberlist-quic/src/stream_layer/quinn.rs
+++ b/memberlist-quic/src/stream_layer/quinn.rs
@@ -97,6 +97,7 @@ impl<R: Runtime> StreamLayer for Quinn<R> {
     let acceptor = Self::Acceptor {
       endpoint: shared_ep.clone(),
       local_addr,
+      max_packet_size: self.opts.max_packet_size,
     };
 
     let connector = Self::Connector {
@@ -105,6 +106,7 @@ impl<R: Runtime> StreamLayer for Quinn<R> {
       local_addr,
       client_config,
       connect_timeout: self.opts.connect_timeout,
+      max_packet_size: self.opts.max_packet_size,
       _marker: PhantomData,
     };
     Ok((local_addr, acceptor, connector))
@@ -115,6 +117,7 @@ impl<R: Runtime> StreamLayer for Quinn<R> {
 pub struct QuinnAcceptor {
   endpoint: SharedEndpoint,
   local_addr: SocketAddr,
+  max_packet_size: usize,
 }
 
 impl Clone for QuinnAcceptor {
@@ -122,6 +125,7 @@ impl Clone for QuinnAcceptor {
     Self {
       endpoint: self.endpoint.clone(),
       local_addr: self.local_addr,
+      max_packet_size: self.max_packet_size,
     }
   }
 }
@@ -139,7 +143,7 @@ impl QuicAcceptor for QuinnAcceptor {
     let remote_addr = conn.remote_address();
 
     Ok((
-      QuinnConnection::new(conn, self.local_addr, remote_addr),
+      QuinnConnection::new(conn, self.local_addr, remote_addr, self.max_packet_size),
       remote_addr,
     ))
   }
@@ -162,6 +166,7 @@ pub struct QuinnConnector<R> {
   connect_timeout: Duration,
   local_addr: SocketAddr,
   _marker: PhantomData<R>,
+  max_packet_size: usize,
 }
 
 impl<R> QuicConnector for QuinnConnector<R>
@@ -178,7 +183,7 @@ where
     let conn = R::timeout(self.connect_timeout, connecting)
       .await
       .map_err(io::Error::from)??;
-    Ok(QuinnConnection::new(conn, self.local_addr, addr))
+    Ok(QuinnConnection::new(conn, self.local_addr, addr, self.max_packet_size))
   }
 
   async fn close(&self) -> io::Result<()> {
@@ -200,13 +205,15 @@ where
 pub struct QuinnProtoReader {
   stream: RecvStream,
   peek_buf: MediumVec<u8>,
+  max_packet_size: usize,
 }
 
-impl From<RecvStream> for QuinnProtoReader {
-  fn from(stream: RecvStream) -> Self {
+impl QuinnProtoReader {
+  fn new(stream: RecvStream, max_packet_size: usize) -> Self {
     Self {
       stream,
       peek_buf: MediumVec::new(),
+      max_packet_size,
     }
   }
 }
@@ -345,10 +352,10 @@ pub struct QuinnStream {
 
 impl QuinnStream {
   #[inline]
-  fn new(send: SendStream, recv: RecvStream) -> Self {
+  fn new(send: SendStream, recv: RecvStream, max_packet_size: usize) -> Self {
     Self {
       send,
-      recv: recv.into(),
+      recv: QuinnProtoReader::new(recv, max_packet_size),
     }
   }
 }
@@ -399,11 +406,10 @@ impl QuicStream for QuinnStream {
   type SendStream = SendStream;
 
   async fn read_packet(&mut self) -> std::io::Result<bytes::Bytes> {
-    // TODO(al8n): make size limit configurable?
     self
       .recv
       .stream
-      .read_to_end(u32::MAX as usize)
+      .read_to_end(self.recv.max_packet_size)
       .await
       .map(|data| {
         if !self.recv.peek_buf.is_empty() {
@@ -429,6 +435,7 @@ pub struct QuinnConnection {
   conn: Connection,
   local_addr: SocketAddr,
   remote_addr: SocketAddr,
+  max_packet_size: usize,
 }
 
 impl Clone for QuinnConnection {
@@ -437,17 +444,19 @@ impl Clone for QuinnConnection {
       conn: self.conn.clone(),
       local_addr: self.local_addr,
       remote_addr: self.remote_addr,
+      max_packet_size: self.max_packet_size,
     }
   }
 }
 
 impl QuinnConnection {
   #[inline]
-  fn new(conn: Connection, local_addr: SocketAddr, remote_addr: SocketAddr) -> Self {
+  fn new(conn: Connection, local_addr: SocketAddr, remote_addr: SocketAddr, max_packet_size: usize) -> Self {
     Self {
       conn,
       local_addr,
       remote_addr,
+      max_packet_size,
     }
   }
 }
@@ -457,12 +466,12 @@ impl QuicConnection for QuinnConnection {
 
   async fn accept_bi(&self) -> io::Result<(Self::Stream, SocketAddr)> {
     let (send, recv) = self.conn.accept_bi().await?;
-    Ok((QuinnStream::new(send, recv), self.remote_addr))
+    Ok((QuinnStream::new(send, recv, self.max_packet_size), self.remote_addr))
   }
 
   async fn open_bi(&self) -> io::Result<(Self::Stream, SocketAddr)> {
     let (send, recv) = self.conn.open_bi().await?;
-    Ok((QuinnStream::new(send, recv), self.remote_addr))
+    Ok((QuinnStream::new(send, recv, self.max_packet_size), self.remote_addr))
   }
 
   async fn close(&self) -> io::Result<()> {

--- a/memberlist-quic/src/stream_layer/quinn/options.rs
+++ b/memberlist-quic/src/stream_layer/quinn/options.rs
@@ -44,7 +44,7 @@ pub struct Options {
   /// To handle such scenarios more gracefully and detect errors like attempting
   /// to connect to a unreachable address more promptly, you need to set this config properly.
   ///
-  /// Default value is 100ms.
+  /// Default value is 10 seconds.
   #[viewit(
     getter(const, attrs(doc = "Gets the timeout of the connect phase.")),
     setter(attrs(doc = "Sets the timeout for connecting to an address."))

--- a/memberlist-quic/src/stream_layer/quinn/options.rs
+++ b/memberlist-quic/src/stream_layer/quinn/options.rs
@@ -124,6 +124,21 @@ pub struct Options {
   )]
   max_connection_data: u32,
 
+  /// Maximum packet size in bytes for `read_packet()`.
+  /// A malicious peer cannot force allocation beyond this limit.
+  ///
+  /// Default is 10MB.
+  #[viewit(
+    getter(
+      const,
+      attrs(doc = "Gets the maximum packet size in bytes for `read_packet()`.")
+    ),
+    setter(attrs(
+      doc = "Sets the maximum packet size in bytes for `read_packet()`."
+    ))
+  )]
+  max_packet_size: u32,
+
   /// TLS client config for the inner [`quinn::ClientConfig`].
   #[viewit(
     getter(
@@ -180,6 +195,7 @@ impl Options {
       // Ensure that one stream is not consuming the whole connection.
       max_stream_data: 10_000_000,
       mtu_discovery_config: Some(Default::default()),
+      max_packet_size: 10_000_000,
     }
   }
 }
@@ -195,6 +211,7 @@ pub(super) struct QuinnOptions {
   connect_timeout: Duration,
   max_stream_data: usize,
   max_connection_data: usize,
+  max_packet_size: usize,
 }
 
 impl From<Options> for QuinnOptions {
@@ -211,6 +228,7 @@ impl From<Options> for QuinnOptions {
       endpoint_config,
       mtu_discovery_config,
       connect_timeout,
+      max_packet_size,
     } = config;
     let mut transport = quinn::TransportConfig::default();
     transport.max_concurrent_uni_streams(max_concurrent_stream_limit.into());
@@ -240,6 +258,7 @@ impl From<Options> for QuinnOptions {
       max_stream_data: max_stream_data as usize,
       max_connection_data: max_connection_data as usize,
       connect_timeout,
+      max_packet_size: max_packet_size as usize,
     }
   }
 }

--- a/memberlist/tests/main/net/send.rs
+++ b/memberlist/tests/main/net/send.rs
@@ -16,6 +16,19 @@ macro_rules! send {
         });
       }
 
+      #[test]
+      fn [< test_ $rt:snake _ $kind:snake _send_many_batches_all_packets >]() {
+        [< $rt:snake _run >](async move {
+          let mut t1_opts = NetTransportOptions::<SmolStr, _, $layer<[< $rt:camel Runtime >]>>::with_stream_layer_options("send_many_node_1".into(), $expr).with_max_packet_size(512);
+          t1_opts.add_bind_address(next_socket_addr_v4(0));
+
+          let mut t2_opts = NetTransportOptions::<SmolStr, _, $layer<[< $rt:camel Runtime >]>>::with_stream_layer_options("send_many_node_2".into(), $expr).with_max_packet_size(512);
+          t2_opts.add_bind_address(next_socket_addr_v4(0));
+
+          memberlist_send_many::<NetTransport<_, SocketAddrResolver<[< $rt:camel Runtime >]>, _, [< $rt:camel Runtime >]>, _>(t1_opts, Options::lan(), t2_opts, Options::lan()).await;
+        });
+      }
+
       #[cfg(any(
         feature = "crc32",
         feature = "xxhash32",


### PR DESCRIPTION
## Summary

This branch contains 10 commits addressing critical QUIC transport layer issues across three categories:

### Bug Fixes

1. **Stream concurrency** (`ab64d3f`)
   `handle_connection` processed streams serially — one slow/blocked stream prevented all others on the same QUIC connection from being handled. Now each stream is dispatched to a detached task. Unknown stream types are logged and skipped instead of killing the entire connection.

2. **Shared endpoint premature close** (`fc15ec3`)
   `QuinnAcceptor` and `QuinnConnector` shared a single `Arc<Endpoint>`. Dropping either one called `Endpoint::close()`, breaking the other. Replaced with a `SharedEndpoint` wrapper that only closes when the last reference drops.

3. **Varint header truncation** (`36899f4`)
   A single `peek()` may return fewer bytes than needed to decode the 1-5 byte varint header, causing `varing::decode_u32_varint` to reject with `InvalidData`. Now loops on `peek()` until enough bytes are accumulated.

4. **send_many dropped packets** (`1516ff0`)
   `send_many` could encode one API call into multiple packet sends but returned after the first send, dropping the rest. Now waits for every packet batch to complete. Added a regression test.

5. **Exponential backoff never reset** (`75e9bc1`)
   Accept error backoff (5ms → 1s) was never reset after a successful accept, so a transient error burst would permanently slow down the acceptor. Now resets on successful accept.

6. **Socket index out-of-bounds panic** (`3bd2ce9`)
   Direct indexing on the socket array during shutdown could panic. Replaced with `.get(idx).cloned()` for safe access.

### Resource / DoS Hardening

7. **read_packet size cap** (`af0f6cc`)
   `read_packet` used `u32::MAX` (~4GB) as the size limit, allowing a malicious peer to force OOM. Now bounded by a configurable `max_packet_size` (default 10MB) threaded through Options → QuinnOptions → QuinnConnection → QuinnStream → QuinnProtoReader.

8. **Packet channel backpressure** (`58daaee`)
   The packet channel was `async_channel::unbounded`, allowing a fast peer to fill unbounded memory. Changed to `bounded(1000)` to provide backpressure.

9. **Connection pool memory leak** (`a8dd6a3`)
   `connection_ttl` defaulted to `None` (`Duration::ZERO`), meaning connections were never proactively expired. Now defaults to 30 seconds. Also fixed `connect_timeout` doc mismatch (said "100ms" but actual default was 10s).

### Refactor

10. **QuinnProtoReader → AsyncPeekable** (`6ad871e`)
    Replaced the hand-rolled QuinnProtoReader (~150 lines of peek_buf management) with `peekable::future::AsyncPeekable<RecvStream>`. Unifies peek/read to consistent "exactly" semantics and removes `consume_peek()` from the `Connection` trait.
