### PR TITLE
memberlist-reactor: gate handle_timeout on inbound quiescence

### DIFF
--- a/memberlist-reactor/src/driver/stream/mod.rs
+++ b/memberlist-reactor/src/driver/stream/mod.rs
@@ -1849,19 +1849,25 @@ where
     // suppress failure detection past it. Outbound caps (actions, transport,
     // gossip egress) do NOT defer: outbound work cannot refute a deadline.
     let inbound_backlog = recv_capped || recv_gated || ingress_capped || inbound_capped;
+    // Sample the clock FRESH for the timeout decision: the drains above take
+    // real time, and a deadline that was in the future at poll entry may have
+    // been crossed during them — evaluating against the stale entry `now`
+    // would route that crossed deadline to the armed-sleep arm below, which
+    // must never fire.
+    let decision_now = Instant::now();
     let target = match this.endpoint.poll_timeout() {
-      Some(d) => d.min(now + this.idle_wake),
-      None => now + this.idle_wake,
+      Some(d) => d.min(decision_now + this.idle_wake),
+      None => decision_now + this.idle_wake,
     };
-    if target <= now {
+    if target <= decision_now {
       if inbound_backlog {
-        this.timeout_stall_since.get_or_insert(now);
+        this.timeout_stall_since.get_or_insert(decision_now);
       }
       let grace_elapsed = this
         .timeout_stall_since
-        .is_some_and(|t| now.saturating_duration_since(t) >= TIMEOUT_STALENESS_GRACE);
+        .is_some_and(|t| decision_now.saturating_duration_since(t) >= TIMEOUT_STALENESS_GRACE);
       if !inbound_backlog || grace_elapsed {
-        this.endpoint.handle_timeout(now);
+        this.endpoint.handle_timeout(decision_now);
         this.timeout_stall_since = None;
         progress = true;
       }
@@ -1871,14 +1877,17 @@ where
       more = true;
     } else {
       this.timeout_stall_since = None;
-      this.arm_timer(target, now);
+      this.arm_timer(target, decision_now);
       if let Some(timer) = this.timer.as_mut()
         && timer.as_mut().poll(cx).is_ready()
       {
-        this.endpoint.handle_timeout(Instant::now());
+        // The sleep elapsed at/just after arming (the deadline crossed between
+        // the fresh sample above and this poll). Do NOT fire here — every
+        // `handle_timeout` goes through the gated due branch, which the next
+        // poll's fresh sample reaches — just clear the consumed sleep and
+        // self-wake.
         this.timer = None;
         this.timer_deadline = None;
-        progress = true;
         more = true;
       }
     }

--- a/memberlist-reactor/src/driver/stream/mod.rs
+++ b/memberlist-reactor/src/driver/stream/mod.rs
@@ -86,6 +86,14 @@ use smallvec::SmallVec;
 /// IP-layer UDP payload maximum; caps the per-recv gossip buffer.
 const GOSSIP_RECV_BUF_MAX: usize = 65507;
 
+/// Wall-clock bound on deferring a DUE `handle_timeout` behind capped inbound
+/// paths. Inbound drains roughly FIFO, so the pre-deadline backlog clears
+/// within a bounded number of capped polls (microseconds at gossip datagram
+/// sizes) — the grace exists so a sustained external flood that keeps every
+/// poll capped cannot suppress failure detection, while a burst that merely
+/// truncated one batch never prematurely times out the input it buffered.
+const TIMEOUT_STALENESS_GRACE: core::time::Duration = core::time::Duration::from_millis(5);
+
 /// The largest the encrypted wrapper can inflate a gossip datagram, or `0` when
 /// no encryption backend is built in. The proto const exists only under an
 /// encryption backend; with none the gossip frame goes out unencrypted, so the
@@ -488,6 +496,11 @@ where
   transmit_batch: usize,
   timer: Option<Pin<Box<R::Sleep>>>,
   timer_deadline: Option<Instant>,
+  /// Anchored the first poll a DUE deadline is held back by a capped inbound
+  /// path; `handle_timeout` force-fires once
+  /// [`TIMEOUT_STALENESS_GRACE`] has elapsed since this anchor, so a
+  /// sustained inbound flood cannot suppress failure detection.
+  timeout_stall_since: Option<Instant>,
   idle_wake: Duration,
   /// No-progress (idle) bound on a bridge's post-Close graceful drain. A
   /// graceful Close has no remaining cancel path, so a non-reading peer would
@@ -581,6 +594,7 @@ where
       transmit_batch,
       timer: None,
       timer_deadline: None,
+      timeout_stall_since: None,
       idle_wake: Duration::from_secs(1),
       close_timeout,
       cidr_policy,
@@ -1190,7 +1204,44 @@ where
   /// snapshot) and whether any surface hit its cap with work left (self-wake).
   // `G: rand::Rng`: the inbound-gossip pass feeds `handle_packet`, which drives
   // the endpoint's gossip RNG.
-  fn drain_surfaces(&mut self, cx: &mut Context<'_>) -> (bool, bool)
+  /// Repeatedly runs the ordered surface pass to a FIXED POINT: a later surface
+  /// can create work for an earlier one (an event answering enqueues a
+  /// transmit; a fed inbound message enqueues an event), and a single ordered
+  /// pass would report false quiescence for it. Each surface stays cap-bounded
+  /// per pass, so a hit cap ends the fixed point (`more == true`, self-wake)
+  /// rather than repeating; on `more == false` no ready machine work remains
+  /// from this poll's input. The third return is whether the INGRESS surface
+  /// specifically hit its cap — parsed gossip not yet fed to the machine —
+  /// which gates the timer below exactly like a capped socket recv.
+  fn drain_surfaces(&mut self, cx: &mut Context<'_>) -> (bool, bool, bool)
+  where
+    G: rand::Rng,
+  {
+    let mut worked = false;
+    let mut ingress_capped = false;
+    loop {
+      let (pass_worked, pass_more, pass_ingress_capped) = self.drain_surfaces_pass(cx);
+      worked |= pass_worked;
+      ingress_capped |= pass_ingress_capped;
+      if pass_more {
+        return (worked, true, ingress_capped);
+      }
+      if !pass_worked {
+        return (worked, false, ingress_capped);
+      }
+    }
+  }
+
+  /// One ordered surface pass — ingress → action → transport → gossip → event —
+  /// each capped surface draining up to the transmit budget. The event surface
+  /// is UNCAPPED (drained to empty) so a surfaced terminal
+  /// (`ExchangeCompleted` / `LeftCluster`) folded by `send_observation` is
+  /// never stranded behind a per-poll cap under a gossip flood. Sound:
+  /// `poll_event` is pump-fed (bounded per poll by the already-capped feeds
+  /// plus a `handle_timeout` burst), `send_observation` is non-blocking
+  /// (overflow + drop), and there is no event→event feedback, so the drain
+  /// terminates.
+  fn drain_surfaces_pass(&mut self, cx: &mut Context<'_>) -> (bool, bool, bool)
   where
     G: rand::Rng,
   {
@@ -1217,7 +1268,8 @@ where
       }
     }
     worked |= ingress > 0;
-    more |= ingress == budget;
+    let ingress_capped = ingress == budget;
+    more |= ingress_capped;
 
     // Stream actions: open dials, half-close, or tear down reliable exchanges.
     // Drained before transport bytes so a fresh Connect installs the bridge
@@ -1271,20 +1323,17 @@ where
     worked |= sent > 0;
     more |= sent == budget;
 
-    // Observation events: retry the overflow first, then drain up to the budget.
+    // Observation events: retry the overflow first, then drain to EMPTY (see
+    // the pass doc for why this surface is uncapped).
     self.flush_obs_overflow();
-    let mut events = 0;
-    while events < budget {
-      let Some(ev) = self.endpoint.poll_event() else {
-        break;
-      };
-      events += 1;
+    let mut events = false;
+    while let Some(ev) = self.endpoint.poll_event() {
+      events = true;
       self.send_observation(ev);
     }
-    worked |= events > 0;
-    more |= events == budget;
+    worked |= events;
 
-    (worked, more)
+    (worked, more, ingress_capped)
   }
 
   /// Retries retained overflow events into the obs channel, stopping at the first
@@ -1508,7 +1557,7 @@ where
           // while there is channel or surface work — drain_surfaces must reach
           // QUIESCENCE before we decide, or a completion (or a second queued event)
           // could be left unfolded.
-          let (_, surf_more) = this.drain_surfaces(cx);
+          let (_, surf_more, _) = this.drain_surfaces(cx);
           if channel_work || surf_more {
             continue;
           }
@@ -1686,9 +1735,8 @@ where
       progress = true;
     }
     more |= recv_gated;
-    if recv_n == this.recv_batch {
-      more = true;
-    }
+    let recv_capped = recv_n == this.recv_batch;
+    more |= recv_capped;
 
     // Accept inbound connections: register each with the machine and bridge it.
     // Aux tasks wake the driver after enqueueing, so try_recv (no waker
@@ -1777,26 +1825,52 @@ where
     if inbound_n > 0 {
       progress = true;
     }
-    if inbound_n == this.recv_batch {
-      more = true;
-    }
+    let inbound_capped = inbound_n == this.recv_batch;
+    more |= inbound_capped;
 
-    // Drain machine surfaces (bounded per surface).
-    let (drained, drain_more) = this.drain_surfaces(cx);
+    // Drain machine surfaces to a fixed point (each surface cap-bounded per
+    // pass; the event surface uncapped so terminals fold before the timer
+    // decision below).
+    let (drained, drain_more, ingress_capped) = this.drain_surfaces(cx);
     progress |= drained;
     more |= drain_more;
 
-    // Timer: fire an overdue deadline inline, else arm + poll the sleep. A fired
-    // deadline may queue transmits/events this pass did not drain.
+    // Timer, gated on INBOUND quiescence. A resolving Ack (or any
+    // deadline-refuting input) that arrived BEFORE a due deadline can still be
+    // buffered behind the per-poll caps — in the kernel socket buffer
+    // (`recv_capped`), the raw ingress buffer (`recv_gated`), the parsed-gossip
+    // surface (`ingress_capped`), or the bridge-inbound channel
+    // (`inbound_capped`). Firing `handle_timeout` past it would time out an
+    // exchange or suspect a live peer prematurely, so a due deadline DEFERS
+    // while any inbound path is capped: the `more` self-wake re-polls and each
+    // capped path drains FIFO, so the pre-deadline backlog clears within a
+    // bounded number of polls. Deferral is itself bounded by a wall-clock
+    // staleness grace — a sustained flood that keeps every poll capped cannot
+    // suppress failure detection past it. Outbound caps (actions, transport,
+    // gossip egress) do NOT defer: outbound work cannot refute a deadline.
+    let inbound_backlog = recv_capped || recv_gated || ingress_capped || inbound_capped;
     let target = match this.endpoint.poll_timeout() {
       Some(d) => d.min(now + this.idle_wake),
       None => now + this.idle_wake,
     };
     if target <= now {
-      this.endpoint.handle_timeout(now);
-      progress = true;
+      if inbound_backlog {
+        this.timeout_stall_since.get_or_insert(now);
+      }
+      let grace_elapsed = this
+        .timeout_stall_since
+        .is_some_and(|t| now.saturating_duration_since(t) >= TIMEOUT_STALENESS_GRACE);
+      if !inbound_backlog || grace_elapsed {
+        this.endpoint.handle_timeout(now);
+        this.timeout_stall_since = None;
+        progress = true;
+      }
+      // Due (fired or deferred): self-wake either way — a fired deadline may
+      // have queued transmits/events this pass did not drain, and a deferred
+      // one needs the re-poll to drain the backlog toward quiescence.
       more = true;
     } else {
+      this.timeout_stall_since = None;
       this.arm_timer(target, now);
       if let Some(timer) = this.timer.as_mut()
         && timer.as_mut().poll(cx).is_ready()

--- a/memberlist-reactor/src/driver/stream/tests.rs
+++ b/memberlist-reactor/src/driver/stream/tests.rs
@@ -2306,3 +2306,104 @@ async fn dispatch_set_ack_payload_running_replies_ok() {
     "an in-budget ack payload is stored on a running node"
   );
 }
+
+/// A DUE deadline must not fire while the gossip recv is capped: an Ack that
+/// arrived before the deadline may still be buffered behind the per-poll
+/// batch, and firing past it would suspect a live peer prematurely. The pump
+/// anchors the deferral instead (and self-wakes to drain), then fires once the
+/// inbound paths are quiescent — observable as the anchor clearing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn due_timeout_defers_while_recv_is_capped_then_fires_on_quiescence() {
+  // Schedulers OFF so no staggered SWIM deadline interferes; a zero idle wake
+  // makes the timer target due on EVERY poll, isolating the gate itself.
+  let (mut driver, _obs_rx, _shared, _bytes) = build_driver_with(64, None, 8, |_| {}).await;
+  driver.idle_wake = Duration::ZERO;
+
+  // Stage a capped recv: more datagrams in the kernel than one batch
+  // (recv_batch == 8). Content is irrelevant — an unparseable datagram still
+  // counts toward the batch.
+  let gossip_addr = driver
+    .socket
+    .as_ref()
+    .expect("gossip socket held")
+    .local_addr()
+    .expect("gossip local addr");
+  let tx = <TokioNet as Net>::UdpSocket::bind("127.0.0.1:0")
+    .await
+    .expect("bind flood socket");
+  for _ in 0..24 {
+    tx.send_to(b"not-a-gossip-frame", gossip_addr)
+      .await
+      .expect("flood send");
+  }
+  // Let the kernel surface the datagrams to the receiving socket.
+  TokioRuntime::sleep(Duration::from_millis(50)).await;
+
+  let _ = poll_once(&mut driver);
+  assert!(
+    driver.timeout_stall_since.is_some(),
+    "a due deadline behind a capped recv batch must defer, not fire"
+  );
+
+  // Draining polls reach quiescence within a bounded number of batches; the
+  // fire on the quiescent poll clears the anchor.
+  let mut fired = false;
+  for _ in 0..16 {
+    let _ = poll_once(&mut driver);
+    if driver.timeout_stall_since.is_none() {
+      fired = true;
+      break;
+    }
+  }
+  assert!(
+    fired,
+    "once the backlog drains, the deferred deadline must fire and clear the anchor"
+  );
+}
+
+/// The deferral is bounded: a sustained flood that keeps every poll capped
+/// cannot suppress `handle_timeout` past the staleness grace — the due
+/// deadline force-fires and the anchor clears even with the backlog still
+/// standing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn due_timeout_force_fires_past_the_staleness_grace() {
+  let (mut driver, _obs_rx, _shared, _bytes) = build_driver_with(64, None, 8, |_| {}).await;
+  driver.idle_wake = Duration::ZERO;
+
+  let gossip_addr = driver
+    .socket
+    .as_ref()
+    .expect("gossip socket held")
+    .local_addr()
+    .expect("gossip local addr");
+  let tx = <TokioNet as Net>::UdpSocket::bind("127.0.0.1:0")
+    .await
+    .expect("bind flood socket");
+
+  // Anchor the deferral with a first capped poll.
+  for _ in 0..24 {
+    tx.send_to(b"not-a-gossip-frame", gossip_addr)
+      .await
+      .expect("flood send");
+  }
+  TokioRuntime::sleep(Duration::from_millis(50)).await;
+  let _ = poll_once(&mut driver);
+  assert!(
+    driver.timeout_stall_since.is_some(),
+    "the flood must anchor a deferral first"
+  );
+
+  // Keep the socket saturated past the grace, then poll: the due deadline
+  // must force-fire (anchor cleared) despite the standing backlog.
+  for _ in 0..24 {
+    tx.send_to(b"not-a-gossip-frame", gossip_addr)
+      .await
+      .expect("flood send");
+  }
+  TokioRuntime::sleep(TIMEOUT_STALENESS_GRACE + Duration::from_millis(10)).await;
+  let _ = poll_once(&mut driver);
+  assert!(
+    driver.timeout_stall_since.is_none(),
+    "a sustained flood must not suppress the deadline past the staleness grace"
+  );
+}

