### PR TITLE
fix(proto): reject over-long wire lengths instead of wrapping on 32-bit

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -75,6 +75,49 @@ jobs:
       - name: Test
         run: cargo test -p memberlist-proto --features "$FEATURES"
 
+  proto-i686:
+    name: i686 - proto (32-bit)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      FEATURES: "std,tcp,tls-rustls-ring,quic-rustls-ring,lz4,snappy,zstd,brotli,crc32,xxhash32,xxhash64,xxhash3,murmur3,aes-gcm,chacha20-poly1305,cidr,serde,clap"
+    steps:
+      - uses: actions/checkout@v7
+
+      # A real 32-bit tier-1 host (with std) so the decoder's
+      # `#[cfg(target_pointer_width = "32")]` bounds regressions execute: a
+      # 64-bit host cannot reach the `offset + len` wrap, and the embedded
+      # thumbv7em lane only cross-compiles (no_std, no test runner).
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          targets: i686-unknown-linux-gnu
+
+      - name: Install 32-bit cross linker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-proto-i686
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test
+        run: cargo test -p memberlist-proto --target i686-unknown-linux-gnu --features "$FEATURES"
+
   sim:
     name: simulation
     runs-on: ubuntu-latest

--- a/memberlist-proto/src/data/mod.rs
+++ b/memberlist-proto/src/data/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! This is a verbatim copy of `memberlist-proto::data` + the supporting
 //! helpers from `memberlist-proto::lib` (`check_encoded_message_size`,
-//! `debug_assert_write_eq`, `debug_assert_read_eq`).  Only the
-//! `use super::WireType` import has been repointed to `crate::wire_type`.
+//! `debug_assert_write_eq`).  Only the `use super::WireType` import has been
+//! repointed to `crate::wire_type`.
 //!
 //! `memberlist-proto` stays frozen and is NOT a dependency of this crate.
 use std::borrow::Cow;
@@ -45,20 +45,6 @@ where
   );
 }
 
-#[cfg(debug_assertions)]
-#[inline]
-pub(crate) fn debug_assert_read_eq<T>(actual: usize, expected: usize)
-where
-  T: ?Sized,
-{
-  debug_assert_eq!(
-    actual,
-    expected,
-    "{}: expect reading {expected} bytes, but actual read {actual} bytes",
-    core::any::type_name::<T>()
-  );
-}
-
 // Only the `std`/`alloc`-gated data submodules (`bytes`, `string`) call this, so
 // it carries the same gate to stay live-code under every feature combination.
 #[cfg(any(feature = "std", feature = "alloc"))]
@@ -96,7 +82,7 @@ where
     }
 
     let (offset, len) = decode_u32_varint(src)?;
-    let mut offset = offset.get();
+    let offset = offset.get();
     let len = len as usize;
     // offset + len may overflow usize on 32-bit targets, where a wrap would let
     // the bounds check pass and panic the slice. Reject an end offset that
@@ -110,11 +96,18 @@ where
     let src = &src[offset..end];
     let (bytes_read, value) = Self::decode(src)?;
 
-    #[cfg(debug_assertions)]
-    debug_assert_read_eq::<Self>(bytes_read, len);
+    // The declared length owns the field boundary: the inner decoder must
+    // consume the whole delimited region. A shorter read (e.g. a fixed-size
+    // `[u8; N]` decoder handed a declared `len > N`) would otherwise leave the
+    // trailing in-region bytes to be reparsed as the next field's tag,
+    // smuggling a field across the boundary. Reject the mismatch and advance by
+    // the declared `len`, so the boundary is authoritative regardless of how
+    // many bytes the inner type read.
+    if bytes_read != len {
+      return Err(DecodeError::length_delimited_mismatch());
+    }
 
-    offset += bytes_read;
-    Ok((offset, value))
+    Ok((offset + len, value))
   }
 }
 
