### PR TITLE
fix(proto): core Endpoint event, broadcast-GC, and probe single-flight correctness (#165)

### DIFF
--- a/memberlist-proto/src/broadcast/mod.rs
+++ b/memberlist-proto/src/broadcast/mod.rs
@@ -460,6 +460,32 @@ where
     None
   }
 
+  /// Remove any queued broadcast owned by `id`, firing its
+  /// [`finished()`](Broadcast::finished) notification, and return how many
+  /// entries were removed (at most one — id-keyed broadcasts are deduplicated
+  /// by id, so a given id owns a single queued entry).
+  ///
+  /// Used when the owning member is reclaimed so queue ownership ends together
+  /// with membership: otherwise that member's last id-keyed broadcast would
+  /// linger in the queue after its `Endpoint` record is gone. Removal keeps
+  /// `q` and `m` consistent, mirroring the id-keyed replacement in
+  /// [`queue_broadcast`](Self::queue_broadcast).
+  pub fn remove_by_id(&mut self, id: &Id) -> usize {
+    match self.m.remove(id) {
+      Some(old) => {
+        old.broadcast.finished();
+        self.q.remove(&old);
+        if self.q.is_empty() {
+          // An emptied (idle) queue resets the id counter, matching the
+          // id-keyed replacement path in `queue_broadcast`.
+          self.id_gen = 0;
+        }
+        1
+      }
+      None => 0,
+    }
+  }
+
   /// Drain all queued broadcasts (calling `finished()` on each).
   pub fn reset(&mut self) {
     let q = core::mem::take(&mut self.q);

--- a/memberlist-proto/src/broadcast/tests.rs
+++ b/memberlist-proto/src/broadcast/tests.rs
@@ -977,3 +977,47 @@ fn user_broadcasts_empty_and_num_queued() {
   assert!(msgs.is_empty());
   assert_eq!(used, 0);
 }
+
+#[test]
+fn remove_by_id_removes_only_the_named_broadcast() {
+  let mut q = BroadcastQueue::new(3);
+  let fa = Arc::new(AtomicUsize::new(0));
+  let fb = Arc::new(AtomicUsize::new(0));
+  q.queue_broadcast(bcast("alice", "hello-a", fa.clone()));
+  q.queue_broadcast(bcast("bob", "hello-b", fb.clone()));
+  assert_eq!(q.num_queued(), 2);
+
+  let removed = q.remove_by_id(&"alice");
+  assert_eq!(removed, 1, "exactly alice's one broadcast is removed");
+  assert_eq!(q.num_queued(), 1);
+  assert_eq!(
+    fa.load(Ordering::SeqCst),
+    1,
+    "the removed broadcast is finished()"
+  );
+  assert_eq!(fb.load(Ordering::SeqCst), 0);
+
+  // The `m` index stays consistent with `q`: re-queuing alice inserts anew
+  // (no stale index entry masks it), and bob is still the only survivor to
+  // drain if alice is not re-queued.
+  let got = q.take_broadcasts(10, 0, 1024);
+  assert_eq!(got, vec!["hello-b".to_string()]);
+
+  // Removing a non-present id is a no-op returning 0.
+  assert_eq!(q.remove_by_id(&"carol"), 0);
+}
+
+#[test]
+fn remove_by_id_of_last_entry_resets_id_generator() {
+  let mut q = BroadcastQueue::new(3);
+  let f = Arc::new(AtomicUsize::new(0));
+  q.queue_broadcast(bcast("alice", "hello", f.clone()));
+  assert_eq!(q.remove_by_id(&"alice"), 1);
+  assert!(q.is_empty());
+  // After emptying, a freshly queued broadcast is drainable — the queue and
+  // its index are fully consistent (no orphaned `m` entry).
+  let f2 = Arc::new(AtomicUsize::new(0));
+  q.queue_broadcast(bcast("bob", "world", f2));
+  assert_eq!(q.num_queued(), 1);
+  assert_eq!(q.take_broadcasts(10, 0, 1024), vec!["world".to_string()]);
+}

--- a/memberlist-proto/src/endpoint/mod.rs
+++ b/memberlist-proto/src/endpoint/mod.rs
@@ -4703,6 +4703,14 @@ where
       );
       self.suspicion_deadlines.set(&id, None);
       self.members.remove(&id);