--- a/memberlist-reactor/src/driver/stream/tests.rs
+++ b/memberlist-reactor/src/driver/stream/tests.rs
@@ -2407,3 +2407,35 @@ async fn due_timeout_force_fires_past_the_staleness_grace() {
     "a sustained flood must not suppress the deadline past the staleness grace"
   );
 }
+
+/// The armed-sleep arm never fires: a sleep that becomes ready is cleared and
+/// the pump self-wakes into the gated due branch (which the next poll's fresh
+/// clock sample reaches), so a deadline crossed mid-poll can never bypass the
+/// inbound-quiescence gate. With no machine deadline due, ready idle sleeps
+/// come and go without ever calling `handle_timeout` from that arm — the
+/// pump's ONLY `handle_timeout` call site is inside the gated branch — and
+/// the anchor stays untouched.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ready_idle_sleep_self_wakes_without_firing() {
+  let (mut driver, _obs_rx, _shared, _bytes) = build_driver_with(64, None, 8, |_| {}).await;
+  driver.idle_wake = Duration::from_millis(10);
+
+  // Quiescent poll arms the idle sleep.
+  let _ = poll_once(&mut driver);
+  let armed = driver.timer_deadline;
+  assert!(armed.is_some(), "the quiescent poll arms the idle sleep");
+
+  // Let the armed sleep elapse, then poll with the pump still quiescent: the
+  // ready sleep is consumed (cleared or re-armed to a NEW deadline) without
+  // any due machine deadline to fire and without touching the anchor.
+  TokioRuntime::sleep(Duration::from_millis(20)).await;
+  let _ = poll_once(&mut driver);
+  assert!(
+    driver.timeout_stall_since.is_none(),
+    "a ready idle sleep with nothing due must not anchor a deferral"
+  );
+  assert_ne!(
+    driver.timer_deadline, armed,
+    "the elapsed sleep is consumed: cleared or re-armed to a fresh deadline"
+  );
+}