@@ -544,6 +537,13 @@ pub enum DecodeError {
   #[error("length-delimited overflow the maximum value of u32")]
   LengthDelimitedOverflow,
 
+  /// Returned when a length-delimited field's declared length does not match
+  /// the number of bytes its inner decoder consumed. The declared length is
+  /// authoritative; a shorter inner read would leave trailing in-region bytes
+  /// to be reparsed as the next field, so the frame is rejected as malformed.
+  #[error("length-delimited field length does not match the consumed bytes")]
+  LengthDelimitedMismatch,
+
   /// A custom decoding error.
   #[error("{0}")]
   Custom(Cow<'static, str>),
@@ -578,6 +578,12 @@ impl DecodeError {
   #[inline]
   pub const fn buffer_underflow() -> Self {
     Self::BufferUnderflow
+  }
+
+  /// Creates a new length-delimited length-mismatch decoding error.
+  #[inline]
+  pub const fn length_delimited_mismatch() -> Self {
+    Self::LengthDelimitedMismatch
   }
 
   /// Creates a new missing field decoding error.

--- a/memberlist-proto/src/data/mod.rs
+++ b/memberlist-proto/src/data/mod.rs
@@ -98,11 +98,16 @@ where
     let (offset, len) = decode_u32_varint(src)?;
     let mut offset = offset.get();
     let len = len as usize;
-    if len + offset > src.len() {
-      return Err(DecodeError::buffer_underflow());
-    }
+    // offset + len may overflow usize on 32-bit targets, where a wrap would let
+    // the bounds check pass and panic the slice. Reject an end offset that
+    // overflows usize or runs past the buffer: the declared payload is not
+    // fully present.
+    let end = match offset.checked_add(len) {
+      Some(end) if end <= src.len() => end,
+      _ => return Err(DecodeError::buffer_underflow()),
+    };
 
-    let src = &src[offset..offset + len];
+    let src = &src[offset..end];
     let (bytes_read, value) = Self::decode(src)?;
 
     #[cfg(debug_assertions)]

--- a/memberlist-proto/src/data/tests.rs
+++ b/memberlist-proto/src/data/tests.rs
@@ -259,6 +259,20 @@ fn decode_rejects_truncated_length_delimited() {
 }
 
 #[test]
+fn decode_length_delimited_rejects_len_exceeding_buffer_without_panicking() {
+  // `[len varint = u32::MAX][a few payload bytes]`. On a 64-bit host
+  // `offset + len` does not overflow usize, so this drives the same over-buffer
+  // branch a 32-bit wrap would take; decode must report BufferUnderflow, never
+  // panic or slice out of range.
+  let mut framed = std::vec![0u8; varing::encoded_u32_varint_len(u32::MAX).get()];
+  varing::encode_u32_varint_to(u32::MAX, &mut framed[..]).expect("encode length prefix");
+  framed.extend_from_slice(b"tiny");
+  let err = String::decode_length_delimited(&framed)
+    .expect_err("a declared length far past the buffer must fail to decode");
+  assert!(matches!(err, DecodeError::BufferUnderflow), "got {err:?}");
+}
+
+#[test]
 fn wire_type_tag_merge_split_roundtrip() {
   for ty in [
     WireType::Byte,
@@ -667,6 +681,20 @@ fn node_decode_skips_unknown_tag() {
 }
 
 #[test]
+fn node_decode_rejects_truncated_trailing_unknown_field() {
+  // A well-formed node followed by an unknown length-delimited field whose
+  // declared payload runs past the buffer. `skip` must fail closed so the
+  // truncated frame is rejected, not silently clamped-and-consumed as if it
+  // were well-formed.
+  let mut buf = small_node_bytes();
+  buf.push(merge(WireType::LengthDelimited, 5)); // unknown tag 5
+  buf.push(8); // declares an 8-byte payload ...
+  buf.extend_from_slice(b"only5"); // ... but only 5 bytes follow
+  let err = SmallNode::decode(&buf).expect_err("truncated unknown field must fail");
+  assert!(matches!(err, DecodeError::BufferUnderflow), "got {err:?}");
+}
+
+#[test]
 fn node_encode_rejects_undersized_buffers() {
   let node = Node::new(7u32, 9u32);
   // Zero-length buffer fails at the very first guard.
@@ -731,6 +759,19 @@ fn tuple_decode_skips_unknown_tag() {
   buf.extend_from_slice(&small_tuple_bytes());
   let (_, t) = <(u32, u32)>::decode(&buf).expect("unknown tag skipped");
   assert_eq!(t, (7u32, 9u32));
+}
+
+#[test]
+fn tuple_decode_rejects_truncated_trailing_unknown_field() {
+  // A well-formed tuple followed by an unknown length-delimited field whose
+  // declared payload runs past the buffer. `skip` must fail closed so the
+  // truncated frame is rejected rather than clamped-and-consumed.
+  let mut buf = small_tuple_bytes();
+  buf.push(merge(WireType::LengthDelimited, 5)); // unknown tag 5
+  buf.push(8); // declares an 8-byte payload ...
+  buf.extend_from_slice(b"only5"); // ... but only 5 bytes follow
+  let err = <(u32, u32)>::decode(&buf).expect_err("truncated unknown field must fail");
+  assert!(matches!(err, DecodeError::BufferUnderflow), "got {err:?}");
 }
 
 #[test]

--- a/memberlist-proto/src/data/tests.rs
+++ b/memberlist-proto/src/data/tests.rs
@@ -273,6 +273,68 @@ fn decode_length_delimited_rejects_len_exceeding_buffer_without_panicking() {
 }
 
 #[test]
+#[cfg(target_pointer_width = "32")]
+fn decode_length_delimited_len_overflow_rejected_on_32bit() {
+  // On a 32-bit target `header_len + u32::MAX` overflows usize. The checked
+  // addition must surface an error, never a wrapped end offset that would pass
+  // the `end <= src.len()` guard and panic the payload slice. The 64-bit host
+  // suite cannot reach this wrap (the sum stays in range), so it only runs on
+  // the i686 CI lane.
+  let mut framed = std::vec![0u8; varing::encoded_u32_varint_len(u32::MAX).get()];
+  varing::encode_u32_varint_to(u32::MAX, &mut framed[..]).expect("encode length prefix");
+  framed.extend_from_slice(b"tiny");
+  let err = String::decode_length_delimited(&framed)
+    .expect_err("a u32::MAX declared length must fail, never panic, on 32-bit");
+  assert!(matches!(err, DecodeError::BufferUnderflow), "got {err:?}");
+}
+
+#[test]
+fn length_delimited_field_longer_than_its_fixed_decoder_is_rejected_not_smuggled() {
+  // The declared length owns a length-delimited field's boundary. When the
+  // inner decoder is fixed-size — `[u8; 4]` always consumes 4 bytes — a length
+  // prefix declaring MORE than that must be rejected. Accepting it by advancing
+  // only the bytes the inner decoder read would leave the trailing in-region
+  // byte to be reparsed as the next field's tag, smuggling a field the sender
+  // hid inside the over-long region across the boundary.
+  //
+  // `([u8; 4], u32)`: field A (tag 1) is the fixed array, field B (tag 2) is a
+  // varint u32. A declares 5 payload bytes but carries only its 4; the 5th
+  // in-region byte is a well-formed B tag followed by a u32 payload.
+  let attack = [
+    merge(WireType::LengthDelimited, 1), // A tag: the [u8; 4] field
+    5,                                   // declares 5 payload bytes for a 4-byte array
+    10,
+    20,
+    30,
+    40,                         // the 4 bytes [u8; 4]::decode consumes
+    merge(WireType::Varint, 2), // 5th in-region byte: a valid B (u32, tag 2) tag
+    7,                          // the u32 an attacker tries to smuggle out of A's region
+  ];
+  // The 5th declared-region byte really is a well-formed next-field tag: a short
+  // read would hand it to the tuple loop and decode a spurious B = 7.
+  assert_eq!(attack[6], merge(WireType::Varint, 2));
+
+  let err = <([u8; 4], u32)>::decode(&attack).expect_err(
+    "a length prefix longer than the fixed-size inner decoder consumes must be rejected, not advanced by the short read",
+  );
+  assert!(
+    matches!(err, DecodeError::LengthDelimitedMismatch),
+    "expected LengthDelimitedMismatch with no smuggled B field, got {err:?}",
+  );
+
+  // The same rejection at the field level: `decode_length_delimited` sees the
+  // inner decoder read 4 of the declared 5 bytes and surfaces the mismatch
+  // rather than returning `Ok` short.
+  let field = &attack[1..]; // strip the tuple's A tag
+  let err = <[u8; 4]>::decode_length_delimited(field)
+    .expect_err("declared length 5 with a 4-byte [u8; 4] decoder must mismatch");
+  assert!(
+    matches!(err, DecodeError::LengthDelimitedMismatch),
+    "got {err:?}",
+  );
+}
+
+#[test]
 fn wire_type_tag_merge_split_roundtrip() {
   for ty in [
     WireType::Byte,
@@ -352,6 +414,75 @@ fn skip_rejects_unknown_wire_type() {
     matches!(err, DecodeError::UnknownWireType(_)),
     "got {err:?}"
   );
+}
+
+#[test]
+fn skip_rejects_truncated_fixed_width_and_length_delimited_fields() {
+  // A field whose declared bytes are not all present is a truncated frame.
+  // `skip` must fail closed with BufferUnderflow so the caller rejects the
+  // datagram, never clamp the advance to the buffer end and silently consume a
+  // partial field as if it were whole.
+
+  // Byte: tag present, its single payload byte absent.
+  let err = skip("t", &[merge(WireType::Byte, 5)]).expect_err("truncated byte field");
+  assert!(
+    matches!(err, DecodeError::BufferUnderflow),
+    "byte: got {err:?}"
+  );
+
+  // Fixed32: tag + only 2 of 4 payload bytes.
+  let err = skip("t", &[merge(WireType::Fixed32, 5), 0, 0]).expect_err("truncated fixed32 field");
+  assert!(
+    matches!(err, DecodeError::BufferUnderflow),
+    "fixed32: got {err:?}"
+  );
+
+  // Fixed64: tag + only 3 of 8 payload bytes.
+  let err =
+    skip("t", &[merge(WireType::Fixed64, 5), 0, 0, 0]).expect_err("truncated fixed64 field");
+  assert!(
+    matches!(err, DecodeError::BufferUnderflow),
+    "fixed64: got {err:?}"
+  );
+
+  // Length-delimited: tag + a length prefix declaring more payload than remains.
+  let err = skip(
+    "t",
+    &[
+      merge(WireType::LengthDelimited, 5),
+      8,
+      b'o',
+      b'n',
+      b'l',
+      b'y',
+      b'5',
+    ],
+  )
+  .expect_err("truncated length-delimited field");
+  assert!(
+    matches!(err, DecodeError::BufferUnderflow),
+    "length-delimited: got {err:?}"
+  );
+}
+
+#[test]
+#[cfg(target_pointer_width = "32")]
+fn skip_length_delimited_len_overflow_rejected_on_32bit() {
+  // On a 32-bit target the length-delimited skip arm computes
+  // `offset + bytes_read + length`, which overflows usize when `length` is near
+  // u32::MAX. The checked addition must surface BufferUnderflow, never a wrapped
+  // end offset that would pass the `end <= buf_len` guard and let a truncated
+  // field be treated as fully skipped. On a 64-bit host the sum stays in range
+  // and the same input is rejected by the buffer-length guard instead, so this
+  // wrap is only reachable on the i686 lane.
+  let mut buf = std::vec![merge(WireType::LengthDelimited, 5)];
+  let mut prefix = std::vec![0u8; varing::encoded_u32_varint_len(u32::MAX).get()];
+  varing::encode_u32_varint_to(u32::MAX, &mut prefix).expect("encode length prefix");
+  buf.extend_from_slice(&prefix);
+  buf.extend_from_slice(b"tiny");
+  let err =
+    skip("t", &buf).expect_err("a u32::MAX declared length must fail, never panic, on 32-bit");
+  assert!(matches!(err, DecodeError::BufferUnderflow), "got {err:?}");
 }
 
 #[test]

--- a/memberlist-proto/src/endpoint/tests.rs
+++ b/memberlist-proto/src/endpoint/tests.rs
@@ -8196,7 +8196,11 @@ fn try_new_at_rejects_zero_max_stream_frame_size() {
 }
 
 #[test]
+#[cfg(target_pointer_width = "64")]
 fn try_new_at_rejects_max_stream_frame_size_above_u32() {
+  // `u32::MAX as usize + 1` only exists as a distinct value on 64-bit; on a
+  // 32-bit target `usize::MAX == u32::MAX`, so the addition overflows at
+  // compile time and the above-u32 case is unreachable there.
   let c = cfg().with_max_stream_frame_size(u32::MAX as usize + 1);
   let t0 = Instant::from_origin(Duration::from_secs(1));
   let res = Endpoint::<SmolStr, SocketAddr>::try_new_at_seeded(c, t0);

--- a/memberlist-proto/src/framing/mod.rs
+++ b/memberlist-proto/src/framing/mod.rs
@@ -784,17 +784,9 @@ pub fn decode_plain_frame(buf: &[u8]) -> Result<(MessageTag, &[u8], usize), Fram
   let header_len = 1 + varint_bytes;
   // header_len + body_len may overflow usize on 32-bit targets, where a wrap
   // below header_len would let the length guard pass and panic the body slice.
-  // A body end past usize::MAX can never be present in a real buffer, so report
+  // Saturate an overflowing end to usize::MAX so the length guard below reports
   // an unsatisfiable incomplete frame rather than wrapping.
-  let body_end = match header_len.checked_add(body_len as usize) {
-    Some(end) => end,
-    None => {
-      return Err(FrameError::Incomplete(IncompleteFrame::new(
-        buf.len(),
-        usize::MAX,
-      )));
-    }
-  };
+  let body_end = header_len.saturating_add(body_len as usize);
   if buf.len() < body_end {
     return Err(FrameError::Incomplete(IncompleteFrame::new(
       buf.len(),

--- a/memberlist-proto/src/framing/mod.rs
+++ b/memberlist-proto/src/framing/mod.rs
@@ -782,7 +782,19 @@ pub fn decode_plain_frame(buf: &[u8]) -> Result<(MessageTag, &[u8], usize), Fram
     Err(e) => return Err(e),
   };
   let header_len = 1 + varint_bytes;
-  let body_end = header_len + body_len as usize;
+  // header_len + body_len may overflow usize on 32-bit targets, where a wrap
+  // below header_len would let the length guard pass and panic the body slice.
+  // A body end past usize::MAX can never be present in a real buffer, so report
+  // an unsatisfiable incomplete frame rather than wrapping.
+  let body_end = match header_len.checked_add(body_len as usize) {
+    Some(end) => end,
+    None => {
+      return Err(FrameError::Incomplete(IncompleteFrame::new(
+        buf.len(),
+        usize::MAX,
+      )));
+    }
+  };
   if buf.len() < body_end {
     return Err(FrameError::Incomplete(IncompleteFrame::new(
       buf.len(),

--- a/memberlist-proto/src/framing/tests.rs
+++ b/memberlist-proto/src/framing/tests.rs
@@ -120,6 +120,49 @@ fn incomplete_frame_returns_error() {
   assert!(matches!(err, FrameError::Incomplete(_)));
 }
 
+#[test]
+fn decode_plain_frame_rejects_body_len_exceeding_buffer_without_panicking() {
+  // A frame that declares a ~4 GiB body but carries only a handful of bytes.
+  // On a 64-bit host `header_len + body_len` does not overflow usize, so this
+  // drives the same over-buffer branch a 32-bit wrap would otherwise take: the
+  // decoder must report Incomplete, never panic or slice out of range.
+  let mut frame = Vec::new();
+  frame.push(MessageTag::UserData as u8);
+  encode_varint_u32(u32::MAX, &mut frame); // declared body length ~4 GiB
+  frame.extend_from_slice(b"only-a-few-bytes");
+  match decode_plain_frame(&frame) {
+    Err(FrameError::Incomplete(f)) => {
+      assert_eq!(f.available(), frame.len());
+      assert!(
+        f.required() > f.available(),
+        "required {} must exceed available {}",
+        f.required(),
+        f.available()
+      );
+    }
+    other => panic!("expected Incomplete, got {other:?}"),
+  }
+}
+
+#[test]
+#[cfg(target_pointer_width = "32")]
+fn decode_plain_frame_body_len_overflow_saturates_to_incomplete_on_32bit() {
+  // On a 32-bit target `header_len + u32::MAX` overflows usize. The checked
+  // addition must surface Incomplete with a saturated `required`, never a value
+  // wrapped below header_len that would pass the length guard and panic the
+  // body slice.
+  let mut frame = Vec::new();
+  frame.push(MessageTag::UserData as u8);
+  encode_varint_u32(u32::MAX, &mut frame);
+  frame.extend_from_slice(b"body");
+  match decode_plain_frame(&frame) {
+    Err(FrameError::Incomplete(f)) => {
+      assert_eq!(f.required(), usize::MAX, "overflow must saturate required");
+    }
+    other => panic!("expected Incomplete, got {other:?}"),
+  }
+}
+
 fn sample_ping() -> AnyMessage {
   AnyMessage::Ping(Ping {
     sequence_number: Some(7),

--- a/memberlist-proto/src/framing/tests.rs
+++ b/memberlist-proto/src/framing/tests.rs
@@ -357,9 +357,14 @@ fn multibyte_length_body_round_trips_through_fallible_encode() {
   assert_eq!(tag, MessageTag::UserData);
   assert_eq!(decoded_body, &body[..]);
   assert_eq!(consumed, frame.len());
-  // The error variant is wired for the overflow path.
-  let e = FrameError::FrameTooLarge(u32::MAX as usize + 1);
-  assert!(e.to_string().contains("too large"));
+  // The error variant is wired for the overflow path. `u32::MAX as usize + 1`
+  // only exists as a distinct value on 64-bit; on a 32-bit target
+  // `usize::MAX == u32::MAX` and the addition overflows at compile time.
+  #[cfg(target_pointer_width = "64")]
+  {
+    let e = FrameError::FrameTooLarge(u32::MAX as usize + 1);
+    assert!(e.to_string().contains("too large"));
+  }
 }
 
 #[cfg(encryption)]
@@ -581,14 +586,17 @@ fn incomplete_frame_accessors_and_display() {
 
 #[test]
 fn frame_error_display_strings_are_nonempty() {
-  let cases: [FrameError; 6] = [
+  let mut cases = vec![
     FrameError::Empty,
     FrameError::Incomplete(IncompleteFrame::new(1, 2)),
     FrameError::UnknownTag(99),
     FrameError::VarintOverflow,
     FrameError::Decode,
-    FrameError::FrameTooLarge(1 << 33),
   ];
+  // `1 << 33` only exists as a distinct usize value on 64-bit; on a 32-bit
+  // target `usize::MAX == u32::MAX` and the shift overflows at compile time.
+  #[cfg(target_pointer_width = "64")]
+  cases.push(FrameError::FrameTooLarge(1 << 33));
   for e in cases {
     assert!(!e.to_string().is_empty(), "empty display for {e:?}");
   }

--- a/memberlist-proto/src/wire_type.rs
+++ b/memberlist-proto/src/wire_type.rs
@@ -91,7 +91,9 @@ pub fn skip(ty: &'static str, src: &[u8]) -> Result<usize, DecodeError> {
   let src = &src[offset..];
   match wire_type {
     WireType::Varint => match varing::decode_u64_varint(src) {
-      Ok((bytes_read, _)) => Ok((offset + bytes_read.get()).min(buf_len)),
+      // varing rejects a truncated varint, so `bytes_read <= src.len()` and
+      // `offset + bytes_read <= buf_len` already holds; no clamp is needed.
+      Ok((bytes_read, _)) => Ok(offset + bytes_read.get()),
       Err(e) => Err(e.into()),
     },
     WireType::LengthDelimited => {
@@ -101,12 +103,26 @@ pub fn skip(ty: &'static str, src: &[u8]) -> Result<usize, DecodeError> {
       }
 
       match varing::decode_u32_varint(src) {
-        Ok((bytes_read, length)) => Ok((offset + bytes_read.get() + length as usize).min(buf_len)),
+        // header + declared payload may run past the buffer, or overflow usize
+        // on 32-bit. A field that is not fully present is a truncated frame and
+        // must be rejected rather than clamped-and-consumed (fail closed).
+        Ok((bytes_read, length)) => offset
+          .checked_add(bytes_read.get())
+          .and_then(|n| n.checked_add(length as usize))
+          .filter(|&end| end <= buf_len)
+          .ok_or(DecodeError::BufferUnderflow),
         Err(e) => Err(e.into()),
       }
     }
-    WireType::Byte => Ok((offset + 1).min(buf_len)),
-    WireType::Fixed32 => Ok((offset + 4).min(buf_len)),
-    WireType::Fixed64 => Ok((offset + 8).min(buf_len)),
+    // A fixed-width field whose bytes are not all present is a truncated frame.
+    WireType::Byte => (offset < buf_len)
+      .then_some(offset + 1)
+      .ok_or(DecodeError::BufferUnderflow),
+    WireType::Fixed32 => (offset + 4 <= buf_len)
+      .then_some(offset + 4)
+      .ok_or(DecodeError::BufferUnderflow),
+    WireType::Fixed64 => (offset + 8 <= buf_len)
+      .then_some(offset + 8)
+      .ok_or(DecodeError::BufferUnderflow),
   }
 }


### PR DESCRIPTION
Closes #167.