+      // Queue ownership ends when the member is reclaimed. A reclaimed id's
+      // membership broadcast is keyed by that id, and once the record is gone
+      // nothing invalidates it by re-broadcasting under the same id; when
+      // gossip cannot drain (disabled, or no usable gossip target) the
+      // retransmit ceiling never fires either, so the orphaned entry would
+      // outlive the member and grow the queue past the `max_members` bound
+      // that is meant to cap every per-member structure. Purge it here.
+      self.broadcast.remove_by_id(&id);
     }
     // Decorrelate probe order across rounds: without a reshuffle the round-robin
     // cursor walks the members in a fixed insertion-derived order every pass, so

--- a/memberlist-proto/src/endpoint/mod.rs
+++ b/memberlist-proto/src/endpoint/mod.rs
@@ -4372,8 +4372,31 @@ where
     }
   }
 
+  /// Whether a periodic failure-detection (`Detection`) probe is currently
+  /// outstanding. Derived from `self.probes` — the single source of truth —
+  /// rather than a separate flag that could desync from the map. O(probes) and
+  /// off the hot path: evaluated once per probe interval, and under the
+  /// single-flight scheduler `self.probes` holds at most one Detection probe
+  /// plus a few application pings.
+  fn detection_probe_in_flight(&self) -> bool {
+    self.probes.values().any(|p| p.kind == ProbeKind::Detection)
+  }
+
   /// Fire the probe scheduler if its deadline has elapsed.
-  /// Calls `start_probe(now)` and reschedules `next_probe = now + probe_interval`.
+  ///
+  /// A Detection probe's failure deadline is `sent + awareness.scale_timeout(
+  /// probe_interval)` = `(score + 1) * probe_interval`, so a degraded local node
+  /// (health score > 0) keeps a probe outstanding for several base intervals.
+  /// Without a single-flight guard the scheduler would start a fresh Detection
+  /// round every base interval, stacking up to `score + 1` concurrent rounds
+  /// precisely when the node is degraded — the opposite of Lifeguard's intent to
+  /// shed load and avoid false suspicions. Instead the deadline is re-armed every
+  /// base interval (missed-tick: re-check each period whether or not a probe
+  /// starts) and the next Detection round waits for the current one's
+  /// terminalization — an ack, or its failure deadline. This mirrors the
+  /// reference implementation's synchronous probe driven by a fixed-interval,
+  /// missed-tick ticker. Application pings (`ProbeKind::Ping`) are independent
+  /// and never gated by this guard.
   fn fire_probe_scheduler(&mut self, now: Instant) {
     let Some(deadline) = self.next_probe else {
       return;
@@ -4381,6 +4404,19 @@ where
     if now < deadline {
       return;
     }
+    // Missed-tick re-arm: advance the deadline every base interval regardless of
+    // whether a probe starts this tick, so the driver re-checks each period. This
+    // is a single re-arm to `now + probe_interval`, not interval catch-up.
+    self.next_probe = Some(now + self.cfg.probe_interval());
+
+    // Single-flight: while a Detection probe is outstanding, skip this tick
+    // without starting a new round and without touching the round-robin / reset
+    // accounting — a skipped tick did no probe work, so the probe count must not
+    // advance (the reference advances it only inside the probe itself).
+    if self.detection_probe_in_flight() {
+      return;
+    }
+
     // Once per full round-robin pass, prune long-dead members. Without
     // this, with the default `dead_node_reclaim_time == 0`, Dead/Left
     // entries are never collected and a returning id at a new address
@@ -4392,7 +4428,6 @@ where
       self.probes_since_reset = 0;
     }
     self.start_probe(now);
-    self.next_probe = Some(now + self.cfg.probe_interval());
   }
 
   /// Fire the gossip scheduler if its deadline has elapsed.

--- a/memberlist-proto/src/endpoint/mod.rs
+++ b/memberlist-proto/src/endpoint/mod.rs
@@ -4045,15 +4045,24 @@ where
 
     if old_state.is_dead() || old_state.is_left() {
       self.emit_event(Event::NodeJoined(new_server));
-    } else if old_meta != new_meta {
+    } else if old_meta != new_meta
+      || local_protocol != alive_protocol
+      || local_delegate != alive_delegate
+    {
+      // A strictly-newer incarnation that changes any event-relevant facet of
+      // the server — metadata, the protocol version, or the delegate version —
+      // is an update. Comparing the whole tuple (not just the metadata) ensures
+      // an event-only consumer never keeps stale protocol/delegate capability
+      // info after a version-only Alive.
       self.emit_event(Event::NodeUpdated(new_server));
     } else {
       // The update applied a strictly-newer incarnation (the older/equal guards
       // returned above), changing the member's incarnation and possibly its
       // state (e.g. a Suspect -> Alive refutation), but NEITHER a resurrection
-      // NOR a meta change fired an event. The published snapshot reflects that
-      // new state/incarnation, so bump explicitly — otherwise a driver would
-      // serve a stale `Suspect` for a node that is now `Alive`.
+      // NOR a change to the metadata / protocol / delegate versions fired an
+      // event. The published snapshot reflects that new state/incarnation, so
+      // bump explicitly — otherwise a driver would serve a stale `Suspect` for a
+      // node that is now `Alive`.
       self.bump_snapshot_version();
     }
   }