--- a/memberlist-reactor/src/driver/stream/tests.rs
+++ b/memberlist-reactor/src/driver/stream/tests.rs
@@ -85,7 +85,7 @@ use std::{
 
 use memberlist_proto::{
   event::{Reliability, UserPacket},
-  typed::{NodeState, State},
+  typed::{Alive, Node, NodeState, State, Suspect},
 };
 use std::sync::atomic::AtomicBool;
 
@@ -435,6 +435,39 @@ fn poll_once(driver: &mut StreamDriver<SmolStr, TokioRuntime, RawRecords>) -> Po
   let waker = flag_waker();
   let mut cx = Context::from_waker(&waker);
   Pin::new(driver).poll(&mut cx)
+}
+
+/// Stage a suspicion timer on a fresh peer: the machine's next deadline is
+/// its suspicion timeout — a fixed multiple of the probe interval, with no
+/// random stagger — and its fire is OBSERVABLE as the peer turning `Dead`,
+/// so a test can distinguish a deferred timeout from a fired one by member
+/// state rather than by driver bookkeeping alone.
+fn stage_suspicion(
+  endpoint: &mut StreamEndpoint<SmolStr, SocketAddr, RawRecords>,
+  id: &str,
+  peer_addr: SocketAddr,
+) {
+  let now = Instant::now();
+  endpoint.handle_alive(
+    peer_addr,
+    Alive::new(1, Node::new(SmolStr::new(id), peer_addr)),
+    now,
+  );
+  endpoint.handle_suspect(
+    peer_addr,
+    Suspect::new(1, SmolStr::new(id), SmolStr::new("drv")),
+    now,
+  );
+}
+
+/// The peer's gossip-tracked liveness, straight from the machine (the
+/// wire-format `NodeState` served by `members()` fixes its state field at
+/// insertion and never reflects Suspect / Dead transitions).
+fn peer_state(driver: &StreamDriver<SmolStr, TokioRuntime, RawRecords>, id: &str) -> Option<State> {
+  driver
+    .endpoint
+    .endpoint_ref()
+    .member_liveness(&SmolStr::new(id))
 }
 
 /// Drives a shutting-down driver to `Poll::Ready`, polling it with the calling