--- a/memberlist-proto/src/endpoint/tests.rs
+++ b/memberlist-proto/src/endpoint/tests.rs
@@ -6265,6 +6265,204 @@ fn probe_scheduler_fires_when_deadline_elapses() {
   );
 }
 
+/// Count of outstanding failure-detection (Detection) probes.
+fn detection_probe_count(e: &Endpoint<SmolStr, SocketAddr>) -> usize {
+  e.probes
+    .values()
+    .filter(|p| p.kind == ProbeKind::Detection)
+    .count()
+}
+
+/// Count of outstanding application (Ping) probes.
+fn app_ping_probe_count(e: &Endpoint<SmolStr, SocketAddr>) -> usize {
+  e.probes
+    .values()
+    .filter(|p| p.kind == ProbeKind::Ping)
+    .count()
+}
+
+/// A degraded local node (health score > 0) must not stack concurrent
+/// Detection rounds. The Detection failure deadline is `sent + scale_timeout(
+/// probe_interval)` = `(score + 1) * probe_interval`, so a probe started at t0
+/// lives past several base intervals. The scheduler re-arms every base interval
+/// (missed-tick) but must NOT start a second Detection round while the first is
+/// still outstanding; it starts a fresh one only after the current one
+/// terminalizes. Application pings stay independent.
+#[test]
+fn degraded_node_single_flights_detection_probes() {
+  let p = Duration::from_millis(100);
+  // probe_timeout > probe_interval so the direct sub-window does not expire (and
+  // escalate/terminate the probe) before t0 + probe_interval — the probe stays
+  // genuinely outstanding across the skipped tick.
+  let cfg = EndpointOptions::<SmolStr, SocketAddr>::new(
+    SmolStr::new("local"),
+    "127.0.0.1:7946".parse().unwrap(),
+  )
+  .with_probe_interval(p)
+  .with_probe_timeout(Duration::from_millis(200))
+  .with_gossip_interval(Duration::ZERO)
+  .with_push_pull_interval(Duration::ZERO);
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg);
+
+  let t_setup = Instant::now();
+  process_alive_auto(&mut e, alive("peer", 7947, 1), false, t_setup);
+  while e.poll_event().is_some() {}
+  while e.poll_transmit().is_some() {}
+
+  // Degrade local health by 2 → failure deadline = (2 + 1) * probe_interval.
+  e.degrade_health(2);
+  assert_eq!(e.health_score(), 2);
+
+  let t0 = Instant::now();
+  e.next_probe = Some(t0);
+
+  // First tick: a Detection probe starts, failure deadline = t0 + 3 * 100ms.
+  e.fire_probe_scheduler(t0);
+  assert_eq!(
+    detection_probe_count(&e),
+    1,
+    "first tick must start exactly one Detection probe"
+  );
+  let first_seq = *e
+    .probes
+    .iter()
+    .find(|(_, p)| p.kind == ProbeKind::Detection)
+    .map(|(seq, _)| seq)
+    .expect("Detection probe present");
+  assert_eq!(
+    e.next_probe,
+    Some(t0 + p),
+    "next_probe re-armed one base interval ahead"
+  );
+  assert_eq!(
+    e.probes_since_reset, 1,
+    "starting tick advances the counter"
+  );
+
+  // Second tick at t0 + probe_interval — BEFORE the first probe's failure
+  // deadline (t0 + 3 * 100ms). Single-flight: no second Detection round.
+  e.fire_probe_scheduler(t0 + p);
+  assert_eq!(
+    detection_probe_count(&e),
+    1,
+    "single-flight: no second Detection probe while the first is outstanding"
+  );
+  assert_eq!(
+    e.next_probe,
+    Some(t0 + 2 * p),
+    "missed-tick: deadline re-armed even though no probe started"
+  );
+  assert_eq!(
+    e.probes_since_reset, 1,
+    "a skipped tick must not advance the round-robin counter"
+  );
+
+  // An application ping issued WHILE the Detection probe is outstanding is NOT
+  // gated by the single-flight guard — it starts independently.
+  let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7947);
+  e.ping(Node::new(SmolStr::new("peer"), peer_addr), t0 + p)
+    .expect("application ping issued while running");
+  assert_eq!(
+    detection_probe_count(&e),
+    1,
+    "application ping must not start a second Detection probe"
+  );
+  assert_eq!(
+    app_ping_probe_count(&e),
+    1,
+    "application ping starts even while a Detection probe is outstanding"
+  );
+  while e.poll_transmit().is_some() {}
+
+  // Terminate the outstanding Detection probe at its failure deadline.
+  e.advance_probe_fsm(t0 + 3 * p);
+  assert_eq!(
+    detection_probe_count(&e),
+    0,
+    "Detection probe terminates at its failure deadline"
+  );
+
+  // Next scheduler tick after terminalization starts a NEW Detection round.
+  e.fire_probe_scheduler(t0 + 3 * p);
+  assert_eq!(
+    detection_probe_count(&e),
+    1,
+    "a new Detection round starts once the previous one terminalized"
+  );
+  let second_seq = *e
+    .probes
+    .iter()
+    .find(|(_, p)| p.kind == ProbeKind::Detection)
+    .map(|(seq, _)| seq)
+    .expect("new Detection probe present");
+  assert_ne!(
+    first_seq, second_seq,
+    "the new Detection round is a distinct probe"
+  );
+}
+
+/// Single-flight must not slow HEALTHY probing. At score 0 the failure deadline
+/// is exactly one base interval and an acked probe terminates before the next
+/// tick, so a fresh Detection probe still starts every interval.
+#[test]
+fn healthy_probe_rate_unchanged_by_single_flight() {
+  let p = Duration::from_millis(100);
+  let cfg = EndpointOptions::<SmolStr, SocketAddr>::new(
+    SmolStr::new("local"),
+    "127.0.0.1:7946".parse().unwrap(),
+  )
+  .with_probe_interval(p)
+  .with_probe_timeout(Duration::from_millis(50))
+  .with_gossip_interval(Duration::ZERO)
+  .with_push_pull_interval(Duration::ZERO);
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg);
+
+  let t_setup = Instant::now();
+  process_alive_auto(&mut e, alive("peer", 7947, 1), false, t_setup);
+  while e.poll_event().is_some() {}
+  while e.poll_transmit().is_some() {}
+  assert_eq!(e.health_score(), 0);
+
+  let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7947);
+  let t0 = Instant::now();
+  e.next_probe = Some(t0);
+
+  // First tick starts a Detection probe.
+  e.fire_probe_scheduler(t0);
+  let first_seq = match e.poll_transmit().expect("first probe Ping") {
+    Transmit::Packet(pkt) => {
+      let (_, message) = pkt.into_parts();
+      if let Message::Ping(ping) = message {
+        ping.sequence_number()
+      } else {
+        panic!("Ping expected");
+      }
+    }
+    _ => panic!("Ping expected"),
+  };
+  assert_eq!(detection_probe_count(&e), 1);
+
+  // Ack the probe before the next tick — it terminates as success.
+  e.handle_ack(
+    peer_addr,
+    Ack::new(first_seq),
+    t0 + Duration::from_millis(10),
+  );
+  assert_eq!(
+    detection_probe_count(&e),
+    0,
+    "acked probe terminates before the next tick"
+  );
+
+  // Next tick starts a fresh Detection probe — healthy rate is unchanged.
+  e.fire_probe_scheduler(t0 + p);
+  assert_eq!(
+    detection_probe_count(&e),
+    1,
+    "single-flight does not slow healthy probing"
+  );
+}
+
 #[test]
 fn probe_scheduler_does_not_fire_after_leave() {
   let cfg = EndpointOptions::<SmolStr, SocketAddr>::new(

--- a/memberlist-proto/src/endpoint/tests.rs
+++ b/memberlist-proto/src/endpoint/tests.rs
@@ -8274,6 +8274,66 @@ fn reset_nodes_keeps_live_members_and_reaps_only_expired_dead() {
 }
 
 #[test]
+fn reset_nodes_purges_reclaimed_members_broadcasts() {
+  // max_members = Some(2) bounds membership to the local node plus one peer at
+  // a time. The gossip queue is NEVER drained here (no scheduler, no
+  // take_broadcasts), so the only thing that can drop a reclaimed member's
+  // id-keyed broadcast is the reset_nodes purge. Repeatedly admit, kill, and
+  // reclaim DISTINCT ids: without the purge each round's Dead broadcast would
+  // linger under its own id and the queue would grow with the round count even
+  // though membership stays bounded.
+  let window = Duration::from_millis(10);
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(
+    cfg()
+      .with_max_members(Some(2))
+      .with_gossip_to_the_dead_time(window),
+  );
+  let baseline = e.broadcast_queue_len();
+  let mut now = Instant::now();
+  for i in 0..6u16 {
+    let id = format!("peer-{i}");
+    process_alive_auto(&mut e, alive(&id, 7001 + i, 1), false, now);
+    // `from != target` ⇒ Dead (reclaimable past `gossip_to_the_dead_time`).
+    e.process_dead(dead(&id, "reporter", 2), now);
+    now += window * 2;
+    e.reset_nodes(now);
+    assert!(e.num_members() <= 2, "membership stays within max_members");
+  }
+  assert_eq!(e.num_members(), 1, "only the local node remains");
+  assert_eq!(
+    e.broadcast_queue_len(),
+    baseline,
+    "reclaimed members' broadcasts must not accumulate in the queue"
+  );
+}
+
+#[test]
+fn reset_nodes_removes_the_reclaimed_ids_broadcast_entry() {
+  // A single reclaim: the reclaimed id's queued Dead broadcast must leave the
+  // queue when reset_nodes prunes the member — the queue length drops by
+  // exactly that one entry.
+  let window = Duration::from_millis(10);
+  let mut e: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(cfg().with_gossip_to_the_dead_time(window));
+  let now = Instant::now();
+  process_alive_auto(&mut e, alive("doomed", 7001, 1), false, now);
+  // The Dead broadcast invalidates the Alive broadcast (same id) and is queued.
+  e.process_dead(dead("doomed", "reporter", 2), now);
+  let before = e.broadcast_queue_len();
+  assert!(before >= 1, "doomed's Dead broadcast is queued");
+  e.reset_nodes(now + window * 2);
+  assert!(
+    e.member(&SmolStr::new("doomed")).is_none(),
+    "doomed reclaimed"
+  );
+  assert_eq!(
+    e.broadcast_queue_len(),
+    before - 1,
+    "exactly the reclaimed id's broadcast leaves the queue"
+  );
+}
+
+#[test]
 fn send_user_packets_empty_slice_is_ok_noop() {
   let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
   let to = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7001);

--- a/memberlist-proto/src/endpoint/tests.rs
+++ b/memberlist-proto/src/endpoint/tests.rs
@@ -8013,6 +8013,84 @@ fn alive_with_changed_meta_emits_node_updated() {
   assert!(updated, "a meta change must emit NodeUpdated");
 }
 
+#[test]
+fn alive_with_changed_protocol_version_emits_node_updated() {
+  // A higher-incarnation Alive for a still-Alive peer that changes ONLY the
+  // protocol version — same address, same meta, same delegate version — must
+  // still emit NodeUpdated so an event-only mirror does not keep stale
+  // capability info.
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  let now = Instant::now();
+  process_alive_auto(&mut e, alive("bob", 7001, 1), false, now);
+  while e.poll_event().is_some() {}
+  let updated_alive = alive("bob", 7001, 2).with_protocol_version(ProtocolVersion::Unknown(2));
+  process_alive_auto(&mut e, updated_alive, false, now);
+  let events: Vec<_> = core::iter::from_fn(|| e.poll_event()).collect();
+  let updated = events
+    .iter()
+    .filter(|ev| matches!(ev, Event::NodeUpdated(n) if n.id_ref() == &SmolStr::new("bob")))
+    .count();
+  assert_eq!(
+    updated, 1,
+    "a protocol-version-only change must emit exactly one NodeUpdated"
+  );
+  assert_eq!(
+    e.member(&SmolStr::new("bob"))
+      .expect("bob present")
+      .protocol_version(),
+    ProtocolVersion::Unknown(2),
+    "the stored member must reflect the new protocol version"
+  );
+}
+
+#[test]
+fn alive_with_changed_delegate_version_emits_node_updated() {
+  // A higher-incarnation Alive that changes ONLY the delegate version — same
+  // address, same meta, same protocol version — must still emit NodeUpdated.
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  let now = Instant::now();
+  process_alive_auto(&mut e, alive("bob", 7001, 1), false, now);
+  while e.poll_event().is_some() {}
+  let updated_alive = alive("bob", 7001, 2).with_delegate_version(DelegateVersion::Unknown(2));
+  process_alive_auto(&mut e, updated_alive, false, now);
+  let events: Vec<_> = core::iter::from_fn(|| e.poll_event()).collect();
+  let updated = events
+    .iter()
+    .filter(|ev| matches!(ev, Event::NodeUpdated(n) if n.id_ref() == &SmolStr::new("bob")))
+    .count();
+  assert_eq!(
+    updated, 1,
+    "a delegate-version-only change must emit exactly one NodeUpdated"
+  );
+  assert_eq!(
+    e.member(&SmolStr::new("bob"))
+      .expect("bob present")
+      .delegate_version(),
+    DelegateVersion::Unknown(2),
+    "the stored member must reflect the new delegate version"
+  );
+}
+
+#[test]
+fn alive_with_unchanged_meta_and_versions_emits_no_node_updated() {
+  // Negative control: a higher-incarnation Alive that leaves meta, protocol
+  // version, and delegate version all unchanged must NOT emit NodeUpdated — the
+  // no-change branch only bumps the snapshot version.
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  let now = Instant::now();
+  process_alive_auto(&mut e, alive("bob", 7001, 1), false, now);
+  while e.poll_event().is_some() {}
+  // Same meta (empty), same V1 protocol + delegate versions, only the
+  // incarnation moves forward.
+  process_alive_auto(&mut e, alive("bob", 7001, 2), false, now);
+  let updated = core::iter::from_fn(|| e.poll_event())
+    .any(|ev| matches!(ev, Event::NodeUpdated(n) if n.id_ref() == &SmolStr::new("bob")));
+  assert!(
+    !updated,
+    "an Alive with unchanged meta and versions must not emit NodeUpdated"
+  );
+}
+
 // ─── refute while leaving + skip-past ─────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Closes #165.

Three core-`Endpoint` correctness fixes in `memberlist-proto` (the Sans-I/O SWIM membership FSM). The adversarial review that opened #165 was run against a stale commit and predates #175 ("probe/ping addressing, generation, and suspicion precision"), which already resolved three of its six findings — suspicion sub-millisecond precision, probe-target address binding, and the over-MTU probe abort. Each was re-verified against current `main` and confirmed fixed; the remaining three are addressed here.

## Fixes

- **NodeUpdated on protocol/delegate version change** (`endpoint/mod.rs`) — a strictly-newer-incarnation `Alive` that changed only the protocol or delegate version updated the stored member and its snapshot but emitted no event, so an event-only consumer kept stale capability info. The remote-`Alive` path now compares the full event-relevant tuple (metadata, protocol version, delegate version) against a snapshot taken before the overwrite. The incarnation/state-only path (e.g. a `Suspect`→`Alive` refutation) still bumps the snapshot version without emitting a spurious event.

- **Purge a reclaimed member's broadcast in `reset_nodes`** (`endpoint/mod.rs`, `broadcast/mod.rs`) — reclaimed `Dead`/`Left` members were removed from the member map but their id-keyed membership broadcast stayed queued. With gossip unable to drain (disabled, or no usable target) the retransmit ceiling never fires, so the orphan outlived the member and grew the queue past the `max_members` bound. New `BroadcastQueue::remove_by_id` purges the index and store, fires `finished()` once, and resets the id generator when the queue empties; `reset_nodes` calls it per reclaimed id.

- **Single-flight periodic detection probes under awareness scaling** (`endpoint/mod.rs`) — a `Detection` probe's failure deadline is `(score + 1) * probe_interval`, but the scheduler started a fresh round every base interval, so a degraded node could stack up to `score + 1` concurrent rounds — the opposite of Lifeguard's load-shedding intent. The scheduler now re-arms the deadline every base interval (missed-tick, not catch-up) and skips starting a new `Detection` round while one is outstanding. Application `ping()` (`ProbeKind::Ping`) stays independent and ungated. This matches HashiCorp memberlist v0.5.2, where `probeNode` is synchronous under a fixed-interval missed-tick ticker and is therefore effectively single-flight.