@@ -2310,14 +2343,29 @@ async fn dispatch_set_ack_payload_running_replies_ok() {
 /// A DUE deadline must not fire while the gossip recv is capped: an Ack that
 /// arrived before the deadline may still be buffered behind the per-poll
 /// batch, and firing past it would suspect a live peer prematurely. The pump
-/// anchors the deferral instead (and self-wakes to drain), then fires once the
-/// inbound paths are quiescent — observable as the anchor clearing.
+/// anchors the deferral instead (and self-wakes to drain), then fires once
+/// the inbound paths are quiescent. Deferral versus firing is read off the
+/// MACHINE — a due suspicion whose fire turns the peer `Dead` — so a
+/// `handle_timeout` call that is silently dropped, or relocated to an arm the
+/// due branch never reaches, fails this test rather than merely re-shuffling
+/// driver bookkeeping.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn due_timeout_defers_while_recv_is_capped_then_fires_on_quiescence() {
-  // Schedulers OFF so no staggered SWIM deadline interferes; a zero idle wake
-  // makes the timer target due on EVERY poll, isolating the gate itself.
-  let (mut driver, _obs_rx, _shared, _bytes) = build_driver_with(64, None, 8, |_| {}).await;
-  driver.idle_wake = Duration::ZERO;
+  // Schedulers OFF so the suspicion timer is the ONLY machine deadline.
+  let peer_addr: SocketAddr = "127.0.0.1:39998".parse().unwrap();
+  let (mut driver, _obs_rx, _shared, _bytes) = build_driver_with(64, None, 8, |endpoint| {
+    stage_suspicion(endpoint, "capped-peer", peer_addr);
+  })
+  .await;
+
+  // Let the suspicion deadline fall due while the pump is unpolled — the
+  // machine is passive, so the peer stays Suspect until a poll fires it.
+  let due_at = driver
+    .endpoint
+    .poll_timeout()
+    .expect("the staged suspicion arms a machine deadline");
+  TokioRuntime::sleep(due_at.saturating_duration_since(Instant::now()) + Duration::from_millis(20))
+    .await;
 
   // Stage a capped recv: more datagrams in the kernel than one batch
   // (recv_batch == 8). Content is irrelevant — an unparseable datagram still
@@ -2344,31 +2392,53 @@ async fn due_timeout_defers_while_recv_is_capped_then_fires_on_quiescence() {
     driver.timeout_stall_since.is_some(),
     "a due deadline behind a capped recv batch must defer, not fire"
   );
+  assert_eq!(
+    peer_state(&driver, "capped-peer"),
+    Some(State::Suspect),
+    "the deferred fire must leave the machine untouched: the due suspicion \
+     has not completed while the recv batch is capped"
+  );
 
   // Draining polls reach quiescence within a bounded number of batches; the
-  // fire on the quiescent poll clears the anchor.
+  // fire on the quiescent poll completes the suspicion and clears the anchor.
   let mut fired = false;
   for _ in 0..16 {
     let _ = poll_once(&mut driver);
-    if driver.timeout_stall_since.is_none() {
+    if peer_state(&driver, "capped-peer") == Some(State::Dead) {
       fired = true;
       break;
     }
   }
   assert!(
     fired,
-    "once the backlog drains, the deferred deadline must fire and clear the anchor"
+    "once the backlog drains, the deferred deadline must fire: the due \
+     suspicion completes and the peer turns Dead"
+  );
+  assert!(
+    driver.timeout_stall_since.is_none(),
+    "the fire clears the deferral anchor"
   );
 }
 
 /// The deferral is bounded: a sustained flood that keeps every poll capped
 /// cannot suppress `handle_timeout` past the staleness grace — the due
-/// deadline force-fires and the anchor clears even with the backlog still
-/// standing.
+/// deadline force-fires even with the backlog still standing, observable as
+/// the due suspicion completing (the peer turns `Dead`) with the socket
+/// still saturated.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn due_timeout_force_fires_past_the_staleness_grace() {
-  let (mut driver, _obs_rx, _shared, _bytes) = build_driver_with(64, None, 8, |_| {}).await;
-  driver.idle_wake = Duration::ZERO;
+  let peer_addr: SocketAddr = "127.0.0.1:39997".parse().unwrap();
+  let (mut driver, _obs_rx, _shared, _bytes) = build_driver_with(64, None, 8, |endpoint| {
+    stage_suspicion(endpoint, "flooded-peer", peer_addr);
+  })
+  .await;
+
+  let due_at = driver
+    .endpoint
+    .poll_timeout()
+    .expect("the staged suspicion arms a machine deadline");
+  TokioRuntime::sleep(due_at.saturating_duration_since(Instant::now()) + Duration::from_millis(20))
+    .await;
 
   let gossip_addr = driver
     .socket
@@ -2380,7 +2450,7 @@ async fn due_timeout_force_fires_past_the_staleness_grace() {
     .await
     .expect("bind flood socket");
 
-  // Anchor the deferral with a first capped poll.
+  // Anchor the deferral with a first capped poll: the due suspicion is held.
   for _ in 0..24 {
     tx.send_to(b"not-a-gossip-frame", gossip_addr)
       .await
@@ -2392,9 +2462,14 @@ async fn due_timeout_force_fires_past_the_staleness_grace() {
     driver.timeout_stall_since.is_some(),
     "the flood must anchor a deferral first"
   );
+  assert_eq!(
+    peer_state(&driver, "flooded-peer"),
+    Some(State::Suspect),
+    "the anchored deferral must hold the due suspicion open"
+  );
 
   // Keep the socket saturated past the grace, then poll: the due deadline
-  // must force-fire (anchor cleared) despite the standing backlog.
+  // must force-fire despite the standing backlog.
   for _ in 0..24 {
     tx.send_to(b"not-a-gossip-frame", gossip_addr)
       .await
@@ -2402,9 +2477,15 @@ async fn due_timeout_force_fires_past_the_staleness_grace() {
   }
   TokioRuntime::sleep(TIMEOUT_STALENESS_GRACE + Duration::from_millis(10)).await;
   let _ = poll_once(&mut driver);
+  assert_eq!(
+    peer_state(&driver, "flooded-peer"),
+    Some(State::Dead),
+    "a sustained flood must not suppress the deadline past the staleness \
+     grace: the force-fire completes the suspicion"
+  );
   assert!(
     driver.timeout_stall_since.is_none(),
-    "a sustained flood must not suppress the deadline past the staleness grace"
+    "the force-fire clears the deferral anchor"
   );
 }
 
@@ -2417,25 +2498,14 @@ async fn due_timeout_force_fires_past_the_staleness_grace() {
 /// arm deterministically.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn ready_sleep_is_cleared_without_touching_the_machine() {
-  use memberlist_proto::typed::{Alive, Node, Suspect};
   let peer_addr: SocketAddr = "127.0.0.1:39999".parse().unwrap();
   let (mut driver, _obs_rx, _shared, _bytes) = build_driver_with(64, None, 8, |endpoint| {
     // A suspicion timer supplies the stable machine deadline the sleep arms
-    // toward: its timeout is a fixed multiple of the probe interval,
-    // comfortably beyond this test's microsecond-scale polls. (The periodic
-    // schedulers stay OFF — their first tick is randomly staggered and can
-    // land arbitrarily close, which would flake the not-yet-due branch.)
-    let now = Instant::now();
-    endpoint.handle_alive(
-      peer_addr,
-      Alive::new(1, Node::new(SmolStr::new("suspect-peer"), peer_addr)),
-      now,
-    );
-    endpoint.handle_suspect(
-      peer_addr,
-      Suspect::new(1, SmolStr::new("suspect-peer"), SmolStr::new("drv")),
-      now,
-    );
+    // toward, comfortably beyond this test's microsecond-scale polls. (The
+    // periodic schedulers stay OFF — their first tick is randomly staggered
+    // and can land arbitrarily close, which would flake the not-yet-due
+    // branch.)
+    stage_suspicion(endpoint, "suspect-peer", peer_addr);
   })
   .await;
   // Keep the idle wake above the suspicion deadline so the machine deadline
@@ -2486,14 +2556,34 @@ async fn ready_sleep_is_cleared_without_touching_the_machine() {
 /// The inbound-quiescence gate is sound only if the machine timer can fire
 /// nowhere else: every `handle_timeout` must route through the single gated
 /// decision (fresh clock sample, backlog deferral, staleness grace). Pin that
-/// structurally — the pump source carries exactly one call site, so no other
-/// arm (the ready-sleep arm in particular) can bypass the gate.
+/// structurally — the pump source carries exactly one call site AND it sits
+/// inside the gated block, so the call can neither gain a sibling nor be
+/// relocated to an arm (the ready-sleep arm in particular) that bypasses the
+/// gate.
 #[test]
-fn the_pump_has_exactly_one_handle_timeout_call_site() {
-  let call_sites = include_str!("mod.rs").matches(".handle_timeout(").count();
+fn the_pump_fires_timeouts_only_inside_the_gated_branch() {
+  let src = include_str!("mod.rs");
   assert_eq!(
-    call_sites, 1,
-    "a handle_timeout call outside the gated due branch can fire a due \
-     deadline past capped inbound backlog holding a deadline-refuting Ack"
+    src.matches(".handle_timeout(").count(),
+    1,
+    "a second handle_timeout call site can fire a due deadline past capped \
+     inbound backlog holding a deadline-refuting Ack"
+  );
+  let gate = src
+    .find("if !inbound_backlog || grace_elapsed")
+    .expect("the gated due decision exists in the pump");
+  // The gated block holds straight-line statements only, so its first `}` is
+  // its closing brace; the sole call must sit between the condition and it.
+  let gate_close = gate
+    + src[gate..]
+      .find('}')
+      .expect("the gated due decision block closes");
+  let call = src
+    .find(".handle_timeout(")
+    .expect("the single call site exists");
+  assert!(
+    gate < call && call < gate_close,
+    "the sole handle_timeout call must sit inside the gated due decision — \
+     anywhere else can fire past capped inbound backlog"
   );
 }

--- a/memberlist-reactor/src/driver/stream/tests.rs
+++ b/memberlist-reactor/src/driver/stream/tests.rs
@@ -2408,34 +2408,92 @@ async fn due_timeout_force_fires_past_the_staleness_grace() {
   );
 }
 
-/// The armed-sleep arm never fires: a sleep that becomes ready is cleared and
-/// the pump self-wakes into the gated due branch (which the next poll's fresh
-/// clock sample reaches), so a deadline crossed mid-poll can never bypass the
-/// inbound-quiescence gate. With no machine deadline due, ready idle sleeps
-/// come and go without ever calling `handle_timeout` from that arm — the
-/// pump's ONLY `handle_timeout` call site is inside the gated branch — and
-/// the anchor stays untouched.
+/// The armed-sleep arm is machine-neutral: when the sleep polls Ready, the
+/// pump clears it and self-wakes — it never touches the endpoint. Entering
+/// that arm requires a STABLE future target (a machine deadline below the
+/// idle wake), else `arm_timer` replaces the staged sleep with a fresh one
+/// before it is ever polled; the schedulers supply one, and swapping the
+/// armed sleep for an elapsed one while keeping `timer_deadline` drives the
+/// arm deterministically.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn ready_idle_sleep_self_wakes_without_firing() {
-  let (mut driver, _obs_rx, _shared, _bytes) = build_driver_with(64, None, 8, |_| {}).await;
-  driver.idle_wake = Duration::from_millis(10);
+async fn ready_sleep_is_cleared_without_touching_the_machine() {
+  use memberlist_proto::typed::{Alive, Node, Suspect};
+  let peer_addr: SocketAddr = "127.0.0.1:39999".parse().unwrap();
+  let (mut driver, _obs_rx, _shared, _bytes) = build_driver_with(64, None, 8, |endpoint| {
+    // A suspicion timer supplies the stable machine deadline the sleep arms
+    // toward: its timeout is a fixed multiple of the probe interval,
+    // comfortably beyond this test's microsecond-scale polls. (The periodic
+    // schedulers stay OFF — their first tick is randomly staggered and can
+    // land arbitrarily close, which would flake the not-yet-due branch.)
+    let now = Instant::now();
+    endpoint.handle_alive(
+      peer_addr,
+      Alive::new(1, Node::new(SmolStr::new("suspect-peer"), peer_addr)),
+      now,
+    );
+    endpoint.handle_suspect(
+      peer_addr,
+      Suspect::new(1, SmolStr::new("suspect-peer"), SmolStr::new("drv")),
+      now,
+    );
+  })
+  .await;
+  // Keep the idle wake above the suspicion deadline so the machine deadline
+  // is the arm target — a nearer idle target recomputes fresh every poll
+  // and would replace the staged sleep.
+  driver.idle_wake = Duration::from_secs(600);
 
-  // Quiescent poll arms the idle sleep.
+  // Quiescent poll arms the sleep toward the machine deadline.
   let _ = poll_once(&mut driver);
   let armed = driver.timer_deadline;
-  assert!(armed.is_some(), "the quiescent poll arms the idle sleep");
+  let machine_deadline = driver.endpoint.poll_timeout();
+  assert_eq!(
+    armed, machine_deadline,
+    "with a machine deadline below the idle wake, the timer arms toward it"
+  );
+  let target = armed.expect("the quiescent poll arms the sleep");
 
-  // Let the armed sleep elapse, then poll with the pump still quiescent: the
-  // ready sleep is consumed (cleared or re-armed to a NEW deadline) without
-  // any due machine deadline to fire and without touching the anchor.
+  // Swap in an elapsed sleep, keeping the recorded deadline: the next poll
+  // recomputes the SAME stable target, so `arm_timer` keeps this sleep and
+  // polls it Ready — the exact shape of a deadline crossing between the
+  // fresh clock sample and the timer poll. The wait lets the zero-duration
+  // sleep pass the timer wheel's coarse (millisecond) elapse check while the
+  // suspicion deadline stays comfortably in the future.
+  driver.timer = Some(Box::pin(TokioRuntime::sleep(Duration::ZERO)));
   TokioRuntime::sleep(Duration::from_millis(20)).await;
+  assert!(
+    Instant::now() < target,
+    "precondition: the machine deadline is still in the future"
+  );
   let _ = poll_once(&mut driver);
+
+  assert!(
+    driver.timer.is_none() && driver.timer_deadline.is_none(),
+    "the ready sleep is consumed by the armed-sleep arm, not replaced"
+  );
+  assert_eq!(
+    driver.endpoint.poll_timeout(),
+    machine_deadline,
+    "the armed-sleep arm must not fire the machine timer: the deadline is \
+     untouched and fires later through the gated due branch"
+  );
   assert!(
     driver.timeout_stall_since.is_none(),
-    "a ready idle sleep with nothing due must not anchor a deferral"
+    "clearing a ready sleep must not anchor a deferral"
   );
-  assert_ne!(
-    driver.timer_deadline, armed,
-    "the elapsed sleep is consumed: cleared or re-armed to a fresh deadline"
+}
+
+/// The inbound-quiescence gate is sound only if the machine timer can fire
+/// nowhere else: every `handle_timeout` must route through the single gated
+/// decision (fresh clock sample, backlog deferral, staleness grace). Pin that
+/// structurally — the pump source carries exactly one call site, so no other
+/// arm (the ready-sleep arm in particular) can bypass the gate.
+#[test]
+fn the_pump_has_exactly_one_handle_timeout_call_site() {
+  let call_sites = include_str!("mod.rs").matches(".handle_timeout(").count();
+  assert_eq!(
+    call_sites, 1,
+    "a handle_timeout call outside the gated due branch can fire a due \
+     deadline past capped inbound backlog holding a deadline-refuting Ack"
   );
 }


### PR DESCRIPTION
Fixes #150.