### PR TITLE
fix(proto): direction-scoped QUIC connection selection and logical-immutable identity (#163)

### DIFF
--- a/memberlist-proto/src/event/mod.rs
+++ b/memberlist-proto/src/event/mod.rs
@@ -391,6 +391,12 @@ impl<I, A> NodeConflict<I, A> {
 /// Payload for [`Event::UserPacket`]: an application-level user-data packet.
 #[derive(Debug)]
 pub struct UserPacket<A> {
+  /// The logical peer identity the packet arrived from — the membership
+  /// address, a best-effort transport-origin hint. It is explicitly NOT the raw
+  /// post-migration transport 4-tuple: a QUIC connection may migrate its egress
+  /// path, but the identity here stays the membership address the connection was
+  /// keyed on. Identity-critical routing uses the advertised SWIM-payload
+  /// address rather than this hint.
   from: A,
   data: Bytes,
   reliability: Reliability,

--- a/memberlist-proto/src/quic/config/mod.rs
+++ b/memberlist-proto/src/quic/config/mod.rs
@@ -237,6 +237,13 @@ impl QuicConfigOptions {
     // immutable for the connection's life, independent of any post-migration
     // transport 4-tuple — so migration is transparent to the connection table.
     if let Some(t) = self.max_idle_timeout {
+      // A zero idle-timeout transport parameter DISABLES the idle timeout (RFC
+      // 9000 §18.2), removing the bound on stale-connection self-healing — the
+      // opposite of the field's intent. Reject it; an unset timeout takes quinn's
+      // finite default.
+      if t.is_zero() {
+        return Err(QuicConfigError::IdleTimeoutZero);
+      }
       let idle = IdleTimeout::try_from(t).map_err(|_| QuicConfigError::IdleTimeoutTooLarge(t))?;
       transport.max_idle_timeout(Some(idle));
     }
@@ -409,6 +416,16 @@ pub enum QuicConfigError {
   /// The configured `max_idle_timeout` exceeds the QUIC varint encoding range.
   #[error("max_idle_timeout {0:?} is too large for the QUIC idle-timeout encoding")]
   IdleTimeoutTooLarge(Duration),
+  /// The configured `max_idle_timeout` is exactly zero. Per RFC 9000 §18.2 a
+  /// zero idle-timeout transport parameter means the idle timeout is DISABLED —
+  /// the opposite of what the field name suggests — which would remove the bound
+  /// on stale-connection self-healing. Leave it unset for quinn's finite default
+  /// instead.
+  #[error(
+    "max_idle_timeout of zero disables the QUIC idle timeout (RFC 9000 §18.2); \
+     leave it unset for the default finite timeout"
+  )]
+  IdleTimeoutZero,
 }
 
 #[cfg(test)]

--- a/memberlist-proto/src/quic/config/mod.rs
+++ b/memberlist-proto/src/quic/config/mod.rs
@@ -239,9 +239,12 @@ impl QuicConfigOptions {
     if let Some(t) = self.max_idle_timeout {
       // A zero idle-timeout transport parameter DISABLES the idle timeout (RFC
       // 9000 §18.2), removing the bound on stale-connection self-healing — the
-      // opposite of the field's intent. Reject it; an unset timeout takes quinn's
-      // finite default.
-      if t.is_zero() {
+      // opposite of the field's intent. quinn's `IdleTimeout::try_from` encodes
+      // `as_millis()`, so any sub-millisecond duration (1ns .. 999_999ns) also
+      // encodes to a disabling zero; reject on the encoded millisecond value, not
+      // just an exactly-zero `Duration`. An unset timeout takes quinn's finite
+      // default.
+      if t.as_millis() == 0 {
         return Err(QuicConfigError::IdleTimeoutZero);
       }
       let idle = IdleTimeout::try_from(t).map_err(|_| QuicConfigError::IdleTimeoutTooLarge(t))?;
@@ -416,14 +419,15 @@ pub enum QuicConfigError {
   /// The configured `max_idle_timeout` exceeds the QUIC varint encoding range.
   #[error("max_idle_timeout {0:?} is too large for the QUIC idle-timeout encoding")]
   IdleTimeoutTooLarge(Duration),
-  /// The configured `max_idle_timeout` is exactly zero. Per RFC 9000 §18.2 a
-  /// zero idle-timeout transport parameter means the idle timeout is DISABLED —
-  /// the opposite of what the field name suggests — which would remove the bound
-  /// on stale-connection self-healing. Leave it unset for quinn's finite default
-  /// instead.
+  /// The configured `max_idle_timeout` encodes to a disabling zero — it is zero,
+  /// or a sub-millisecond duration that quinn's millisecond encoding rounds to
+  /// zero. Per RFC 9000 §18.2 a zero idle-timeout transport parameter means the
+  /// idle timeout is DISABLED — the opposite of what the field name suggests —
+  /// which would remove the bound on stale-connection self-healing. Leave it
+  /// unset for quinn's finite default, or configure at least one millisecond.
   #[error(
-    "max_idle_timeout of zero disables the QUIC idle timeout (RFC 9000 §18.2); \
-     leave it unset for the default finite timeout"
+    "max_idle_timeout encodes to a disabling zero (RFC 9000 §18.2); leave it \
+     unset for the default finite timeout, or configure at least 1ms"
   )]
   IdleTimeoutZero,
 }

--- a/memberlist-proto/src/quic/config/mod.rs
+++ b/memberlist-proto/src/quic/config/mod.rs
@@ -232,6 +232,10 @@ impl QuicConfigOptions {
     let endpoint = EndpointConfig::default();
 
     let mut transport = TransportConfig::default();
+    // Connection migration stays enabled (quinn's default). The membership
+    // identity a connection is keyed on is its logical/advertised address and is
+    // immutable for the connection's life, independent of any post-migration
+    // transport 4-tuple — so migration is transparent to the connection table.
     if let Some(t) = self.max_idle_timeout {
       let idle = IdleTimeout::try_from(t).map_err(|_| QuicConfigError::IdleTimeoutTooLarge(t))?;
       transport.max_idle_timeout(Some(idle));

--- a/memberlist-proto/src/quic/config/tests.rs
+++ b/memberlist-proto/src/quic/config/tests.rs
@@ -94,6 +94,32 @@ fn build_installs_configured_server_name() {
   assert_eq!(&*cfg.sni_for(&peer), "localhost");
 }
 
+#[test]
+fn build_rejects_zero_max_idle_timeout() {
+  install_provider();
+  let dir = unique_dir();
+  let (cert, key, ca) = write_self_signed(&dir);
+
+  // A zero idle-timeout transport parameter DISABLES the QUIC idle timeout
+  // (RFC 9000 §18.2), removing the stale-connection self-healing bound — rejected.
+  // (`QuicOptions` is not `Debug`, so match the `Result` rather than `expect_err`.)
+  let result = QuicConfigOptions::new(cert, key, ca)
+    .with_max_idle_timeout(Some(Duration::ZERO))
+    .build();
+  assert!(
+    matches!(result, Err(QuicConfigError::IdleTimeoutZero)),
+    "a zero max_idle_timeout must be rejected with IdleTimeoutZero"
+  );
+
+  // A finite idle-timeout still builds.
+  let dir = unique_dir();
+  let (cert, key, ca) = write_self_signed(&dir);
+  QuicConfigOptions::new(cert, key, ca)
+    .with_max_idle_timeout(Some(Duration::from_secs(20)))
+    .build()
+    .expect("a finite max_idle_timeout builds");
+}
+
 #[cfg(feature = "serde")]
 #[test]
 fn quic_config_options_serde_round_trip() {

--- a/memberlist-proto/src/quic/config/tests.rs
+++ b/memberlist-proto/src/quic/config/tests.rs
@@ -95,29 +95,40 @@ fn build_installs_configured_server_name() {
 }
 
 #[test]
-fn build_rejects_zero_max_idle_timeout() {
+fn build_rejects_max_idle_timeout_that_encodes_to_zero() {
   install_provider();
-  let dir = unique_dir();
-  let (cert, key, ca) = write_self_signed(&dir);
 
-  // A zero idle-timeout transport parameter DISABLES the QUIC idle timeout
-  // (RFC 9000 §18.2), removing the stale-connection self-healing bound — rejected.
-  // (`QuicOptions` is not `Debug`, so match the `Result` rather than `expect_err`.)
-  let result = QuicConfigOptions::new(cert, key, ca)
-    .with_max_idle_timeout(Some(Duration::ZERO))
-    .build();
-  assert!(
-    matches!(result, Err(QuicConfigError::IdleTimeoutZero)),
-    "a zero max_idle_timeout must be rejected with IdleTimeoutZero"
-  );
+  // A zero idle-timeout transport parameter DISABLES the QUIC idle timeout (RFC
+  // 9000 §18.2), removing the stale-connection self-healing bound. quinn encodes
+  // the timeout in milliseconds, so any sub-millisecond duration also rounds to a
+  // disabling zero — all must be rejected. (`QuicOptions` is not `Debug`, so match
+  // the `Result` rather than `expect_err`.)
+  for t in [
+    Duration::ZERO,
+    Duration::from_nanos(1),
+    Duration::from_micros(500),
+    Duration::from_nanos(999_999),
+  ] {
+    let dir = unique_dir();
+    let (cert, key, ca) = write_self_signed(&dir);
+    let result = QuicConfigOptions::new(cert, key, ca)
+      .with_max_idle_timeout(Some(t))
+      .build();
+    assert!(
+      matches!(result, Err(QuicConfigError::IdleTimeoutZero)),
+      "max_idle_timeout {t:?} encodes to a disabling zero and must be rejected"
+    );
+  }
 
-  // A finite idle-timeout still builds.
-  let dir = unique_dir();
-  let (cert, key, ca) = write_self_signed(&dir);
-  QuicConfigOptions::new(cert, key, ca)
-    .with_max_idle_timeout(Some(Duration::from_secs(20)))
-    .build()
-    .expect("a finite max_idle_timeout builds");
+  // A finite >= 1ms idle-timeout still builds.
+  for t in [Duration::from_millis(1), Duration::from_secs(20)] {
+    let dir = unique_dir();
+    let (cert, key, ca) = write_self_signed(&dir);
+    QuicConfigOptions::new(cert, key, ca)
+      .with_max_idle_timeout(Some(t))
+      .build()
+      .expect("a finite (>= 1ms) max_idle_timeout builds");
+  }
 }
 
 #[cfg(feature = "serde")]

--- a/memberlist-proto/src/quic/conn/mod.rs
+++ b/memberlist-proto/src/quic/conn/mod.rs
@@ -325,15 +325,6 @@ impl ConnTable {
     }
   }
 
-  /// `true` iff the table currently holds at least one closed connection whose
-  /// drained-reap will free a global-cap slot. A `dial_fresh` refused at the
-  /// global cap is recoverable only while such a connection exists (the slot is
-  /// about to free); a permanently-full table (every connection live) has no
-  /// slot coming, so the intent is retired rather than reparked.
-  pub(crate) fn has_reapable_connection(&self) -> bool {
-    self.conns.iter().any(|(_, e)| e.conn.is_closed())
-  }
-
   pub(crate) fn get_mut(&mut self, ch: ConnectionHandle) -> Option<&mut ConnEntry> {
     self.conns.get_mut(ch.0)
   }

--- a/memberlist-proto/src/quic/conn/mod.rs
+++ b/memberlist-proto/src/quic/conn/mod.rs
@@ -727,21 +727,30 @@ impl ConnTable {
   ///
   /// The accepted connection is always inserted into the slab (so quinn can
   /// drive it and its inbound bidi streams are serviced). It is written into
-  /// `route.inbound` when the current inbound is `None`, classifies closed, or
-  /// is older by generation — so an accept tracks the freshest inbound (this
-  /// connection is newest-created, so a newer accept always wins over a live
-  /// older one). NEVER written into `route.outbound`: an accept can therefore
-  /// never displace a self-initiated outbound, else the peer-initiated
-  /// connection would become the slot our outbound exchanges select while the
-  /// peer binds its accept side to the other connection, wedging the exchange
-  /// (the peer wrongly never confirmed → false Suspect). Keeping the two
-  /// directions in separate fields makes that wedge-avoidance structural.
+  /// `route.inbound` only when the current inbound slot is empty or holds a
+  /// closed/gone connection — an accept never displaces a live (handshaking or
+  /// established) tracked inbound.
+  ///
+  /// The rule: an accept proves only that an Initial datagram arrived, which a
+  /// delayed pre-crash Initial can also produce; it does NOT prove the remote
+  /// instance is currently alive. A completed handshake does prove liveness.
+  /// Route displacement between competing inbounds is therefore gated on the
+  /// establishment chokepoint ([`Self::on_established_transition`]), where the
+  /// freshest proven-live inbound wins by generation — not at accept time, where
+  /// a delayed pre-crash Initial (structurally incapable of completing its
+  /// handshake) would otherwise displace a proven-live route. Accept-time writes
+  /// fill only an empty or closed slot.
+  ///
+  /// NEVER written into `route.outbound`: an accept can therefore never displace
+  /// a self-initiated outbound, else the peer-initiated connection would become
+  /// the slot our outbound exchanges select while the peer binds its accept side
+  /// to the other connection, wedging the exchange (the peer wrongly never
+  /// confirmed → false Suspect). Keeping the two directions in separate fields
+  /// makes that wedge-avoidance structural.
   ///
   /// The displaced (previous) inbound, if any, stays in the slab until its
   /// drained-reap; its handle is no longer in `route.inbound`, so the
-  /// equality-guarded [`Self::reap_if_drained`] cannot clobber this one. A
-  /// newest-established-inbound promotion for the same peer runs later at the
-  /// establishment chokepoint ([`Self::on_established_transition`]).
+  /// equality-guarded [`Self::reap_if_drained`] cannot clobber this one.
   pub(crate) fn insert_accepted(
     &mut self,
     ch: ConnectionHandle,
@@ -771,16 +780,12 @@ impl ConnTable {
       "accepted connection slab slot must equal ConnectionHandle"
     );
     *self.pending_inbound.entry(peer).or_insert(0) += 1;
-    // Track the freshest inbound: set `route.inbound` when the current inbound
-    // is None/closed, or when this newly-created (hence newest-generation)
-    // connection is fresher than the one currently tracked. Never touch
-    // `route.outbound`.
+    // Fill only an empty or closed inbound slot; never displace a live inbound
+    // at accept (that decision belongs to the establishment chokepoint). Never
+    // touch `route.outbound`.
     let replace = match self.peer_routes.get(&peer).and_then(|r| r.inbound) {
       None => true,
-      Some(cur) => self
-        .conns
-        .get(cur.0)
-        .is_none_or(|e| e.conn.is_closed() || generation > e.generation),
+      Some(cur) => self.conns.get(cur.0).is_none_or(|e| e.conn.is_closed()),
     };
     if replace {
       self.peer_routes.entry(peer).or_default().inbound = Some(ch);

--- a/memberlist-proto/src/quic/conn/mod.rs
+++ b/memberlist-proto/src/quic/conn/mod.rs
@@ -90,6 +90,15 @@ pub(crate) struct ConnEntry {
   /// Independent of the coordinator's separate `inbound_bridge_count` (which
   /// counts accepted bridges); a bridge contributes to exactly one of the two.
   outbound_bridge_count: usize,
+  /// Monotonic creation stamp, drawn from [`ConnTable::next_gen`] the moment
+  /// this entry is created (in `dial_fresh` and `insert_accepted`) and never
+  /// mutated. Orders connections by recency of CREATION — a later-created
+  /// connection always has a strictly greater generation. This is the correct
+  /// freshness signal for choosing among same-class connections to one peer:
+  /// unlike establishment time (which a delayed handshake distorts), creation
+  /// order cannot be reordered by a slow handshake, so a fresh post-restart
+  /// connection always outranks a stale pre-restart one.
+  generation: u64,
 }
 
 impl ConnEntry {
@@ -285,6 +294,11 @@ pub(crate) struct ConnTable {
   /// an O(total connections) scan per rejected datagram. A source with zero
   /// pending inbound connections has no entry (the map never stores a zero).
   pending_inbound: HashMap<SocketAddr, usize>,
+  /// The next connection generation to hand out. Increments on every connection
+  /// creation ([`Self::next_gen`]), so each connection's stamp is strictly
+  /// greater than every connection created before it. A `u64` never wraps in
+  /// practice (one increment per connection created for the process's life).
+  next_generation: u64,
 }
 
 impl ConnTable {
@@ -293,7 +307,40 @@ impl ConnTable {
       conns: Slab::new(),
       peer_routes: HashMap::new(),
       pending_inbound: HashMap::new(),
+      next_generation: 0,
     }
+  }
+
+  /// Return the next connection generation and advance the counter. Each call
+  /// yields a strictly greater value than the previous, so a later-created
+  /// connection always outranks an earlier one by generation.
+  fn next_gen(&mut self) -> u64 {
+    let g = self.next_generation;
+    debug_assert!(
+      self.next_generation != u64::MAX,
+      "connection generation counter must not wrap"
+    );
+    self.next_generation = self.next_generation.wrapping_add(1);
+    g
+  }
+
+  /// The fresher (higher-generation) of two tracked handles — the tiebreak used
+  /// when both candidates in the same selection class are usable, so a fresh
+  /// post-restart connection outranks a same-class zombie. A slab-gone handle
+  /// has generation `0` and loses to any live one.
+  fn fresher(&self, a: ConnectionHandle, b: ConnectionHandle) -> ConnectionHandle {
+    let ga = self.conns.get(a.0).map_or(0, |e| e.generation);
+    let gb = self.conns.get(b.0).map_or(0, |e| e.generation);
+    if ga >= gb { a } else { b }
+  }
+
+  /// `true` iff the table currently holds at least one closed connection whose
+  /// drained-reap will free a global-cap slot. A `dial_fresh` refused at the
+  /// global cap is recoverable only while such a connection exists (the slot is
+  /// about to free); a permanently-full table (every connection live) has no
+  /// slot coming, so the intent is retired rather than reparked.
+  pub(crate) fn has_reapable_connection(&self) -> bool {
+    self.conns.iter().any(|(_, e)| e.conn.is_closed())
   }
 
   pub(crate) fn get_mut(&mut self, ch: ConnectionHandle) -> Option<&mut ConnEntry> {
@@ -333,7 +380,9 @@ impl ConnTable {
   /// The best usable handle for `peer` — the derived selection an observer
   /// (`live_connections_to`, `try_open_uni_stream_to`, datagram sizing) rides,
   /// with NO dial side effect. Prefers an established connection, then a
-  /// handshaking one; outbound before inbound within each. A closed/terminal
+  /// handshaking one; within the first satisfied class, when BOTH the outbound
+  /// and inbound match, returns the fresher (higher-generation) one so a fresh
+  /// post-restart connection outranks a same-class zombie. A closed/terminal
   /// handle is never usable, so this returns `None` for a peer whose only
   /// tracked connections are draining or handshake-failed. At most one handle
   /// (0 or 1 per peer).
@@ -341,10 +390,17 @@ impl ConnTable {
     let route = self.peer_routes.get(peer)?;
     let candidates = [route.outbound, route.inbound];
     for want in [HandleClass::Established, HandleClass::Handshaking] {
+      let mut best: Option<ConnectionHandle> = None;
       for ch in candidates.into_iter().flatten() {
         if self.classify(ch) == want {
-          return Some(ch);
+          best = Some(match best {
+            None => ch,
+            Some(b) => self.fresher(b, ch),
+          });
         }
+      }
+      if best.is_some() {
+        return best;
       }
     }
     None
@@ -458,6 +514,7 @@ impl ConnTable {
     let (ch, conn) = quinn
       .connect(now.into_std(), client, peer, server_name)
       .map_err(DialError::Connect)?;
+    let generation = self.next_gen();
     let slot = self.conns.insert(ConnEntry {
       conn,
       peer,
@@ -468,6 +525,7 @@ impl ConnTable {
       pending_indexed: false,
       pending_events: VecDeque::new(),
       outbound_bridge_count: 0,
+      generation,
     });
     debug_assert_eq!(slot, ch.0, "quinn ConnectionHandle is the slab vacant_key");
     self.peer_routes.entry(peer).or_default().outbound = Some(ch);
@@ -485,7 +543,8 @@ impl ConnTable {
   /// `route.outbound` (`O`) and `route.inbound` (`I`), then applies the table
   /// for `reliability`:
   ///
-  /// **Reliable** (first matching row): R1 `O` Established → `O`; R2 `I`
+  /// **Reliable** (first matching row): both Established → the fresher by
+  /// generation; R1 `O` Established → `O`; R2 `I`
   /// Established → `I`; R3 `O` Handshaking → `O`; R4 `O` TerminalOutbound + `I`
   /// Handshaking → `I`; R5 `O` TerminalOutbound + no `I` → `O` (downstream
   /// `dial_failed`, anti-storm); R6 no `O` + `I` Handshaking → dial fresh under
@@ -493,7 +552,8 @@ impl ConnTable {
   /// — return the live inbound and repark, never propagate); R7 no `O`, no `I`
   /// → dial fresh under cap, else propagate the dial error.
   ///
-  /// **Unreliable** (first matching row): U1 `O` Established → `O`; U2 `I`
+  /// **Unreliable** (first matching row): both Established → the fresher by
+  /// generation; U1 `O` Established → `O`; U2 `I`
   /// Established → `I`; U3 `O` Handshaking → `O`; U4 `I` Handshaking → `I` (no
   /// companion dial); U5 `O` TerminalOutbound + no `I` → `O`; U6 no `O`, no `I`
   /// → cold-dial under cap, else the dial error (the datagram caller maps every
@@ -526,6 +586,16 @@ impl ConnTable {
     let ic = inbound.map(|ch| self.classify(ch));
     match reliability {
       Reliability::Reliable => {
+        if oc == Some(Established) && ic == Some(Established) {
+          // Both established: return the fresher by generation so a fresh
+          // post-restart connection outranks a same-class zombie (e.g. an
+          // established inbound from a restarted peer beats a locally-still-
+          // Established outbound to its dead prior instance).
+          return Ok(self.fresher(
+            outbound.expect("Established outbound handle present"),
+            inbound.expect("Established inbound handle present"),
+          ));
+        }
         if oc == Some(Established) {
           return Ok(outbound.expect("Established outbound handle present")); // R1
         }
@@ -565,6 +635,14 @@ impl ConnTable {
         self.dial_fresh(quinn, now, client, peer, server_name, max_connections)
       }
       Reliability::Unreliable => {
+        if oc == Some(Established) && ic == Some(Established) {
+          // Both established: the fresher by generation (same tiebreak as the
+          // reliable plane) — a fresh post-restart connection outranks a zombie.
+          return Ok(self.fresher(
+            outbound.expect("Established outbound handle present"),
+            inbound.expect("Established inbound handle present"),
+          ));
+        }
         if oc == Some(Established) {
           return Ok(outbound.expect("Established outbound handle present")); // U1
         }
@@ -597,21 +675,44 @@ impl ConnTable {
 
   /// Establishment-chokepoint promotion. Called the pass a connection's sticky
   /// `established_at_least_once` flips `false → true`. A newly-established
-  /// INBOUND becomes `route.inbound` unconditionally (newest-established-inbound
-  /// wins): a completed fresh handshake means the peer deliberately redialed, so
-  /// its previous inbound is dead/draining on its side, and the displaced entry
-  /// stays slab-serviced until reaped. Touches only `.inbound` (never displaces
-  /// a self-initiated outbound). A newly-established OUTBOUND must already be its
-  /// peer's tracked `route.outbound` (an establishing outbound is `!closed`, so
-  /// the pre-pass never cleared it) — asserted, not written.
+  /// INBOUND becomes `route.inbound` only when the current inbound is `None` or
+  /// this connection is at least as fresh by generation
+  /// (`ch.generation >= current.generation`). Freshness is CREATION order, not
+  /// establishment order: a delayed pre-crash inbound whose handshake finishes
+  /// *after* a fresher post-restart inbound is already tracked has an older
+  /// generation, so it is REJECTED here and never overwrites the fresher one.
+  /// Touches only `.inbound` (never displaces a self-initiated outbound). A
+  /// newly-established OUTBOUND must already be its peer's tracked
+  /// `route.outbound` (an establishing outbound is `!closed`, so the pre-pass
+  /// never cleared it) — asserted, not written.
+  ///
+  /// Bounded self-healing residual (a per-peer generation high-watermark
+  /// surviving route removal would close it but adds unbounded per-peer state —
+  /// the bounded window is the deliberate tradeoff): if the freshest inbound
+  /// reaps and empties the route, and only THEN a much-older pre-crash inbound
+  /// finally establishes, that stale inbound is promoted into the now-empty
+  /// route and selected until it idle-kills (~`max_idle_timeout`), after which
+  /// the route empties and a fresh dial proceeds. This is a narrow multi-event
+  /// window that self-heals.
   pub(crate) fn on_established_transition(&mut self, ch: ConnectionHandle) {
-    let (peer, direction) = match self.conns.get(ch.0) {
-      Some(e) => (e.peer, e.direction),
+    let (peer, direction, generation) = match self.conns.get(ch.0) {
+      Some(e) => (e.peer, e.direction, e.generation),
       None => return,
     };
     match direction {
       ConnDirection::Inbound => {
-        self.peer_routes.entry(peer).or_default().inbound = Some(ch);
+        // Promote only when this connection is at least as fresh as the current
+        // tracked inbound; a stale delayed establishment is rejected.
+        let promote = match self.peer_routes.get(&peer).and_then(|r| r.inbound) {
+          None => true,
+          Some(cur) => self
+            .conns
+            .get(cur.0)
+            .is_none_or(|e| generation >= e.generation),
+        };
+        if promote {
+          self.peer_routes.entry(peer).or_default().inbound = Some(ch);
+        }
       }
       ConnDirection::Outbound => {
         debug_assert!(
@@ -626,13 +727,15 @@ impl ConnTable {
   ///
   /// The accepted connection is always inserted into the slab (so quinn can
   /// drive it and its inbound bidi streams are serviced). It is written into
-  /// `route.inbound` iff the current inbound is `None` or classifies closed —
-  /// NEVER into `route.outbound`. An accept can therefore never displace a
-  /// self-initiated outbound: were the peer-initiated connection to become the
-  /// slot our outbound exchanges select while the peer binds its accept side to
-  /// the other connection, the exchange would wedge (the peer wrongly never
-  /// confirmed → false Suspect). Keeping the two directions in separate fields
-  /// makes that wedge-avoidance structural.
+  /// `route.inbound` when the current inbound is `None`, classifies closed, or
+  /// is older by generation — so an accept tracks the freshest inbound (this
+  /// connection is newest-created, so a newer accept always wins over a live
+  /// older one). NEVER written into `route.outbound`: an accept can therefore
+  /// never displace a self-initiated outbound, else the peer-initiated
+  /// connection would become the slot our outbound exchanges select while the
+  /// peer binds its accept side to the other connection, wedging the exchange
+  /// (the peer wrongly never confirmed → false Suspect). Keeping the two
+  /// directions in separate fields makes that wedge-avoidance structural.
   ///
   /// The displaced (previous) inbound, if any, stays in the slab until its
   /// drained-reap; its handle is no longer in `route.inbound`, so the
@@ -645,6 +748,7 @@ impl ConnTable {
     conn: Connection,
     peer: SocketAddr,
   ) {
+    let generation = self.next_gen();
     let slot = self.conns.insert(ConnEntry {
       conn,
       peer,
@@ -660,21 +764,25 @@ impl ConnTable {
       // handle a later local dial rides (simultaneous bidirectional dial), so a
       // dialer bridge may be opened on it — start the outbound count at zero.
       outbound_bridge_count: 0,
+      generation,
     });
     assert_eq!(
       slot, ch.0,
       "accepted connection slab slot must equal ConnectionHandle"
     );
     *self.pending_inbound.entry(peer).or_insert(0) += 1;
-    // Set `route.inbound` iff the current inbound is None or closed; never
-    // touch `route.outbound`.
-    let inbound_usable = self
-      .peer_routes
-      .get(&peer)
-      .and_then(|r| r.inbound)
-      .and_then(|existing| self.conns.get(existing.0))
-      .is_some_and(|e| !e.conn.is_closed());
-    if !inbound_usable {
+    // Track the freshest inbound: set `route.inbound` when the current inbound
+    // is None/closed, or when this newly-created (hence newest-generation)
+    // connection is fresher than the one currently tracked. Never touch
+    // `route.outbound`.
+    let replace = match self.peer_routes.get(&peer).and_then(|r| r.inbound) {
+      None => true,
+      Some(cur) => self
+        .conns
+        .get(cur.0)
+        .is_none_or(|e| e.conn.is_closed() || generation > e.generation),
+    };
+    if replace {
       self.peer_routes.entry(peer).or_default().inbound = Some(ch);
     }
   }

--- a/memberlist-proto/src/quic/conn/mod.rs
+++ b/memberlist-proto/src/quic/conn/mod.rs
@@ -350,6 +350,27 @@ impl ConnTable {
     None
   }
 
+  /// Debug tripwire for the logical-immutable identity contract: a connection's
+  /// `peer` is the key its route is filed under, so no `peer_routes` key OTHER
+  /// than `ch`'s own peer may reference `ch`. A future change that let `peer`
+  /// follow QUIC path migration would file the route under a stale key while
+  /// `peer()` returns the migrated address, stranding peer-keyed parked dials;
+  /// this catches that divergence. Debug-only (the scan compiles out in release).
+  pub(crate) fn debug_assert_peer_is_route_key(&self, ch: ConnectionHandle) {
+    debug_assert!(
+      {
+        match self.conns.get(ch.0) {
+          None => true,
+          Some(e) => !self
+            .peer_routes
+            .iter()
+            .any(|(k, r)| *k != e.peer && (r.outbound == Some(ch) || r.inbound == Some(ch))),
+        }
+      },
+      "connection {ch:?} is referenced by a peer_routes key other than its own peer"
+    );
+  }
+
   /// Pre-pass over `peer`'s route, applied before either selection table.
   ///
   /// **P1 — prune a closed inbound.** A `DeadInbound` (closed, never

--- a/memberlist-proto/src/quic/conn/mod.rs
+++ b/memberlist-proto/src/quic/conn/mod.rs
@@ -1,6 +1,29 @@
 //! Per-peer QUIC connection table. One long-lived `quinn_proto::Connection`
 //! per peer (idle-evicted by quinn-proto's own `max_idle_timeout`); reaped
 //! only when `Connection::is_drained()` (the same protocol quinn uses).
+//!
+//! ## Residual: the transport layer does not order instance epochs
+//!
+//! Establishment does not prove the remote instance is *currently* alive: the
+//! server completes a handshake by replying to a client's `Finished`, and a
+//! delayed pre-crash client `Finished` still arriving under network delay drives
+//! that same completion. Nor does any transport-local signal reliably order two
+//! connections by which peer instance-epoch opened them — under unbounded
+//! network delay a delayed packet can interleave to fool creation-order,
+//! establishment-order, and close-the-older tracking alike. This table therefore
+//! makes NO attempt to rank connection instance-epochs; it selects the best
+//! *usable* connection and lets the most recently established inbound win.
+//!
+//! The bounded consequence: a zombie (an established connection to a peer's dead
+//! prior instance) can capture selection, but only until the negotiated idle
+//! timeout reaps it — the idle timeout is always finite (see the `build`-time
+//! rejection of a zero `max_idle_timeout`), and the negotiated value is the
+//! minimum of the two peers'. This is safety-preserving: every established
+//! connection is serviced by the coordinator's unconditional accept loops, so
+//! the peer's traffic and its SWIM refutations still flow over whichever
+//! connection each side prefers. The signal that actually resolves an
+//! instance-epoch conflict is the membership incarnation at the SWIM layer, one
+//! layer up — not the transport.
 
 use crate::Instant;
 use core::net::SocketAddr;
@@ -90,15 +113,6 @@ pub(crate) struct ConnEntry {
   /// Independent of the coordinator's separate `inbound_bridge_count` (which
   /// counts accepted bridges); a bridge contributes to exactly one of the two.
   outbound_bridge_count: usize,
-  /// Monotonic creation stamp, drawn from [`ConnTable::next_gen`] the moment
-  /// this entry is created (in `dial_fresh` and `insert_accepted`) and never
-  /// mutated. Orders connections by recency of CREATION — a later-created
-  /// connection always has a strictly greater generation. This is the correct
-  /// freshness signal for choosing among same-class connections to one peer:
-  /// unlike establishment time (which a delayed handshake distorts), creation
-  /// order cannot be reordered by a slow handshake, so a fresh post-restart
-  /// connection always outranks a stale pre-restart one.
-  generation: u64,
 }
 
 impl ConnEntry {
@@ -294,11 +308,6 @@ pub(crate) struct ConnTable {
   /// an O(total connections) scan per rejected datagram. A source with zero
   /// pending inbound connections has no entry (the map never stores a zero).
   pending_inbound: HashMap<SocketAddr, usize>,
-  /// The next connection generation to hand out. Increments on every connection
-  /// creation ([`Self::next_gen`]), so each connection's stamp is strictly
-  /// greater than every connection created before it. A `u64` never wraps in
-  /// practice (one increment per connection created for the process's life).
-  next_generation: u64,
 }
 
 impl ConnTable {
@@ -307,31 +316,7 @@ impl ConnTable {
       conns: Slab::new(),
       peer_routes: HashMap::new(),
       pending_inbound: HashMap::new(),
-      next_generation: 0,
     }
-  }
-
-  /// Return the next connection generation and advance the counter. Each call
-  /// yields a strictly greater value than the previous, so a later-created
-  /// connection always outranks an earlier one by generation.
-  fn next_gen(&mut self) -> u64 {
-    let g = self.next_generation;
-    debug_assert!(
-      self.next_generation != u64::MAX,
-      "connection generation counter must not wrap"
-    );
-    self.next_generation = self.next_generation.wrapping_add(1);
-    g
-  }
-
-  /// The fresher (higher-generation) of two tracked handles — the tiebreak used
-  /// when both candidates in the same selection class are usable, so a fresh
-  /// post-restart connection outranks a same-class zombie. A slab-gone handle
-  /// has generation `0` and loses to any live one.
-  fn fresher(&self, a: ConnectionHandle, b: ConnectionHandle) -> ConnectionHandle {
-    let ga = self.conns.get(a.0).map_or(0, |e| e.generation);
-    let gb = self.conns.get(b.0).map_or(0, |e| e.generation);
-    if ga >= gb { a } else { b }
   }
 
   /// `true` iff the table currently holds at least one closed connection whose
@@ -380,9 +365,7 @@ impl ConnTable {
   /// The best usable handle for `peer` — the derived selection an observer
   /// (`live_connections_to`, `try_open_uni_stream_to`, datagram sizing) rides,
   /// with NO dial side effect. Prefers an established connection, then a
-  /// handshaking one; within the first satisfied class, when BOTH the outbound
-  /// and inbound match, returns the fresher (higher-generation) one so a fresh
-  /// post-restart connection outranks a same-class zombie. A closed/terminal
+  /// handshaking one; outbound before inbound within each class. A closed/terminal
   /// handle is never usable, so this returns `None` for a peer whose only
   /// tracked connections are draining or handshake-failed. At most one handle
   /// (0 or 1 per peer).
@@ -390,17 +373,10 @@ impl ConnTable {
     let route = self.peer_routes.get(peer)?;
     let candidates = [route.outbound, route.inbound];
     for want in [HandleClass::Established, HandleClass::Handshaking] {
-      let mut best: Option<ConnectionHandle> = None;
       for ch in candidates.into_iter().flatten() {
         if self.classify(ch) == want {
-          best = Some(match best {
-            None => ch,
-            Some(b) => self.fresher(b, ch),
-          });
+          return Some(ch);
         }
-      }
-      if best.is_some() {
-        return best;
       }
     }
     None
@@ -514,7 +490,6 @@ impl ConnTable {
     let (ch, conn) = quinn
       .connect(now.into_std(), client, peer, server_name)
       .map_err(DialError::Connect)?;
-    let generation = self.next_gen();
     let slot = self.conns.insert(ConnEntry {
       conn,
       peer,
@@ -525,7 +500,6 @@ impl ConnTable {
       pending_indexed: false,
       pending_events: VecDeque::new(),
       outbound_bridge_count: 0,
-      generation,
     });
     debug_assert_eq!(slot, ch.0, "quinn ConnectionHandle is the slab vacant_key");
     self.peer_routes.entry(peer).or_default().outbound = Some(ch);
@@ -543,8 +517,7 @@ impl ConnTable {
   /// `route.outbound` (`O`) and `route.inbound` (`I`), then applies the table
   /// for `reliability`:
   ///
-  /// **Reliable** (first matching row): both Established → the fresher by
-  /// generation; R1 `O` Established → `O`; R2 `I`
+  /// **Reliable** (first matching row): R1 `O` Established → `O`; R2 `I`
   /// Established → `I`; R3 `O` Handshaking → `O`; R4 `O` TerminalOutbound + `I`
   /// Handshaking → `I`; R5 `O` TerminalOutbound + no `I` → `O` (downstream
   /// `dial_failed`, anti-storm); R6 no `O` + `I` Handshaking → dial fresh under
@@ -552,8 +525,7 @@ impl ConnTable {
   /// — return the live inbound and repark, never propagate); R7 no `O`, no `I`
   /// → dial fresh under cap, else propagate the dial error.
   ///
-  /// **Unreliable** (first matching row): both Established → the fresher by
-  /// generation; U1 `O` Established → `O`; U2 `I`
+  /// **Unreliable** (first matching row): U1 `O` Established → `O`; U2 `I`
   /// Established → `I`; U3 `O` Handshaking → `O`; U4 `I` Handshaking → `I` (no
   /// companion dial); U5 `O` TerminalOutbound + no `I` → `O`; U6 no `O`, no `I`
   /// → cold-dial under cap, else the dial error (the datagram caller maps every
@@ -586,16 +558,6 @@ impl ConnTable {
     let ic = inbound.map(|ch| self.classify(ch));
     match reliability {
       Reliability::Reliable => {
-        if oc == Some(Established) && ic == Some(Established) {
-          // Both established: return the fresher by generation so a fresh
-          // post-restart connection outranks a same-class zombie (e.g. an
-          // established inbound from a restarted peer beats a locally-still-
-          // Established outbound to its dead prior instance).
-          return Ok(self.fresher(
-            outbound.expect("Established outbound handle present"),
-            inbound.expect("Established inbound handle present"),
-          ));
-        }
         if oc == Some(Established) {
           return Ok(outbound.expect("Established outbound handle present")); // R1
         }
@@ -635,14 +597,6 @@ impl ConnTable {
         self.dial_fresh(quinn, now, client, peer, server_name, max_connections)
       }
       Reliability::Unreliable => {
-        if oc == Some(Established) && ic == Some(Established) {
-          // Both established: the fresher by generation (same tiebreak as the
-          // reliable plane) — a fresh post-restart connection outranks a zombie.
-          return Ok(self.fresher(
-            outbound.expect("Established outbound handle present"),
-            inbound.expect("Established inbound handle present"),
-          ));
-        }
         if oc == Some(Established) {
           return Ok(outbound.expect("Established outbound handle present")); // U1
         }
@@ -675,44 +629,28 @@ impl ConnTable {
 
   /// Establishment-chokepoint promotion. Called the pass a connection's sticky
   /// `established_at_least_once` flips `false → true`. A newly-established
-  /// INBOUND becomes `route.inbound` only when the current inbound is `None` or
-  /// this connection is at least as fresh by generation
-  /// (`ch.generation >= current.generation`). Freshness is CREATION order, not
-  /// establishment order: a delayed pre-crash inbound whose handshake finishes
-  /// *after* a fresher post-restart inbound is already tracked has an older
-  /// generation, so it is REJECTED here and never overwrites the fresher one.
-  /// Touches only `.inbound` (never displaces a self-initiated outbound). A
-  /// newly-established OUTBOUND must already be its peer's tracked
-  /// `route.outbound` (an establishing outbound is `!closed`, so the pre-pass
-  /// never cleared it) — asserted, not written.
+  /// INBOUND becomes `route.inbound` unconditionally: completing the handshake is
+  /// the strongest liveness signal available at the transport layer, so the most
+  /// recently established inbound is the one selection should ride. Touches only
+  /// `.inbound` (never displaces a self-initiated outbound). A newly-established
+  /// OUTBOUND must already be its peer's tracked `route.outbound` (an
+  /// establishing outbound is `!closed`, so the pre-pass never cleared it) —
+  /// asserted, not written.
   ///
-  /// Bounded self-healing residual (a per-peer generation high-watermark
-  /// surviving route removal would close it but adds unbounded per-peer state —
-  /// the bounded window is the deliberate tradeoff): if the freshest inbound
-  /// reaps and empties the route, and only THEN a much-older pre-crash inbound
-  /// finally establishes, that stale inbound is promoted into the now-empty
-  /// route and selected until it idle-kills (~`max_idle_timeout`), after which
-  /// the route empties and a fresh dial proceeds. This is a narrow multi-event
-  /// window that self-heals.
+  /// The transport layer does NOT attempt to order connection instance-epochs
+  /// (see the module-level residual note): establishment proves an Initial +
+  /// Finished were exchanged, not that the remote instance is currently alive, so
+  /// a zombie can capture selection until the idle timeout reaps it. This is
+  /// bounded and safety-preserving; the resolving signal is the membership
+  /// incarnation at the SWIM layer.
   pub(crate) fn on_established_transition(&mut self, ch: ConnectionHandle) {
-    let (peer, direction, generation) = match self.conns.get(ch.0) {
-      Some(e) => (e.peer, e.direction, e.generation),
+    let (peer, direction) = match self.conns.get(ch.0) {
+      Some(e) => (e.peer, e.direction),
       None => return,
     };
     match direction {
       ConnDirection::Inbound => {
-        // Promote only when this connection is at least as fresh as the current
-        // tracked inbound; a stale delayed establishment is rejected.
-        let promote = match self.peer_routes.get(&peer).and_then(|r| r.inbound) {
-          None => true,
-          Some(cur) => self
-            .conns
-            .get(cur.0)
-            .is_none_or(|e| generation >= e.generation),
-        };
-        if promote {
-          self.peer_routes.entry(peer).or_default().inbound = Some(ch);
-        }
+        self.peer_routes.entry(peer).or_default().inbound = Some(ch);
       }
       ConnDirection::Outbound => {
         debug_assert!(
@@ -733,13 +671,12 @@ impl ConnTable {
   ///
   /// The rule: an accept proves only that an Initial datagram arrived, which a
   /// delayed pre-crash Initial can also produce; it does NOT prove the remote
-  /// instance is currently alive. A completed handshake does prove liveness.
-  /// Route displacement between competing inbounds is therefore gated on the
-  /// establishment chokepoint ([`Self::on_established_transition`]), where the
-  /// freshest proven-live inbound wins by generation — not at accept time, where
-  /// a delayed pre-crash Initial (structurally incapable of completing its
-  /// handshake) would otherwise displace a proven-live route. Accept-time writes
-  /// fill only an empty or closed slot.
+  /// instance is currently alive. Route displacement between competing inbounds
+  /// is therefore gated on the establishment chokepoint
+  /// ([`Self::on_established_transition`]), which promotes the most recently
+  /// established inbound — not at accept time, where a delayed pre-crash Initial
+  /// (structurally incapable of completing its handshake) would otherwise
+  /// displace a live route. Accept-time writes fill only an empty or closed slot.
   ///
   /// NEVER written into `route.outbound`: an accept can therefore never displace
   /// a self-initiated outbound, else the peer-initiated connection would become
@@ -757,7 +694,6 @@ impl ConnTable {
     conn: Connection,
     peer: SocketAddr,
   ) {
-    let generation = self.next_gen();
     let slot = self.conns.insert(ConnEntry {
       conn,
       peer,
@@ -773,7 +709,6 @@ impl ConnTable {
       // handle a later local dial rides (simultaneous bidirectional dial), so a
       // dialer bridge may be opened on it — start the outbound count at zero.
       outbound_bridge_count: 0,
-      generation,
     });
     assert_eq!(
       slot, ch.0,

--- a/memberlist-proto/src/quic/conn/mod.rs
+++ b/memberlist-proto/src/quic/conn/mod.rs
@@ -16,14 +16,20 @@
 //!
 //! The bounded consequence: a zombie (an established connection to a peer's dead
 //! prior instance) can capture selection, but only until the negotiated idle
-//! timeout reaps it — the idle timeout is always finite (see the `build`-time
-//! rejection of a zero `max_idle_timeout`), and the negotiated value is the
-//! minimum of the two peers'. This is safety-preserving: every established
-//! connection is serviced by the coordinator's unconditional accept loops, so
-//! the peer's traffic and its SWIM refutations still flow over whichever
-//! connection each side prefers. The signal that actually resolves an
-//! instance-epoch conflict is the membership incarnation at the SWIM layer, one
-//! layer up — not the transport.
+//! timeout reaps it. That finite bound is guaranteed by the file-based
+//! `QuicConfigOptions::build` path, which rejects a `max_idle_timeout` that
+//! encodes to a disabling zero (zero, or a sub-millisecond value quinn rounds to
+//! zero) — so a config-built endpoint always negotiates a finite idle timeout
+//! (the minimum of the two peers'). The raw `QuicOptions::new` /
+//! `new_with_sni_provider` constructors are an advanced escape hatch that takes a
+//! caller-supplied `TransportConfig` verbatim, so a caller CAN disable the idle
+//! timeout there (`max_idle_timeout(None)` or an encoded-zero value) and thereby
+//! forgo the bound — an opt-out those constructors caution against. Even so this
+//! is safety-preserving: every established connection is serviced by the
+//! coordinator's unconditional accept loops, so the peer's traffic and its SWIM
+//! refutations still flow over whichever connection each side prefers. The signal
+//! that actually resolves an instance-epoch conflict is the membership
+//! incarnation at the SWIM layer, one layer up — not the transport.
 
 use crate::Instant;
 use core::net::SocketAddr;

--- a/memberlist-proto/src/quic/conn/mod.rs
+++ b/memberlist-proto/src/quic/conn/mod.rs
@@ -210,9 +210,73 @@ impl ConnEntry {
   }
 }
 
+/// Whether a selection is servicing the RELIABLE plane (push/pull, reliable-ping,
+/// user message — an intent that may create a fresh outbound connection and is
+/// retired through `dial_failed` on terminal failure) or the UNRELIABLE plane
+/// (a best-effort gossip/probe datagram that never surfaces a dial error as a
+/// membership signal and never creates a companion connection beside a live
+/// handshaking inbound). The discriminant the two selection tables branch on.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Reliability {
+  /// Reliable-plane intent — the reliable selection table (may dial fresh; a
+  /// terminal outbound is authoritative and routes to `dial_failed`).
+  Reliable,
+  /// Unreliable-plane datagram — the unreliable selection table (every dial
+  /// failure degrades to a best-effort UDP fallback; no companion dial beside a
+  /// live handshaking inbound).
+  Unreliable,
+}
+
+/// The at-most-two tracked handles for one logical peer. `outbound` is our most
+/// recent self-initiated dial; `inbound` is the peer's most recent accepted
+/// connection. Direction is the discriminant the terminality rule is asymmetric
+/// on — a closed-never-established outbound is our own failed dial (authoritative
+/// unreachability on our egress), while a closed-never-established inbound is the
+/// peer's failed dial toward us (says nothing about our egress) — so it is kept
+/// structural, one field per direction. A `PeerRoute` with both fields `None` is
+/// dropped from the map; the connection slab may still hold further entries for
+/// the same peer (draining residue, a superseded same-direction accept) — all
+/// serviced by the coordinator, none selectable here.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct PeerRoute {
+  outbound: Option<ConnectionHandle>,
+  inbound: Option<ConnectionHandle>,
+}
+
+/// Per-handle classification computed inline from the slab state — NOT a stored
+/// field, so it is always current. `closed` is `Connection::is_closed()`
+/// (`Closed | Draining | Drained`). The direction split of the two
+/// closed-never-established classes is the asymmetric-reachability fix: our own
+/// failed dial ([`HandleClass::TerminalOutbound`]) proves the peer is
+/// unreachable on our egress and is authoritative (anti-storm); the peer's
+/// failed dial toward us ([`HandleClass::DeadInbound`]) proves nothing about our
+/// egress and is never returned.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum HandleClass {
+  /// `!closed && !is_handshaking` — usable, ready to mint.
+  Established,
+  /// `!closed && is_handshaking` — usable, repark.
+  Handshaking,
+  /// `closed && established_at_least_once` — drain window, redial.
+  DrainClosed,
+  /// `closed && !established && direction == Outbound` — authoritative failure.
+  TerminalOutbound,
+  /// `closed && !established && direction == Inbound` — non-authoritative, prune.
+  DeadInbound,
+  /// The slab slot is gone (race-defensive).
+  Gone,
+}
+
 pub(crate) struct ConnTable {
   conns: Slab<ConnEntry>,
-  peers: HashMap<SocketAddr, ConnectionHandle>,
+  /// The at-most-two tracked handles per logical peer — the self-initiated
+  /// `outbound` and the peer-accepted `inbound` — that [`Self::get_or_dial`]
+  /// selects among. Replaces a single direction-blind canonical pointer: a
+  /// peer-initiated inbound still handshaking can no longer occupy the slot a
+  /// reliable outbound intent selects, so an inbound that stalls or fails does
+  /// not suppress our own independent outbound dial to a peer reachable on our
+  /// egress. An entry whose both fields fall to `None` is removed.
+  peer_routes: HashMap<SocketAddr, PeerRoute>,
   /// Per-source count of INBOUND connections that have not yet established — the
   /// half-open population the coordinator's per-source pending cap bounds. Kept
   /// as an index so admission is an O(1) lookup ([`Self::pending_inbound_from`])
@@ -227,7 +291,7 @@ impl ConnTable {
   pub(crate) fn new() -> Self {
     Self {
       conns: Slab::new(),
-      peers: HashMap::new(),
+      peer_routes: HashMap::new(),
       pending_inbound: HashMap::new(),
     }
   }
@@ -242,53 +306,116 @@ impl ConnTable {
     self.conns.get(ch.0)
   }
 
-  pub(crate) fn handle_for(&self, peer: &SocketAddr) -> Option<ConnectionHandle> {
-    self.peers.get(peer).copied()
+  /// Classify one tracked handle from its current slab state. See
+  /// [`HandleClass`]; direction resolves the two closed-never-established
+  /// classes.
+  fn classify(&self, ch: ConnectionHandle) -> HandleClass {
+    match self.conns.get(ch.0) {
+      None => HandleClass::Gone,
+      Some(e) => {
+        if !e.conn.is_closed() {
+          if e.conn.is_handshaking() {
+            HandleClass::Handshaking
+          } else {
+            HandleClass::Established
+          }
+        } else if e.established_at_least_once {
+          HandleClass::DrainClosed
+        } else if e.direction == ConnDirection::Outbound {
+          HandleClass::TerminalOutbound
+        } else {
+          HandleClass::DeadInbound
+        }
+      }
+    }
   }
 
-  /// Return the existing connection handle for `peer`, or dial a new one.
+  /// The best usable handle for `peer` — the derived selection an observer
+  /// (`live_connections_to`, `try_open_uni_stream_to`, datagram sizing) rides,
+  /// with NO dial side effect. Prefers an established connection, then a
+  /// handshaking one; outbound before inbound within each. A closed/terminal
+  /// handle is never usable, so this returns `None` for a peer whose only
+  /// tracked connections are draining or handshake-failed. At most one handle
+  /// (0 or 1 per peer).
+  pub(crate) fn handle_for(&self, peer: &SocketAddr) -> Option<ConnectionHandle> {
+    let route = self.peer_routes.get(peer)?;
+    let candidates = [route.outbound, route.inbound];
+    for want in [HandleClass::Established, HandleClass::Handshaking] {
+      for ch in candidates.into_iter().flatten() {
+        if self.classify(ch) == want {
+          return Some(ch);
+        }
+      }
+    }
+    None
+  }
+
+  /// Pre-pass over `peer`'s route, applied before either selection table.
   ///
-  /// quinn-proto assigns `ConnectionHandle(slab.vacant_key())` inside
-  /// `Endpoint::connect`, so the slab index and the handle's inner value are
-  /// always in sync (asserted at insert time).
+  /// **P1 — prune a closed inbound.** A `DeadInbound` (closed, never
+  /// established — the peer's failed dial toward us) or `DrainClosed`
+  /// (established-then-closed) inbound, or one whose slab slot is gone, is
+  /// cleared from `route.inbound`; the slab entry is kept for its
+  /// handle-equality reap. Past P1, `route.inbound` only ever carries a live
+  /// (Established/Handshaking) inbound.
   ///
-  /// **Closed-before-drained pool window: redial, don't reuse.** A pooled
-  /// `Connection` may sit in `Closed`/`Draining` for the 3×PTO drain window
-  /// before it reaches `Drained`. During that window, quinn-proto's
-  /// `Streams::open(Dir::Bi)` already returns `None` (it checks
-  /// `self.conn_state.is_closed()`, and `Connection::is_closed()` covers
-  /// `Closed | Draining | Drained`), but `Connection::is_handshaking`
-  /// is *also* `false`, so the coordinator's `service_dials` handshaking-
-  /// requeue path would not catch it; the intent would fall into
-  /// `dial_failed` and the push/pull / reliable-ping-fallback / user message
-  /// would be silently lost. We therefore probe the cached connection with
-  /// `is_closed()` (the same predicate `Streams::open` uses to refuse) AND
-  /// `established_at_least_once` (sticky — set the first time the conn was
-  /// observed `!is_handshaking() && !is_closed()`): a closed conn that
-  /// was previously Established is in the drain window and we redial (drop
-  /// only the `peers` mapping; keep the slab entry so `reap_if_drained`
-  /// completes the drained-reap on the original handle later; dial a fresh
-  /// connection). A closed conn that never reached Established is a
-  /// handshake failure for an unreachable peer — returning the cached
-  /// handle lets `service_dials::open(Dir::Bi)=None && !is_handshaking()`
-  /// fall through to `dial_failed`, so a genuinely-unreachable peer does
-  /// not generate fresh handshake attempts inside one push/pull deadline. The slab momentarily holds two entries
-  /// for the same peer (the old one awaiting drained-reap; the new one
-  /// live); this is by design — `peers[peer]` always points at the live
-  /// one for new outbound exchanges, and `reap_if_drained` clears the old
-  /// slab slot when its `Drained` state is reached.
+  /// **P2 — clear the outbound drain window.** A `DrainClosed`
+  /// (established-then-closed) outbound, or one whose slab slot is gone, is
+  /// cleared from `route.outbound` so a fresh redial can proceed. A
+  /// `TerminalOutbound` (closed, never established — our own failed dial) is
+  /// LEFT in place: it is authoritative unreachability on our egress and
+  /// suppresses a fresh-handshake storm. Past P2,
+  /// `route.outbound ∈ {None, Handshaking, Established, TerminalOutbound}`.
   ///
-  /// **Global connection cap covers outbound dials too.** `max_connections`
-  /// (the coordinator's `max_quic_connections`) is enforced right before a NEW
-  /// outbound `quinn.connect` commits a fresh slab slot — the no-reusable-entry
-  /// branch only. Without it, `max_quic_connections` would bound inbound
-  /// Initials while a large or attacker-influenced membership address set could
-  /// still grow the slab past the cap through reliable dials and datagram
-  /// fallbacks (both reach here). Every early-return reuse path above (a usable
-  /// pooled connection, or a cached closed-never-Established handle) returns
-  /// BEFORE the check, so reusing a slot is never blocked — only a genuinely
-  /// new connection is refused, with [`DialError::AtGlobalCap`].
-  pub(crate) fn get_or_dial(
+  /// A route left with both fields `None` is removed (no permanent empty
+  /// entries).
+  fn prepass(&mut self, peer: &SocketAddr) {
+    let Some(route) = self.peer_routes.get(peer) else {
+      return;
+    };
+    let clear_inbound = match route.inbound {
+      None => false,
+      // Any closed (or slab-gone) inbound is pruned; only a live inbound may
+      // survive P1. `is_closed()` covers `DeadInbound` and `DrainClosed`.
+      Some(ch) => self.conns.get(ch.0).is_none_or(|e| e.conn.is_closed()),
+    };
+    let clear_outbound = match route.outbound {
+      None => false,
+      // Only a `DrainClosed` (or slab-gone) outbound is cleared; a
+      // `TerminalOutbound` stays authoritative.
+      Some(ch) => self
+        .conns
+        .get(ch.0)
+        .is_none_or(|e| e.conn.is_closed() && e.established_at_least_once),
+    };
+    if clear_inbound || clear_outbound {
+      let route = self
+        .peer_routes
+        .get_mut(peer)
+        .expect("route present for the peer just inspected");
+      if clear_inbound {
+        route.inbound = None;
+      }
+      if clear_outbound {
+        route.outbound = None;
+      }
+    }
+    if self
+      .peer_routes
+      .get(peer)
+      .is_some_and(|r| r.outbound.is_none() && r.inbound.is_none())
+    {
+      self.peer_routes.remove(peer);
+    }
+  }
+
+  /// Commit a fresh self-initiated outbound `quinn.connect` and record it as
+  /// `route.outbound`. Enforces the global connection cap right before the new
+  /// slab slot commits (the only site a NEW connection is created), so a large
+  /// or attacker-influenced membership set cannot grow the slab past the cap
+  /// through reliable dials and datagram fallbacks. Reached only when
+  /// `route.outbound` is `None` after the pre-pass.
+  fn dial_fresh(
     &mut self,
     quinn: &mut QuinnEndpoint,
     now: Instant,
@@ -297,42 +424,16 @@ impl ConnTable {
     server_name: &str,
     max_connections: Option<usize>,
   ) -> Result<ConnectionHandle, DialError> {
-    if let Some(ch) = self.peers.get(&peer).copied() {
-      let (reusable, was_established) = match self.conns.get(ch.0) {
-        Some(e) => (!e.conn.is_closed(), e.established_at_least_once),
-        None => (false, false),
-      };
-      if reusable {
-        return Ok(ch);
-      }
-      // Cached conn is closed (or its slab slot is gone — race-defensive).
-      // If it was previously Established, we are in the closed-before-
-      // drained pool window: drop ONLY the `peers` mapping (keep the
-      // slab so its in-flight drained-reap can complete on the original
-      // handle) and fall through to dial a fresh connection. If it was
-      // NEVER Established, treat the cached entry as authoritative —
-      // returning it lets the existing `service_dials` path fire
-      // `dial_failed` via `open(Bi)=None && !is_handshaking()`.
-      if !was_established {
-        return Ok(ch);
-      }
-      self.peers.remove(&peer);
-    }
-    // Global connection cap — enforced ONLY here, on the no-reusable-entry
-    // branch that is about to create a fresh slab slot. A reused connection
-    // returned above without reaching this check. `len()` counts every tracked
-    // slab entry (handshaking, established, draining), so this caps the total
-    // outbound + inbound connection population at `max_connections`.
+    // `len()` counts every tracked slab entry (handshaking, established,
+    // draining), so this caps the total outbound + inbound population.
     if max_connections.is_some_and(|max| self.conns.len() >= max) {
       return Err(DialError::AtGlobalCap);
     }
-    // `server_name` is the rustls verification identity for the peer's
-    // cert — supplied by the driver's SNI provider so the verification
-    // name is keyed on the membership address (not a hardcoded constant).
-    // quinn-proto forwards it verbatim to
-    // `config.crypto.start_session(version, server_name, ...)`; the
-    // rustls-backed `start_session` parses it via `ServerName::try_from`
-    // and feeds the result to the configured `ServerCertVerifier`.
+    // `server_name` is the rustls verification identity for the peer's cert,
+    // supplied by the driver's SNI provider so the name is keyed on the
+    // membership address. quinn-proto forwards it verbatim to
+    // `config.crypto.start_session`; the rustls-backed `start_session` parses
+    // it via `ServerName::try_from` and feeds the configured verifier.
     let (ch, conn) = quinn
       .connect(now.into_std(), client, peer, server_name)
       .map_err(DialError::Connect)?;
@@ -348,44 +449,175 @@ impl ConnTable {
       outbound_bridge_count: 0,
     });
     debug_assert_eq!(slot, ch.0, "quinn ConnectionHandle is the slab vacant_key");
-    self.peers.insert(peer, ch);
+    self.peer_routes.entry(peer).or_default().outbound = Some(ch);
     Ok(ch)
+  }
+
+  /// Select the connection handle for an intent to `peer`, dialing a fresh
+  /// outbound when the selection tables call for one.
+  ///
+  /// quinn-proto assigns `ConnectionHandle(slab.vacant_key())` inside
+  /// `Endpoint::connect`, so the slab index and the handle's inner value are
+  /// always in sync (asserted at insert time).
+  ///
+  /// The selection runs the [`Self::prepass`], classifies the surviving
+  /// `route.outbound` (`O`) and `route.inbound` (`I`), then applies the table
+  /// for `reliability`:
+  ///
+  /// **Reliable** (first matching row): R1 `O` Established → `O`; R2 `I`
+  /// Established → `I`; R3 `O` Handshaking → `O`; R4 `O` TerminalOutbound + `I`
+  /// Handshaking → `I`; R5 `O` TerminalOutbound + no `I` → `O` (downstream
+  /// `dial_failed`, anti-storm); R6 no `O` + `I` Handshaking → dial fresh under
+  /// cap, else degrade to `I` (a synchronous connect error degrades identically
+  /// — return the live inbound and repark, never propagate); R7 no `O`, no `I`
+  /// → dial fresh under cap, else propagate the dial error.
+  ///
+  /// **Unreliable** (first matching row): U1 `O` Established → `O`; U2 `I`
+  /// Established → `I`; U3 `O` Handshaking → `O`; U4 `I` Handshaking → `I` (no
+  /// companion dial); U5 `O` TerminalOutbound + no `I` → `O`; U6 no `O`, no `I`
+  /// → cold-dial under cap, else the dial error (the datagram caller maps every
+  /// dial error to a best-effort UDP fallback).
+  ///
+  /// **Fresh-dial condition** (the asymmetric-reachability core): a
+  /// `quinn.connect` is issued iff `route.outbound` is `None` after the pre-pass
+  /// (R6/R7/U6) — never for a Handshaking/Established/TerminalOutbound outbound,
+  /// and never keyed on `route.inbound`. So a peer's stalled or failed inbound
+  /// never suppresses our own independent outbound dial to a peer reachable on
+  /// our egress.
+  #[allow(clippy::too_many_arguments)]
+  pub(crate) fn get_or_dial(
+    &mut self,
+    quinn: &mut QuinnEndpoint,
+    now: Instant,
+    client: quinn_proto::ClientConfig,
+    peer: SocketAddr,
+    server_name: &str,
+    max_connections: Option<usize>,
+    reliability: Reliability,
+  ) -> Result<ConnectionHandle, DialError> {
+    use HandleClass::{Established, Handshaking, TerminalOutbound};
+    self.prepass(&peer);
+    let (outbound, inbound) = match self.peer_routes.get(&peer) {
+      Some(r) => (r.outbound, r.inbound),
+      None => (None, None),
+    };
+    let oc = outbound.map(|ch| self.classify(ch));
+    let ic = inbound.map(|ch| self.classify(ch));
+    match reliability {
+      Reliability::Reliable => {
+        if oc == Some(Established) {
+          return Ok(outbound.expect("Established outbound handle present")); // R1
+        }
+        if ic == Some(Established) {
+          return Ok(inbound.expect("Established inbound handle present")); // R2
+        }
+        if oc == Some(Handshaking) {
+          return Ok(outbound.expect("Handshaking outbound handle present")); // R3
+        }
+        if oc == Some(TerminalOutbound) {
+          if ic == Some(Handshaking) {
+            // R4: our dial failed but the peer's inbound may still establish.
+            return Ok(inbound.expect("Handshaking inbound handle present"));
+          }
+          debug_assert!(
+            ic.is_none(),
+            "reliable R5 reached with a live inbound the pre-pass should have surfaced earlier"
+          );
+          // R5: authoritative terminal — downstream `dial_failed` (anti-storm).
+          return Ok(outbound.expect("TerminalOutbound handle present"));
+        }
+        debug_assert!(
+          oc.is_none(),
+          "reliable selection reached the fresh-dial rows with a non-None outbound class"
+        );
+        if ic == Some(Handshaking) {
+          // R6: dial our own outbound under cap; at cap OR on a synchronous
+          // connect error, degrade to the live inbound and repark (never
+          // propagate the dial error — a live candidate exists).
+          return match self.dial_fresh(quinn, now, client, peer, server_name, max_connections) {
+            Ok(ch) => Ok(ch),
+            Err(_) => Ok(inbound.expect("Handshaking inbound handle present")),
+          };
+        }
+        // R7: no candidate of either direction — propagate the dial error.
+        debug_assert!(ic.is_none(), "reliable R7 reached with a live inbound");
+        self.dial_fresh(quinn, now, client, peer, server_name, max_connections)
+      }
+      Reliability::Unreliable => {
+        if oc == Some(Established) {
+          return Ok(outbound.expect("Established outbound handle present")); // U1
+        }
+        if ic == Some(Established) {
+          return Ok(inbound.expect("Established inbound handle present")); // U2
+        }
+        if oc == Some(Handshaking) {
+          return Ok(outbound.expect("Handshaking outbound handle present")); // U3
+        }
+        if ic == Some(Handshaking) {
+          // U4: ride the live handshaking inbound (→ NotReady → UDP); NEVER
+          // create a companion outbound beside a live inbound.
+          return Ok(inbound.expect("Handshaking inbound handle present"));
+        }
+        if oc == Some(TerminalOutbound) {
+          debug_assert!(ic.is_none(), "unreliable U5 reached with a live inbound");
+          // U5: (→ NotReady → UDP).
+          return Ok(outbound.expect("TerminalOutbound handle present"));
+        }
+        // U6: no candidate — cold-dial under cap; the datagram caller maps a
+        // dial error (at cap / connect error) to a best-effort UDP fallback.
+        debug_assert!(
+          oc.is_none() && ic.is_none(),
+          "unreliable U6 reached with a live handle"
+        );
+        self.dial_fresh(quinn, now, client, peer, server_name, max_connections)
+      }
+    }
+  }
+
+  /// Establishment-chokepoint promotion. Called the pass a connection's sticky
+  /// `established_at_least_once` flips `false → true`. A newly-established
+  /// INBOUND becomes `route.inbound` unconditionally (newest-established-inbound
+  /// wins): a completed fresh handshake means the peer deliberately redialed, so
+  /// its previous inbound is dead/draining on its side, and the displaced entry
+  /// stays slab-serviced until reaped. Touches only `.inbound` (never displaces
+  /// a self-initiated outbound). A newly-established OUTBOUND must already be its
+  /// peer's tracked `route.outbound` (an establishing outbound is `!closed`, so
+  /// the pre-pass never cleared it) — asserted, not written.
+  pub(crate) fn on_established_transition(&mut self, ch: ConnectionHandle) {
+    let (peer, direction) = match self.conns.get(ch.0) {
+      Some(e) => (e.peer, e.direction),
+      None => return,
+    };
+    match direction {
+      ConnDirection::Inbound => {
+        self.peer_routes.entry(peer).or_default().inbound = Some(ch);
+      }
+      ConnDirection::Outbound => {
+        debug_assert!(
+          self.peer_routes.get(&peer).and_then(|r| r.outbound) == Some(ch),
+          "an establishing outbound must already be its peer's tracked outbound route"
+        );
+      }
+    }
   }
 
   /// Record an inbound connection accepted by the server endpoint.
   ///
   /// The accepted connection is always inserted into the slab (so quinn can
-  /// drive it and its inbound bidi streams are serviced). The `peers`
-  /// address→handle map — which `get_or_dial` consults to route NEW
-  /// OUTBOUND streams — is (re)pointed at this connection only if the
-  /// existing canonical (if any) is no longer usable, using the **same
-  /// `!Connection::is_closed()` predicate** `get_or_dial` uses for
-  /// outbound reuse.
+  /// drive it and its inbound bidi streams are serviced). It is written into
+  /// `route.inbound` iff the current inbound is `None` or classifies closed —
+  /// NEVER into `route.outbound`. An accept can therefore never displace a
+  /// self-initiated outbound: were the peer-initiated connection to become the
+  /// slot our outbound exchanges select while the peer binds its accept side to
+  /// the other connection, the exchange would wedge (the peer wrongly never
+  /// confirmed → false Suspect). Keeping the two directions in separate fields
+  /// makes that wedge-avoidance structural.
   ///
-  /// Symmetry with `get_or_dial`. Outbound dial considers a cached
-  /// connection re-usable iff `!is_closed()` (quinn-proto's
-  /// `Connection::is_closed` covers `Closed|Draining|Drained`); a closed
-  /// cached handle is treated as unreachable (`Streams::open(Bi)=None`).
-  /// Inbound accept must use the *same* predicate: when the existing
-  /// canonical is closed/draining/drained, the new accepted connection
-  /// becomes canonical (`peers[peer] = new_ch`); the old slab entry
-  /// persists until its drained-reap completes (its `peers` mapping is
-  /// already gone, so the equality-guarded `reap_if_drained` cannot
-  /// clobber the new canonical). Without this symmetry an accepted live
-  /// connection from a peer can be hidden behind a closed-never-
-  /// Established cached handle — subsequent outbound dials hit the
-  /// closed cached handle and silently `dial_failed`, leaving the live
-  /// accepted connection unused.
-  ///
-  /// Simultaneous bidirectional dial. When both peers `connect` to each
-  /// other before either accepts, each side ends up with one
-  /// self-initiated and one accepted connection to the same address. If
-  /// the self-initiated one is healthy (`!is_closed()`) it stays
-  /// canonical for this node's outbound exchanges — unconditionally
-  /// clobbering `peers` would route outbound onto the peer-initiated
-  /// connection while the peer's accept side is bound to the other one,
-  /// wedging the exchange (the peer is then wrongly never confirmed →
-  /// false Suspect). The `!is_closed()` gate preserves this property.
+  /// The displaced (previous) inbound, if any, stays in the slab until its
+  /// drained-reap; its handle is no longer in `route.inbound`, so the
+  /// equality-guarded [`Self::reap_if_drained`] cannot clobber this one. A
+  /// newest-established-inbound promotion for the same peer runs later at the
+  /// establishment chokepoint ([`Self::on_established_transition`]).
   pub(crate) fn insert_accepted(
     &mut self,
     ch: ConnectionHandle,
@@ -413,18 +645,22 @@ impl ConnTable {
       "accepted connection slab slot must equal ConnectionHandle"
     );
     *self.pending_inbound.entry(peer).or_insert(0) += 1;
-    let existing_usable = self
-      .peers
+    // Set `route.inbound` iff the current inbound is None or closed; never
+    // touch `route.outbound`.
+    let inbound_usable = self
+      .peer_routes
       .get(&peer)
+      .and_then(|r| r.inbound)
       .and_then(|existing| self.conns.get(existing.0))
       .is_some_and(|e| !e.conn.is_closed());
-    if !existing_usable {
-      self.peers.insert(peer, ch);
+    if !inbound_usable {
+      self.peer_routes.entry(peer).or_default().inbound = Some(ch);
     }
   }
 
   /// Drained-reap: if `Connection::is_drained()`, relay `EndpointEvent::drained()`
-  /// to quinn (cleans its CID index) then drop the slab + peers entry.
+  /// to quinn (cleans its CID index) then drop the slab entry and clear it from
+  /// its peer's route.
   ///
   /// Returns `true` if the connection was reaped.
   ///
@@ -432,14 +668,13 @@ impl ConnTable {
   /// `Connection::is_drained()` the runtime sends `EndpointEvent::drained()`
   /// (via `Endpoint::handle_event`) and then frees the connection.
   ///
-  /// **Handle-equality-guarded `peers` removal.** When a redial happened
-  /// during the original connection's drain window (`get_or_dial` saw the
-  /// cached `Connection` in `Closed`/`Draining`/`Drained` and dialed a
-  /// fresh `ConnectionHandle`), `peers[e.peer]` now points at the NEW
-  /// handle while the slab still holds the OLD entry awaiting this reap.
-  /// Removing `peers[e.peer]` unconditionally would clobber the redial's
-  /// mapping. We therefore drop the `peers` entry only when it still points
-  /// at the handle being reaped — the canonical post-redial invariant.
+  /// **Handle-equality-guarded route removal.** A superseding write may have
+  /// already repointed `route.outbound`/`route.inbound` at a fresh handle (a
+  /// drain-window redial, a newest-established-inbound promotion) while the slab
+  /// still holds the OLD entry awaiting this reap. Clearing a field
+  /// unconditionally would clobber the newer handle, so each field is cleared
+  /// only when it still equals the handle being reaped. A `PeerRoute` left with
+  /// both fields `None` is dropped.
   ///
   /// Contract: once this returns `true` the slab slot is gone — the caller must not forward any further `poll_endpoint_events()` for `ch` into the endpoint (that would double-drain a removed handle).
   pub(crate) fn reap_if_drained(
@@ -468,8 +703,20 @@ impl ConnTable {
       if e.pending_indexed {
         Self::release_pending_inbound(&mut self.pending_inbound, e.peer);
       }
-      if self.peers.get(&e.peer).copied() == Some(ch) {
-        self.peers.remove(&e.peer);
+      if let Some(route) = self.peer_routes.get_mut(&e.peer) {
+        if route.outbound == Some(ch) {
+          route.outbound = None;
+        }
+        if route.inbound == Some(ch) {
+          route.inbound = None;
+        }
+      }
+      if self
+        .peer_routes
+        .get(&e.peer)
+        .is_some_and(|r| r.outbound.is_none() && r.inbound.is_none())
+      {
+        self.peer_routes.remove(&e.peer);
       }
     }
     true

--- a/memberlist-proto/src/quic/conn/tests.rs
+++ b/memberlist-proto/src/quic/conn/tests.rs
@@ -34,6 +34,7 @@ fn dial_inserts_then_reuse_returns_same_handle() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
     .unwrap();
   let ch2 = t
@@ -44,6 +45,7 @@ fn dial_inserts_then_reuse_returns_same_handle() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
     .unwrap();
   assert_eq!(ch1, ch2, "second call reuses the peer connection");
@@ -64,6 +66,7 @@ fn reap_if_drained_is_false_until_drained_then_removes() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
     .unwrap();
   assert!(
@@ -93,7 +96,7 @@ fn reap_if_drained_is_false_until_drained_then_removes() {
     t.reap_if_drained(&mut client, ch),
     "connection must be drained after close+timeout drive"
   );
-  assert_eq!(t.handle_for(&peer), None, "peers entry removed on reap");
+  assert_eq!(t.handle_for(&peer), None, "route entry removed on reap");
 }
 
 /// `Connection::close` drives the cached `Connection` into `State::Closed`
@@ -104,14 +107,14 @@ fn reap_if_drained_is_false_until_drained_then_removes() {
 /// (same `is_closed()` check inside `Streams::open`), but
 /// `is_handshaking()` is `false`, so `service_dials`'s handshaking-requeue
 /// would not catch it.
-/// For a connection that had previously reached `Established`,
-/// `get_or_dial` MUST detect the un-reusable cached connection and dial
-/// a fresh one — silently returning the cached handle would route a
-/// redialable intent into `dial_failed` and lose the exchange.
+/// For an outbound that had previously reached `Established` (now
+/// `DrainClosed`), the pre-pass (P2) clears `route.outbound` and the reliable
+/// selection dials a fresh one (R7) — silently reusing the cached handle would
+/// route a redialable intent into `dial_failed` and lose the exchange.
 ///
-/// Negative control: revert the `is_closed()` check in `get_or_dial`
-/// (return the cached `ch` whenever the slab still holds it) and this
-/// test fails — `ch_redial == ch1` and the slab/peers state is wrong.
+/// Negative control: drop P2's `DrainClosed` clear (leave a closed
+/// established-once outbound in `route.outbound`) and this test fails —
+/// `ch_redial == ch1` and the route/slab state is wrong.
 #[test]
 fn get_or_dial_redials_when_cached_conn_is_closed_not_drained() {
   let (mut client, _server, cfg) = quinn_pair();
@@ -126,6 +129,7 @@ fn get_or_dial_redials_when_cached_conn_is_closed_not_drained() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
     .unwrap();
   // Synthesize "this connection has reached Established at least once"
@@ -155,6 +159,7 @@ fn get_or_dial_redials_when_cached_conn_is_closed_not_drained() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
     .unwrap();
   assert_ne!(
@@ -171,16 +176,16 @@ fn get_or_dial_redials_when_cached_conn_is_closed_not_drained() {
     t.get(ch_redial).is_some(),
     "new slab entry inserted by the redial"
   );
-  // `peers[peer]` points at the live (new) handle for subsequent
+  // The best-usable handle is the live (new) redial for subsequent
   // outbound exchanges.
   assert_eq!(
     t.handle_for(&peer),
     Some(ch_redial),
-    "peers mapping advanced to the fresh redial"
+    "route advanced to the fresh redial"
   );
 
   // Drive the OLD connection to `Drained` and confirm its slab slot is
-  // cleared while the new mapping is preserved (Part B equality guard).
+  // cleared while the new route is preserved (the equality guard).
   for _ in 0..5000 {
     if t.get(ch1).is_none_or(|e| e.conn_ref().is_drained()) {
       break;
@@ -194,12 +199,12 @@ fn get_or_dial_redials_when_cached_conn_is_closed_not_drained() {
     t.reap_if_drained(&mut client, ch1),
     "old closed connection must drain-reap to completion"
   );
-  // Critical: the new redial's mapping MUST survive the old handle's
+  // Critical: the new redial's route MUST survive the old handle's
   // drained-reap (handle-equality guard).
   assert_eq!(
     t.handle_for(&peer),
     Some(ch_redial),
-    "drained-reap of the OLD handle must NOT clobber the NEW redial's peers mapping"
+    "drained-reap of the OLD handle must NOT clobber the NEW redial's route"
   );
   assert!(
     t.get(ch_redial).is_some(),
@@ -207,15 +212,19 @@ fn get_or_dial_redials_when_cached_conn_is_closed_not_drained() {
   );
 }
 
-/// A cached connection that is `is_closed()` but has NEVER reached
-/// `Established` (handshake failure for an unreachable peer) must NOT be
-/// redialed by `get_or_dial`: a fresh dial to the same unreachable peer
-/// would just fail the same way, and a SWIM periodic push-pull schedule
-/// would generate one fresh handshake per attempt for the lifetime of
-/// the deadline. Return the cached handle so
-/// `service_dials::open(Dir::Bi)=None && !is_handshaking()` falls through
-/// to `dial_failed`, consuming the intent on a single handshake attempt
-/// per push-pull deadline.
+/// Anti-storm: a closed OUTBOUND that never reached `Established` (our own dial
+/// to an unreachable peer) is authoritative — `TerminalOutbound`. A reliable
+/// intent must return it (R5) so the caller's `open(Dir::Bi)=None &&
+/// !is_handshaking()` path falls through to `dial_failed`, consuming the intent
+/// on a single handshake attempt per push-pull deadline rather than generating a
+/// fresh handshake per attempt. The pre-pass (P2) leaves a `TerminalOutbound` in
+/// place; no redial happens within the drain window.
+///
+/// Negative control (the outbound half of the direction split): remove the
+/// `direction == Outbound` arm of the handle classifier so a closed
+/// never-established connection no longer classifies as `TerminalOutbound` — R5
+/// is not taken, the reliable fresh-dial guard is tripped, and this test fails
+/// (a fresh redial replaces the terminal, or a debug assertion fires).
 #[test]
 fn closed_never_established_does_not_redial() {
   let (mut client, _server, cfg) = quinn_pair();
@@ -230,6 +239,7 @@ fn closed_never_established_does_not_redial() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
     .unwrap();
   // Do NOT seed `established_at_least_once`: this represents a
@@ -251,6 +261,7 @@ fn closed_never_established_does_not_redial() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
     .unwrap();
   assert_eq!(
@@ -280,6 +291,7 @@ fn established_flag_sticks_via_conn_mut_lazy_tracking() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
     .unwrap();
   assert!(!t.conns.get(ch.0).unwrap().established_at_least_once);
@@ -311,41 +323,26 @@ fn established_flag_sticks_via_conn_mut_lazy_tracking() {
   );
 }
 
-/// Closed-never-Established cached entry must NOT hide a live accepted
-/// connection. `insert_accepted` uses the SAME `!Connection::is_closed()`
-/// usability predicate as `get_or_dial`'s outbound reuse check, so when
-/// the cached canonical for a peer is closed (regardless of whether it
-/// ever reached Established), the newly-accepted connection becomes
-/// canonical (`peers[peer] = new_ch`). Symmetric with `get_or_dial`.
+/// A closed-never-Established OUTBOUND (`TerminalOutbound`) must NOT hide a
+/// live accepted inbound. The two fields are independent: an accepted
+/// connection is written to `route.inbound` while the closed outbound stays
+/// in `route.outbound`, and the reliable table's R4 (`TerminalOutbound` +
+/// handshaking inbound → return the inbound) surfaces the live connection.
 ///
-/// Setup: dial X (the cache is seeded with `ch1`, `was_established`
-/// left false — the handshake-failed-or-closed-before-Established
-/// signature). Close X. Now `insert_accepted` a new connection for X.
-/// Assert that `peers[X]` advances to the new handle (the live
-/// accepted connection becomes the canonical), and that subsequent
-/// `get_or_dial(X)` returns the new handle so future outbound
-/// exchanges ride the live connection instead of the closed cached
-/// one. Finally, drive the OLD handle through drained-reap and
-/// confirm the equality-guarded `reap_if_drained` does NOT clobber
-/// the new canonical mapping.
-///
-/// Negative control: if `insert_accepted` checked only
-/// `self.conns.contains(existing.0)` (slab presence — true while the
-/// closed handle is still awaiting its drained-reap), the cached
-/// closed handle would stay canonical. The assertion
-/// `peers[X] == Some(new_ch)` below would fail, every subsequent
-/// outbound dial would hit the closed cached `ch1`, fall through to
-/// the `service_dials::is_closed → dial_failed` branch, and the live
-/// accepted connection would be permanently unused.
+/// Setup: dial X (outbound `ch1`, never established), close it
+/// (`TerminalOutbound`), then `insert_accepted` a fresh inbound for the same
+/// peer. Assert the peer's best-usable handle is the live inbound, that a
+/// subsequent reliable `get_or_dial` returns it (R4), and that reaping the OLD
+/// outbound does not clobber the inbound (handle-equality guard).
 #[test]
-fn closed_never_established_cached_does_not_hide_live_accepted_connection() {
+fn terminal_outbound_does_not_hide_live_accepted_inbound() {
   let (mut client, _server, cfg) = quinn_pair();
   let mut t = ConnTable::new();
   let now = Instant::now();
   let peer: SocketAddr = "127.0.0.1:4433".parse().unwrap();
-  // (1) Outbound dial X. `ch1` is now the canonical handle for peer.
+  // (1) Outbound dial X → `route.outbound = ch1`.
   // `established_at_least_once` is left false to represent a
-  // handshake failure / closed-before-Established cache.
+  // handshake failure / closed-before-Established outbound.
   let ch1 = t
     .get_or_dial(
       &mut client,
@@ -354,6 +351,7 @@ fn closed_never_established_cached_does_not_hide_live_accepted_connection() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
     .unwrap();
   assert_eq!(t.handle_for(&peer), Some(ch1));
@@ -375,28 +373,24 @@ fn closed_never_established_cached_does_not_hide_live_accepted_connection() {
   // endpoint's slab so the new `ch.0` lines up with the local
   // ConnTable slab's next vacant key (the lockstep `insert_accepted`
   // asserts). The accept-vs-dial origin does not matter to
-  // `insert_accepted` itself — it only inserts the entry into the
-  // slab and updates `peers` per the usability predicate.
+  // `insert_accepted` itself — it inserts the entry as inbound and sets
+  // `route.inbound`.
   let alt: SocketAddr = "127.0.0.1:4500".parse().unwrap();
   let (new_ch, new_conn) = client
     .connect(now.into_std(), cfg.client().clone(), alt, "localhost")
     .expect("fresh connection minted on the same client endpoint");
   t.insert_accepted(new_ch, new_conn, peer);
-  // (4) The accepted connection IS live (`!is_closed()`), and the
-  // cached canonical was closed (`is_closed()`), so the `peers`
-  // canonical advances to `new_ch`. The slab-presence-only predicate
-  // (`self.conns.contains(ch1.0)`) would instead leave the closed
-  // handle canonical because the drained-pending slab entry is still
-  // present.
+  // (4) The accepted inbound is live; the closed outbound is
+  // `TerminalOutbound`. The best-usable handle is the live inbound — the
+  // closed outbound in the separate `route.outbound` field cannot hide it.
   assert_eq!(
     t.handle_for(&peer),
     Some(new_ch),
-    "the live accepted connection must replace the closed cached \
-             canonical (the closed cached handle was hiding the live \
-             accepted connection from subsequent outbound dials)"
+    "the live accepted inbound is the best-usable handle; the closed \
+             outbound in a separate field cannot hide it"
   );
-  // (5) Subsequent outbound dial returns the NEW canonical: outbound
-  // exchanges ride the live accepted connection.
+  // (5) A subsequent reliable dial returns the live inbound via R4
+  // (`TerminalOutbound` outbound + handshaking inbound).
   let ch_after = t
     .get_or_dial(
       &mut client,
@@ -405,16 +399,17 @@ fn closed_never_established_cached_does_not_hide_live_accepted_connection() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
     .unwrap();
   assert_eq!(
     ch_after, new_ch,
-    "outbound dial after the accept must reuse the new live canonical, \
-             not the closed cached ch1"
+    "a reliable dial with a terminal outbound + live inbound returns the \
+             inbound (R4), not the closed outbound ch1"
   );
-  // (6) Old slab entry persists awaiting its drained-reap. Drive it
+  // (6) Old outbound entry persists awaiting its drained-reap. Drive it
   // to Drained and confirm the equality-guarded `reap_if_drained`
-  // clears the OLD slab slot without clobbering the NEW canonical.
+  // clears the OLD slab slot without clobbering the live inbound.
   for _ in 0..5000 {
     if t.get(ch1).is_none_or(|e| e.conn_ref().is_drained()) {
       break;
@@ -426,26 +421,26 @@ fn closed_never_established_cached_does_not_hide_live_accepted_connection() {
   }
   assert!(
     t.reap_if_drained(&mut client, ch1),
-    "old closed cached handle must drained-reap to completion"
+    "old closed outbound must drained-reap to completion"
   );
   assert_eq!(
     t.handle_for(&peer),
     Some(new_ch),
-    "the new canonical must survive the OLD handle's drained-reap \
-             (handle-equality-guarded `peers` removal protects it)"
+    "the live inbound must survive the OLD outbound's drained-reap \
+             (handle-equality-guarded route removal protects it)"
   );
 }
 
-/// Part B isolated: the handle-equality guard's three cases — plain reap
-/// (peers→ch holds, remove), mid-drain redial (peers→new_ch holds,
-/// skip), and peers absent (None, skip). The first two are exercised by
+/// Isolated: the handle-equality guard's three cases — plain reap
+/// (route holds `ch`, clear it), mid-drain redial (route holds new_ch,
+/// skip), and route absent (skip). The first two are exercised by
 /// `reap_if_drained_is_false_until_drained_then_removes` and
 /// `get_or_dial_redials_when_cached_conn_is_closed_not_drained`
 /// respectively; this test pins case (c): a synthetic state where the
-/// slab still holds `ch` (drained) but `peers[e.peer]` was already
+/// slab still holds `ch` (drained) but the route entry was already
 /// removed (e.g. by a fresh `get_or_dial` that dialed before this reap
 /// ran). The reap must be idempotent — clear the slab slot, leave the
-/// (now-absent) peers state alone.
+/// (now-absent) route state alone.
 #[test]
 fn reap_if_drained_handle_equality_guard_idempotent_when_peers_absent() {
   let (mut client, _server, cfg) = quinn_pair();
@@ -460,6 +455,7 @@ fn reap_if_drained_handle_equality_guard_idempotent_when_peers_absent() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
     .unwrap();
   // Drive the conn through `close` to `Drained`.
@@ -477,43 +473,49 @@ fn reap_if_drained_handle_equality_guard_idempotent_when_peers_absent() {
     }
   }
   assert!(t.get(ch).unwrap().conn_ref().is_drained());
-  // Synthesize "peers entry already removed" (the redial case at the
-  // limit: peers cleared but the old slab still holds the drained
+  // Synthesize "route entry already removed" (the redial case at the
+  // limit: the route was cleared but the old slab still holds the drained
   // entry awaiting this reap).
-  t.peers.remove(&peer);
+  t.peer_routes.remove(&peer);
   assert_eq!(t.handle_for(&peer), None);
   // The reap must still complete (slab cleared, no panic, no
-  // resurrection of a stale peers entry).
+  // resurrection of a stale route entry).
   assert!(
     t.reap_if_drained(&mut client, ch),
-    "reap must succeed even when peers entry was pre-removed"
+    "reap must succeed even when the route entry was pre-removed"
   );
   assert!(t.get(ch).is_none(), "slab slot freed");
   assert_eq!(
     t.handle_for(&peer),
     None,
-    "peers state unchanged (no resurrection)"
+    "route state unchanged (no resurrection)"
   );
 }
 
-/// Race-defensive arm of `get_or_dial`: the `peers` map holds a handle whose
-/// slab slot has already been vacated (the `None` arm of the `match
-/// self.conns.get(ch.0)` → `(reusable=false, was_established=false)`). A
-/// never-Established cached handle is authoritative — the call returns the
-/// cached handle so `service_dials`'s `open(Bi)=None && !is_handshaking()`
-/// path fires `dial_failed` rather than spawning a fresh handshake storm. No
-/// new slab entry is created.
+/// Race-defensive pre-pass arm: a route field pointing at a handle whose slab
+/// slot has already been vacated is a slab-gone class. The pre-pass clears it
+/// (`is_none_or` treats a vanished slab entry as clearable), and with the field
+/// gone the reliable selection dials a FRESH outbound rather than returning the
+/// dangling handle.
+///
+/// Negative control: if P2 did not treat a slab-gone outbound as clearable, its
+/// class would be `Gone` and the reliable table would trip the
+/// `debug_assert!(oc.is_none())` fresh-dial guard.
 #[test]
-fn get_or_dial_returns_cached_handle_when_peers_points_at_vacated_slab_slot() {
+fn prepass_clears_slab_gone_outbound_then_dials_fresh() {
   let (mut client, _server, cfg) = quinn_pair();
   let mut t = ConnTable::new();
   let now = Instant::now();
   let peer: SocketAddr = "127.0.0.1:4433".parse().unwrap();
-  // Plant a `peers` mapping to a handle index that has no slab entry — the
-  // race-defensive `None` arm's input. `was_established` resolves to false,
-  // so this is the never-Established branch.
+  // Plant a route whose outbound handle has no slab entry — the slab-gone input.
   let phantom = ConnectionHandle(999);
-  t.peers.insert(peer, phantom);
+  t.peer_routes.insert(
+    peer,
+    PeerRoute {
+      outbound: Some(phantom),
+      inbound: None,
+    },
+  );
   assert!(t.conns.get(phantom.0).is_none(), "slab slot is vacant");
 
   let ch = t
@@ -524,22 +526,20 @@ fn get_or_dial_returns_cached_handle_when_peers_points_at_vacated_slab_slot() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
-    .expect("get_or_dial returns the cached handle");
+    .expect("a fresh outbound is dialed after the slab-gone field is pruned");
+  assert_ne!(ch, phantom, "the dangling handle is never returned");
+  assert_eq!(t.conns.len(), 1, "a fresh outbound slab entry was created");
   assert_eq!(
-    ch, phantom,
-    "the stale never-Established handle is authoritative — returned so \
-       service_dials fires dial_failed, not a fresh handshake"
-  );
-  assert_eq!(
-    t.conns.len(),
-    0,
-    "no new slab entry was created for a phantom"
+    t.handle_for(&peer),
+    Some(ch),
+    "the fresh outbound is the peer's best-usable handle"
   );
 }
 
 /// `reap_if_drained` on a handle whose slab slot is already gone returns
-/// `false` without touching quinn or `peers` (the `None => return false`
+/// `false` without touching quinn or the route (the `None => return false`
 /// guard). Idempotent: a second reap of a handle that was already reaped is a
 /// no-op.
 #[test]
@@ -573,6 +573,7 @@ fn conn_entry_observation_accessors_on_fresh_entry() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
     .unwrap();
   let e = t.get_mut(ch).unwrap();
@@ -614,6 +615,7 @@ fn pending_inbound_from_excludes_local_outbound_dial() {
       peer,
       "localhost",
       None,
+      Reliability::Reliable,
     )
     .unwrap();
   // A freshly-dialed outbound connection is handshaking and never established;
@@ -639,7 +641,7 @@ fn pending_inbound_from_excludes_local_outbound_dial() {
 /// inbound TLS handshake (`is_closed() && !is_handshaking()`, established flag
 /// never set); `Connection::close` on a handshaking connection reproduces it
 /// exactly — the same modelling the closed-never-Established tests in this file
-/// use (`closed_never_established_cached_does_not_hide_live_accepted_connection`).
+/// use (`terminal_outbound_does_not_hide_live_accepted_inbound`).
 ///
 /// Negative control: release the index unit when a connection closes (e.g. clear
 /// `pending_indexed` on `is_closed()`) — the closed failed entries drop out and
@@ -655,7 +657,7 @@ fn pending_inbound_from_charges_failed_never_established_inbound() {
   // minted on the same endpoint so their slab slots stay in lockstep with the
   // local ConnTable (the accept-vs-dial origin is irrelevant to
   // `insert_accepted`, which sets direction = Inbound and inserts — see
-  // `closed_never_established_cached_does_not_hide_live_accepted_connection`).
+  // `terminal_outbound_does_not_hide_live_accepted_inbound`).
   let a1: SocketAddr = "127.0.0.1:4500".parse().unwrap();
   let a2: SocketAddr = "127.0.0.1:4501".parse().unwrap();
   let (ch1, c1) = client
@@ -821,4 +823,691 @@ fn pending_inbound_index_pairs_increment_with_exactly_one_decrement() {
   // s2 was never touched: its count and recount are unchanged throughout.
   assert_eq!(t.pending_inbound_from(&s2), 2);
   assert_eq!(t.pending_inbound_from(&s2), t.indexed_inbound_recount(&s2));
+}
+
+/// Reliable `get_or_dial` with no global cap.
+fn dial_reliable(
+  t: &mut ConnTable,
+  quinn: &mut QuinnEndpoint,
+  cfg: &QuicOptions,
+  now: Instant,
+  peer: SocketAddr,
+) -> Result<ConnectionHandle, DialError> {
+  t.get_or_dial(
+    quinn,
+    now,
+    cfg.client().clone(),
+    peer,
+    "localhost",
+    None,
+    Reliability::Reliable,
+  )
+}
+
+/// Accept a fresh inbound connection for `peer`, minted on `quinn` in lockstep
+/// so the ConnTable slab slot matches the handle (the `insert_accepted` slot
+/// assertion). The accept-vs-dial origin is irrelevant to `insert_accepted`.
+fn accept_inbound(
+  t: &mut ConnTable,
+  quinn: &mut QuinnEndpoint,
+  cfg: &QuicOptions,
+  now: Instant,
+  peer: SocketAddr,
+  mint_addr: SocketAddr,
+) -> ConnectionHandle {
+  let (ch, conn) = quinn
+    .connect(now.into_std(), cfg.client().clone(), mint_addr, "localhost")
+    .expect("fresh connection minted on the client endpoint");
+  t.insert_accepted(ch, conn, peer);
+  ch
+}
+
+/// Transport address a ferried inbound is delivered from (its membership key).
+const FERRY_CLIENT_ADDR: &str = "127.0.0.1:5001";
+/// Transport address of the endpoint a ferried outbound dials.
+const FERRY_SERVER_ADDR: &str = "127.0.0.1:5000";
+
+/// Drive a full QUIC handshake so `t` (acting as SERVER, on `server_ep`) holds a
+/// freshly ESTABLISHED inbound from [`FERRY_CLIENT_ADDR`]. A raw client
+/// connection on `client_ep` dials, and datagrams are ferried both ways until
+/// the inbound leaves handshaking. Returns the inbound handle in `t`. Multiple
+/// calls (a fresh raw client each) yield distinct inbounds from the same peer.
+fn establish_inbound(
+  t: &mut ConnTable,
+  server_ep: &mut QuinnEndpoint,
+  client_ep: &mut QuinnEndpoint,
+  cfg: &QuicOptions,
+) -> ConnectionHandle {
+  use quinn_proto::DatagramEvent;
+  let server_addr: SocketAddr = FERRY_SERVER_ADDR.parse().unwrap();
+  let client_addr: SocketAddr = FERRY_CLIENT_ADDR.parse().unwrap();
+  let now = Instant::now().into_std();
+  let (cch, mut cconn) = client_ep
+    .connect(now, cfg.client().clone(), server_addr, "localhost")
+    .expect("raw client dial");
+  let mut inbound: Option<ConnectionHandle> = None;
+  for _ in 0..200 {
+    let mut buf = Vec::new();
+    while let Some(tr) = cconn.poll_transmit(now, 1, &mut buf) {
+      let data = bytes::BytesMut::from(&buf[..tr.size]);
+      let mut scratch = Vec::new();
+      if let Some(ev) = server_ep.handle(now, client_addr, None, None, data, &mut scratch) {
+        match ev {
+          DatagramEvent::ConnectionEvent(ch, cev) => {
+            if let Some(e) = t.get_mut(ch) {
+              e.conn_mut().handle_event(cev);
+            }
+          }
+          DatagramEvent::NewConnection(inc) => {
+            let mut ab = Vec::new();
+            if let Ok((ch, conn)) = server_ep.accept(inc, now, &mut ab, Some(cfg.server_arc())) {
+              t.insert_accepted(ch, conn, client_addr);
+              inbound = Some(ch);
+            }
+          }
+          DatagramEvent::Response(_) => {}
+        }
+      }
+      buf.clear();
+    }
+    if let Some(ich) = inbound {
+      let mut sbuf = Vec::new();
+      while let Some(tr) = t
+        .get_mut(ich)
+        .unwrap()
+        .conn_mut()
+        .poll_transmit(now, 1, &mut sbuf)
+      {
+        let data = bytes::BytesMut::from(&sbuf[..tr.size]);
+        let mut scratch = Vec::new();
+        if let Some(DatagramEvent::ConnectionEvent(ch, cev)) =
+          client_ep.handle(now, server_addr, None, None, data, &mut scratch)
+        {
+          debug_assert_eq!(ch, cch);
+          cconn.handle_event(cev);
+        }
+        sbuf.clear();
+      }
+    }
+    while let Some(ev) = cconn.poll_endpoint_events() {
+      if ev.is_drained() {
+        continue;
+      }
+      if let Some(cev) = client_ep.handle_event(cch, ev) {
+        cconn.handle_event(cev);
+      }
+    }
+    if let Some(ich) = inbound {
+      while let Some(ev) = t.get_mut(ich).unwrap().conn_mut().poll_endpoint_events() {
+        if ev.is_drained() {
+          continue;
+        }
+        if let Some(cev) = server_ep.handle_event(ich, ev) {
+          t.get_mut(ich).unwrap().conn_mut().handle_event(cev);
+        }
+      }
+    }
+    cconn.handle_timeout(now);
+    if let Some(ich) = inbound {
+      t.get_mut(ich).unwrap().conn_mut().handle_timeout(now);
+    }
+    let cup = !cconn.is_handshaking() && !cconn.is_closed();
+    let sup = inbound
+      .and_then(|ich| t.get(ich))
+      .map(|e| !e.conn_ref().is_handshaking() && !e.conn_ref().is_closed())
+      .unwrap_or(false);
+    if cup && sup {
+      break;
+    }
+  }
+  let ich = inbound.expect("server accepted the inbound");
+  assert!(
+    !t.get(ich).unwrap().conn_ref().is_handshaking(),
+    "the inbound must reach Established"
+  );
+  ich
+}
+
+/// Drive a full QUIC handshake so `t` (acting as CLIENT, on `client_ep`) holds a
+/// freshly ESTABLISHED OUTBOUND dialed to `peer`. The peer is a throwaway
+/// server-side `ConnTable` on `server_ep`. Returns the outbound handle in `t`.
+fn establish_outbound(
+  t: &mut ConnTable,
+  client_ep: &mut QuinnEndpoint,
+  server_ep: &mut QuinnEndpoint,
+  cfg: &QuicOptions,
+  peer: SocketAddr,
+) -> ConnectionHandle {
+  use quinn_proto::DatagramEvent;
+  let client_addr: SocketAddr = FERRY_CLIENT_ADDR.parse().unwrap();
+  let now = Instant::now().into_std();
+  let ch = t
+    .get_or_dial(
+      client_ep,
+      Instant::from_std(now),
+      cfg.client().clone(),
+      peer,
+      "localhost",
+      None,
+      Reliability::Reliable,
+    )
+    .unwrap();
+  let mut server_conns = ConnTable::new();
+  let mut server_ch: Option<ConnectionHandle> = None;
+  for _ in 0..200 {
+    let mut buf = Vec::new();
+    while let Some(tr) = t
+      .get_mut(ch)
+      .unwrap()
+      .conn_mut()
+      .poll_transmit(now, 1, &mut buf)
+    {
+      let data = bytes::BytesMut::from(&buf[..tr.size]);
+      let mut scratch = Vec::new();
+      if let Some(ev) = server_ep.handle(now, client_addr, None, None, data, &mut scratch) {
+        match ev {
+          DatagramEvent::ConnectionEvent(sch, cev) => {
+            if let Some(e) = server_conns.get_mut(sch) {
+              e.conn_mut().handle_event(cev);
+            }
+          }
+          DatagramEvent::NewConnection(inc) => {
+            let mut ab = Vec::new();
+            if let Ok((sch, conn)) = server_ep.accept(inc, now, &mut ab, Some(cfg.server_arc())) {
+              server_conns.insert_accepted(sch, conn, client_addr);
+              server_ch = Some(sch);
+            }
+          }
+          DatagramEvent::Response(_) => {}
+        }
+      }
+      buf.clear();
+    }
+    if let Some(sch) = server_ch {
+      let mut sbuf = Vec::new();
+      while let Some(tr) = server_conns
+        .get_mut(sch)
+        .unwrap()
+        .conn_mut()
+        .poll_transmit(now, 1, &mut sbuf)
+      {
+        let data = bytes::BytesMut::from(&sbuf[..tr.size]);
+        let mut scratch = Vec::new();
+        if let Some(DatagramEvent::ConnectionEvent(rch, cev)) =
+          client_ep.handle(now, peer, None, None, data, &mut scratch)
+          && rch == ch
+        {
+          t.get_mut(ch).unwrap().conn_mut().handle_event(cev);
+        }
+        sbuf.clear();
+      }
+    }
+    while let Some(ev) = t.get_mut(ch).unwrap().conn_mut().poll_endpoint_events() {
+      if ev.is_drained() {
+        continue;
+      }
+      if let Some(cev) = client_ep.handle_event(ch, ev) {
+        t.get_mut(ch).unwrap().conn_mut().handle_event(cev);
+      }
+    }
+    if let Some(sch) = server_ch {
+      while let Some(ev) = server_conns
+        .get_mut(sch)
+        .unwrap()
+        .conn_mut()
+        .poll_endpoint_events()
+      {
+        if ev.is_drained() {
+          continue;
+        }
+        if let Some(cev) = server_ep.handle_event(sch, ev) {
+          server_conns
+            .get_mut(sch)
+            .unwrap()
+            .conn_mut()
+            .handle_event(cev);
+        }
+      }
+    }
+    t.get_mut(ch).unwrap().conn_mut().handle_timeout(now);
+    if let Some(sch) = server_ch {
+      server_conns
+        .get_mut(sch)
+        .unwrap()
+        .conn_mut()
+        .handle_timeout(now);
+    }
+    let cup = t
+      .get(ch)
+      .map(|e| !e.conn_ref().is_handshaking() && !e.conn_ref().is_closed())
+      .unwrap_or(false);
+    let sup = server_ch
+      .and_then(|sch| server_conns.get(sch))
+      .map(|e| !e.conn_ref().is_handshaking() && !e.conn_ref().is_closed())
+      .unwrap_or(false);
+    if cup && sup {
+      break;
+    }
+  }
+  assert!(
+    !t.get(ch).unwrap().conn_ref().is_handshaking(),
+    "the outbound must reach Established"
+  );
+  ch
+}
+
+/// Asymmetric-reachability fix: a closed never-established INBOUND (the peer's
+/// failed dial toward us) is non-authoritative — it says nothing about our
+/// egress. A reliable intent must dial our OWN independent outbound, and the
+/// pre-pass must have pruned the dead inbound from the route (never left it as a
+/// stale authoritative entry).
+///
+/// Negative control: drop P1's inbound prune — the dead inbound is left in
+/// `route.inbound` and the final `route.inbound == None` assertion fails. The
+/// contrasting outbound half (a closed never-established OUTBOUND stays
+/// authoritative → `dial_failed`, no redial) is pinned by
+/// `closed_never_established_does_not_redial`.
+#[test]
+fn closed_inbound_is_non_authoritative_and_triggers_a_fresh_outbound_dial() {
+  let (mut client, _server, cfg) = quinn_pair();
+  let mut t = ConnTable::new();
+  let now = Instant::now();
+  let peer: SocketAddr = "127.0.0.1:4433".parse().unwrap();
+  // An inbound that closes WITHOUT ever establishing (DeadInbound).
+  let dead = accept_inbound(
+    &mut t,
+    &mut client,
+    &cfg,
+    now,
+    peer,
+    "127.0.0.1:4500".parse().unwrap(),
+  );
+  t.get_mut(dead)
+    .unwrap()
+    .conn_mut()
+    .close(now.into_std(), 0u32.into(), bytes::Bytes::new());
+  assert!(t.get(dead).unwrap().conn_ref().is_closed());
+  assert!(!t.get(dead).unwrap().established_at_least_once());
+
+  let ch = dial_reliable(&mut t, &mut client, &cfg, now, peer)
+    .expect("a fresh independent outbound is dialed");
+  assert_ne!(
+    ch, dead,
+    "the dead inbound is never returned as authoritative"
+  );
+  assert_eq!(
+    t.conns.get(ch.0).unwrap().direction,
+    ConnDirection::Outbound,
+    "a fresh outbound was dialed"
+  );
+  assert_eq!(
+    t.conns.len(),
+    2,
+    "the dead inbound is retained (awaiting reap) beside the new outbound"
+  );
+  assert_eq!(
+    t.peer_routes.get(&peer).and_then(|r| r.inbound),
+    None,
+    "the closed never-established inbound is pruned from the route by the pre-pass"
+  );
+  assert_eq!(
+    t.peer_routes.get(&peer).and_then(|r| r.outbound),
+    Some(ch),
+    "the fresh outbound is recorded as the route's outbound"
+  );
+}
+
+/// Establishment-chokepoint promotion (the crash-restart class). An inbound X
+/// is the tracked inbound; a NEW inbound Y accepted while X is live is declined
+/// at accept (X stays the tracked inbound); when Y establishes the promotion
+/// sets `route.inbound = Y` (newest-established-inbound wins), so the derived
+/// selection surfaces Y — not the stale X — and Y stays discoverable after X is
+/// reaped.
+///
+/// Negative controls: without the establishment write (revert the inbound arm
+/// of `on_established_transition`), the selection keeps surfacing the stale X;
+/// without the accept guard (`insert_accepted` always overwrites), Y would
+/// wrongly become the tracked inbound the moment it is accepted. (The
+/// end-to-end established-selection is additionally covered by
+/// `established_inbound_selected_and_promotion_supersedes_the_prior_one`.)
+#[test]
+fn establishment_promotes_the_newest_inbound_over_a_live_prior_one() {
+  let (mut client, _server, cfg) = quinn_pair();
+  let mut t = ConnTable::new();
+  let now = Instant::now();
+  let peer: SocketAddr = "127.0.0.1:4433".parse().unwrap();
+  // Inbound X accepted → route.inbound = X.
+  let x = accept_inbound(
+    &mut t,
+    &mut client,
+    &cfg,
+    now,
+    peer,
+    "127.0.0.1:4500".parse().unwrap(),
+  );
+  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(x));
+  assert_eq!(t.handle_for(&peer), Some(x));
+
+  // A NEW inbound Y accepted while X is live (not closed) → declined at accept.
+  let y = accept_inbound(
+    &mut t,
+    &mut client,
+    &cfg,
+    now,
+    peer,
+    "127.0.0.1:4501".parse().unwrap(),
+  );
+  assert_eq!(
+    t.peer_routes.get(&peer).and_then(|r| r.inbound),
+    Some(x),
+    "a new inbound accepted while an inbound is live is declined at accept"
+  );
+
+  // Y reaches the establishment chokepoint → promotion sets route.inbound = Y.
+  t.on_established_transition(y);
+  assert_eq!(
+    t.peer_routes.get(&peer).and_then(|r| r.inbound),
+    Some(y),
+    "the newly-established inbound is promoted over the prior one"
+  );
+  // The derived selection surfaces the promoted Y, not the stale X.
+  assert_eq!(
+    t.handle_for(&peer),
+    Some(y),
+    "selection surfaces the promoted inbound, not the stale one"
+  );
+
+  // After X is removed, Y is still discoverable.
+  t.get_mut(x)
+    .unwrap()
+    .conn_mut()
+    .close(now.into_std(), 0u32.into(), bytes::Bytes::new());
+  drive_to_drained(&mut t, x);
+  assert!(t.reap_if_drained(&mut client, x));
+  assert_eq!(
+    t.handle_for(&peer),
+    Some(y),
+    "the promoted inbound remains discoverable after the prior one is reaped"
+  );
+}
+
+/// At the global connection cap with a live handshaking inbound, a reliable
+/// intent (R6) must degrade to the live inbound and repark — NOT propagate
+/// `AtGlobalCap`. (A synchronous `connect` error at R6 degrades through the same
+/// arm; it cannot be injected at this unit level, so this at-cap case is the
+/// anchor for that arm.)
+///
+/// Negative control: propagate the dial error at R6 (`Err(e) => Err(e)`) — the
+/// `expect` below panics because no handle is returned.
+#[test]
+fn reliable_r6_at_cap_returns_the_live_inbound_not_an_error() {
+  let (mut client, _server, cfg) = quinn_pair();
+  let mut t = ConnTable::new();
+  let now = Instant::now();
+  let peer: SocketAddr = "127.0.0.1:4433".parse().unwrap();
+  let inbound = accept_inbound(
+    &mut t,
+    &mut client,
+    &cfg,
+    now,
+    peer,
+    "127.0.0.1:4500".parse().unwrap(),
+  );
+  assert!(t.get(inbound).unwrap().conn_ref().is_handshaking());
+  let sel = t
+    .get_or_dial(
+      &mut client,
+      now,
+      cfg.client().clone(),
+      peer,
+      "localhost",
+      Some(1),
+      Reliability::Reliable,
+    )
+    .expect("R6 at cap returns the live inbound, not an error");
+  assert_eq!(
+    sel, inbound,
+    "the live handshaking inbound is returned for repark"
+  );
+  assert_eq!(
+    t.conns.len(),
+    1,
+    "no companion outbound was created at the cap"
+  );
+}
+
+/// Simultaneous-dial: an established OUTBOUND stays canonical even when a live
+/// INBOUND is also present (R1 precedes R2/R3), so the exchange does not wedge.
+///
+/// Negative control: remove the R1 arm — the established outbound is no longer
+/// matched, the reliable table trips its fresh-dial guard, and `sel == o` fails.
+#[test]
+fn established_outbound_precedes_a_live_inbound() {
+  let (mut client, mut server, cfg) = quinn_pair();
+  let mut t = ConnTable::new();
+  let now = Instant::now();
+  let peer: SocketAddr = FERRY_SERVER_ADDR.parse().unwrap();
+  // A real established outbound O (drives a full handshake).
+  let o = establish_outbound(&mut t, &mut client, &mut server, &cfg, peer);
+  // A live handshaking inbound I for the same peer.
+  let i = accept_inbound(
+    &mut t,
+    &mut client,
+    &cfg,
+    now,
+    peer,
+    "127.0.0.1:4600".parse().unwrap(),
+  );
+  assert_ne!(o, i);
+
+  let sel = dial_reliable(&mut t, &mut client, &cfg, now, peer).unwrap();
+  assert_eq!(
+    sel, o,
+    "R1 (established outbound) is selected over a live inbound; no wedge"
+  );
+}
+
+/// A real established INBOUND is selected on both planes (R2 / U2), and a newer
+/// inbound that establishes while it is live is declined at accept, then
+/// promoted at the establishment chokepoint so selection follows to the newest
+/// established inbound — the end-to-end crash-restart property.
+///
+/// Negative control: revert the inbound arm of `on_established_transition` — the
+/// promotion never runs, `route.inbound` stays the prior X, and the final
+/// `sel2 == y` assertion fails (selection keeps returning the superseded one).
+#[test]
+fn established_inbound_selected_and_promotion_supersedes_the_prior_one() {
+  let (mut client, mut server, cfg) = quinn_pair();
+  let mut t = ConnTable::new();
+  let now = Instant::now();
+  let peer: SocketAddr = FERRY_CLIENT_ADDR.parse().unwrap();
+
+  // A real established inbound X, no outbound.
+  let x = establish_inbound(&mut t, &mut server, &mut client, &cfg);
+  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(x));
+  // R2 / U2: the established inbound is selected on both planes.
+  assert_eq!(
+    dial_reliable(&mut t, &mut client, &cfg, now, peer).unwrap(),
+    x,
+    "R2 selects the established inbound"
+  );
+  assert_eq!(
+    t.get_or_dial(
+      &mut client,
+      now,
+      cfg.client().clone(),
+      peer,
+      "localhost",
+      None,
+      Reliability::Unreliable,
+    )
+    .unwrap(),
+    x,
+    "U2 selects the established inbound"
+  );
+
+  // A NEW inbound Y establishes while X is live → declined at accept.
+  let y = establish_inbound(&mut t, &mut server, &mut client, &cfg);
+  assert_ne!(x, y);
+  assert_eq!(
+    t.peer_routes.get(&peer).and_then(|r| r.inbound),
+    Some(x),
+    "a new inbound accepted while X is live is declined at accept"
+  );
+
+  // Y reaches the establishment chokepoint → promotion sets route.inbound = Y.
+  t.on_established_transition(y);
+  assert_eq!(
+    t.peer_routes.get(&peer).and_then(|r| r.inbound),
+    Some(y),
+    "the newly-established inbound is promoted over the prior one"
+  );
+  let sel2 = dial_reliable(&mut t, &mut client, &cfg, now, peer).unwrap();
+  assert_eq!(
+    sel2, y,
+    "selection follows to the promoted established inbound (R2), not the stale X"
+  );
+}
+
+/// The unreliable table finds a live handshaking inbound behind a terminal
+/// outbound (U4) and never creates a companion outbound beside it; a terminal
+/// outbound with no inbound is returned so the datagram falls back to UDP (U5).
+/// (The established-inbound rows U1/U2 are covered by
+/// `established_inbound_selected_and_promotion_supersedes_the_prior_one`.)
+#[test]
+fn unreliable_selection_prefers_live_inbound_without_companion_dial() {
+  let (mut client, _server, cfg) = quinn_pair();
+  let mut t = ConnTable::new();
+  let now = Instant::now();
+
+  // U4: a live handshaking inbound, no outbound → return the inbound, no dial.
+  let p1: SocketAddr = "127.0.0.1:4433".parse().unwrap();
+  let i1 = accept_inbound(
+    &mut t,
+    &mut client,
+    &cfg,
+    now,
+    p1,
+    "127.0.0.1:4500".parse().unwrap(),
+  );
+  let before = t.conns.len();
+  let sel = t
+    .get_or_dial(
+      &mut client,
+      now,
+      cfg.client().clone(),
+      p1,
+      "localhost",
+      None,
+      Reliability::Unreliable,
+    )
+    .unwrap();
+  assert_eq!(sel, i1, "U4 returns the live handshaking inbound");
+  assert_eq!(
+    t.conns.len(),
+    before,
+    "U4 never creates a companion outbound beside a live inbound"
+  );
+
+  // U4 behind a terminal outbound: a live handshaking inbound is found even
+  // though a closed never-established outbound occupies the outbound field.
+  let p2: SocketAddr = "127.0.0.1:4444".parse().unwrap();
+  let o = dial_reliable(&mut t, &mut client, &cfg, now, p2).unwrap();
+  t.get_mut(o)
+    .unwrap()
+    .conn_mut()
+    .close(now.into_std(), 0u32.into(), bytes::Bytes::new());
+  let i2 = accept_inbound(
+    &mut t,
+    &mut client,
+    &cfg,
+    now,
+    p2,
+    "127.0.0.1:4600".parse().unwrap(),
+  );
+  let sel2 = t
+    .get_or_dial(
+      &mut client,
+      now,
+      cfg.client().clone(),
+      p2,
+      "localhost",
+      None,
+      Reliability::Unreliable,
+    )
+    .unwrap();
+  assert_eq!(
+    sel2, i2,
+    "U4 returns the live handshaking inbound even behind a terminal outbound"
+  );
+
+  // U5: a terminal outbound with no inbound → the outbound (→ NotReady → UDP).
+  let p3: SocketAddr = "127.0.0.1:4455".parse().unwrap();
+  let o3 = dial_reliable(&mut t, &mut client, &cfg, now, p3).unwrap();
+  t.get_mut(o3)
+    .unwrap()
+    .conn_mut()
+    .close(now.into_std(), 0u32.into(), bytes::Bytes::new());
+  let sel3 = t
+    .get_or_dial(
+      &mut client,
+      now,
+      cfg.client().clone(),
+      p3,
+      "localhost",
+      None,
+      Reliability::Unreliable,
+    )
+    .unwrap();
+  assert_eq!(
+    sel3, o3,
+    "U5 returns the terminal outbound; the datagram path then falls back to UDP"
+  );
+}
+
+/// A route the pre-pass empties (its only tracked connection pruned) leaves no
+/// `peer_routes` entry.
+///
+/// Negative control: drop the F4 empty-route removal — the route lingers as a
+/// `PeerRoute` with both fields `None` and the `!contains_key` assertion fails.
+#[test]
+fn prepass_removes_a_route_left_fully_empty() {
+  let (mut client, _server, cfg) = quinn_pair();
+  let mut t = ConnTable::new();
+  let now = Instant::now();
+  let peer: SocketAddr = "127.0.0.1:4433".parse().unwrap();
+  // Only a closed never-established inbound → route.inbound set, no outbound.
+  let dead = accept_inbound(
+    &mut t,
+    &mut client,
+    &cfg,
+    now,
+    peer,
+    "127.0.0.1:4500".parse().unwrap(),
+  );
+  t.get_mut(dead)
+    .unwrap()
+    .conn_mut()
+    .close(now.into_std(), 0u32.into(), bytes::Bytes::new());
+  assert!(t.peer_routes.contains_key(&peer));
+
+  // A reliable intent AT the global cap: the pre-pass prunes the dead inbound,
+  // emptying the route (F4 removes it); the fresh dial is then refused at the
+  // cap, so nothing recreates the route.
+  let err = t
+    .get_or_dial(
+      &mut client,
+      now,
+      cfg.client().clone(),
+      peer,
+      "localhost",
+      Some(1),
+      Reliability::Reliable,
+    )
+    .expect_err("the fresh dial is refused at the global cap");
+  assert!(matches!(err, DialError::AtGlobalCap));
+  assert!(
+    !t.peer_routes.contains_key(&peer),
+    "a route the pre-pass emptied leaves no peer_routes entry"
+  );
 }

--- a/memberlist-proto/src/quic/conn/tests.rs
+++ b/memberlist-proto/src/quic/conn/tests.rs
@@ -1197,19 +1197,18 @@ fn closed_inbound_is_non_authoritative_and_triggers_a_fresh_outbound_dial() {
   );
 }
 
-/// An accept tracks the freshest inbound by generation: a newer inbound Y
-/// accepted while an older X is live becomes `route.inbound` immediately (Y is
-/// newest-created), the derived selection surfaces Y (not the stale X), the
-/// establishment chokepoint keeps Y, and Y stays discoverable after X is reaped.
+/// An accept never displaces a LIVE tracked inbound: a newer inbound Y accepted
+/// while an older X is live (handshaking) does NOT overwrite `route.inbound` —
+/// an accept proves only that an Initial arrived, not that the remote instance
+/// is alive. Y becomes the tracked inbound only once it establishes (the
+/// establishment chokepoint promotes the fresher connection), after which
+/// selection surfaces Y and Y stays discoverable when X is reaped.
 ///
-/// Negative control: revert `insert_accepted` to never overwrite a live inbound
-/// — Y is not tracked at accept and the `route.inbound == Y` assertion fails.
-/// (The delayed-establishment freshness guard is pinned separately by
-/// `on_established_transition_rejects_a_delayed_older_inbound`; the end-to-end
-/// established-selection by
-/// `established_inbound_selected_and_promotion_supersedes_the_prior_one`.)
+/// Negative control: restore the accept-time displacement in `insert_accepted`
+/// (`|| generation > e.generation`) — Y then displaces the live X at accept and
+/// the `route.inbound == Some(x)` assertion fails.
 #[test]
-fn accept_tracks_the_freshest_inbound_by_generation() {
+fn accept_does_not_displace_a_live_inbound() {
   let (mut client, _server, cfg) = quinn_pair();
   let mut t = ConnTable::new();
   let now = Instant::now();
@@ -1226,8 +1225,8 @@ fn accept_tracks_the_freshest_inbound_by_generation() {
   assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(x));
   assert_eq!(t.handle_for(&peer), Some(x));
 
-  // A NEWER inbound Y accepted while X is live (not closed) → tracked at accept
-  // (Y is newest-created, so it is fresher than the live older X).
+  // A NEWER inbound Y accepted while X is live (not closed) → X is NOT displaced;
+  // the tracked inbound stays X even though Y has a greater generation.
   let y = accept_inbound(
     &mut t,
     &mut client,
@@ -1242,21 +1241,21 @@ fn accept_tracks_the_freshest_inbound_by_generation() {
   );
   assert_eq!(
     t.peer_routes.get(&peer).and_then(|r| r.inbound),
-    Some(y),
-    "the freshest inbound is tracked at accept, displacing the older live one"
-  );
-  assert_eq!(
-    t.handle_for(&peer),
-    Some(y),
-    "selection surfaces the freshest inbound"
+    Some(x),
+    "an accept does not displace a live tracked inbound"
   );
 
-  // Y reaches the establishment chokepoint → promotion keeps route.inbound = Y.
+  // Y establishes → the chokepoint promotes the fresher connection to tracked.
   t.on_established_transition(y);
   assert_eq!(
     t.peer_routes.get(&peer).and_then(|r| r.inbound),
     Some(y),
-    "establishment keeps the freshest inbound tracked"
+    "establishment promotes the fresher inbound"
+  );
+  assert_eq!(
+    t.handle_for(&peer),
+    Some(y),
+    "selection surfaces the promoted inbound"
   );
 
   // After X is removed, Y is still discoverable.
@@ -1269,7 +1268,7 @@ fn accept_tracks_the_freshest_inbound_by_generation() {
   assert_eq!(
     t.handle_for(&peer),
     Some(y),
-    "the freshest inbound remains discoverable after the older one is reaped"
+    "the promoted inbound remains discoverable after the older one is reaped"
   );
 }
 
@@ -1296,7 +1295,8 @@ fn on_established_transition_rejects_a_delayed_older_inbound() {
     peer,
     "127.0.0.1:4500".parse().unwrap(),
   );
-  // Y accepted second (newer generation) — the post-restart inbound; tracked.
+  // Y accepted second (newer generation) — the post-restart inbound. The live X
+  // is not displaced at accept, so the tracked inbound is still X.
   let y = accept_inbound(
     &mut t,
     &mut client,
@@ -1306,9 +1306,9 @@ fn on_established_transition_rejects_a_delayed_older_inbound() {
     "127.0.0.1:4501".parse().unwrap(),
   );
   assert!(t.conns.get(y.0).unwrap().generation > t.conns.get(x.0).unwrap().generation);
-  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(y));
+  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(x));
 
-  // Y establishes → stays tracked.
+  // Y establishes → the chokepoint promotes the fresher connection to tracked.
   t.on_established_transition(y);
   assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(y));
 
@@ -1458,6 +1458,87 @@ fn freshest_established_wins_over_a_same_class_zombie() {
   );
 }
 
+/// A proven-live route (an older established outbound O plus a fresher
+/// established inbound Y, tracked) must not be knocked off by a LATE accepted
+/// handshaking X (a delayed pre-crash Initial, newest generation). The accept
+/// does not displace the live Y, so every plane keeps selecting the fresher
+/// established Y — even though X outranks Y by generation, X has not proven
+/// liveness. When X later closes and reaps, Y stays tracked.
+///
+/// Negative control: restore the accept-time displacement in `insert_accepted`
+/// (`|| generation > e.generation`) — X (newest generation) displaces the live Y
+/// at accept, so `route.inbound` becomes the handshaking X, selection falls back
+/// to the established outbound O, and the `== y` assertions fail.
+#[test]
+fn a_late_accept_does_not_knock_a_proven_live_route_off_the_fresh_inbound() {
+  let (mut client, _server, cfg) = quinn_pair();
+  let mut t = ConnTable::new();
+  let now = Instant::now();
+  let peer: SocketAddr = FERRY_SERVER_ADDR.parse().unwrap();
+  // Older established outbound O (created first → lower generation).
+  let o = establish_outbound(&mut t, &mut client, &cfg, peer);
+  // Fresher established inbound Y for the same peer (tracked at accept because the
+  // inbound slot was empty).
+  let remote_y: SocketAddr = "127.0.0.1:5002".parse().unwrap();
+  let y = establish_client_dialed_as_inbound(&mut t, &mut client, &cfg, peer, remote_y);
+  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.outbound), Some(o));
+  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(y));
+
+  // A LATE accepted handshaking X (newest generation) — a delayed pre-crash
+  // Initial. It does NOT displace the live Y at accept.
+  let x = accept_inbound(
+    &mut t,
+    &mut client,
+    &cfg,
+    now,
+    peer,
+    "127.0.0.1:4700".parse().unwrap(),
+  );
+  assert!(t.conns.get(x.0).unwrap().generation > t.conns.get(y.0).unwrap().generation);
+  assert!(t.conns.get(x.0).unwrap().conn_ref().is_handshaking());
+  assert_eq!(
+    t.peer_routes.get(&peer).and_then(|r| r.inbound),
+    Some(y),
+    "the late accept does not displace the proven-live inbound"
+  );
+
+  // Every plane keeps selecting the fresher established inbound Y.
+  assert_eq!(
+    dial_reliable(&mut t, &mut client, &cfg, now, peer).unwrap(),
+    y,
+    "reliable selection stays on the fresher established inbound"
+  );
+  assert_eq!(
+    t.get_or_dial(
+      &mut client,
+      now,
+      cfg.client().clone(),
+      peer,
+      "localhost",
+      None,
+      Reliability::Unreliable,
+    )
+    .unwrap(),
+    y,
+    "unreliable selection stays on the fresher established inbound"
+  );
+  assert_eq!(t.handle_for(&peer), Some(y), "handle_for stays on Y");
+
+  // X closes and reaps → Y (in neither field changed) stays tracked.
+  t.get_mut(x)
+    .unwrap()
+    .conn_mut()
+    .close(now.into_std(), 0u32.into(), bytes::Bytes::new());
+  drive_to_drained(&mut t, x);
+  assert!(t.reap_if_drained(&mut client, x));
+  assert_eq!(
+    t.peer_routes.get(&peer).and_then(|r| r.inbound),
+    Some(y),
+    "reaping the late X leaves Y tracked"
+  );
+  assert_eq!(t.handle_for(&peer), Some(y));
+}
+
 /// A real established INBOUND is selected on both planes (R2 / U2), and a newer
 /// inbound that establishes while it is live is declined at accept, then
 /// promoted at the establishment chokepoint so selection follows to the newest
@@ -1497,23 +1578,24 @@ fn established_inbound_selected_and_promotion_supersedes_the_prior_one() {
     "U2 selects the established inbound"
   );
 
-  // A NEWER inbound Y establishes while X is live → tracked at accept (freshest
-  // by generation), so selection follows to Y over the older established X.
+  // A NEWER inbound Y is accepted+established while X is live → NOT displaced at
+  // accept (X stays tracked); the promotion at the establishment chokepoint is
+  // what moves selection to the fresher Y.
   let y = establish_inbound(&mut t, &mut server, &mut client, &cfg);
   assert_ne!(x, y);
   assert!(t.conns.get(y.0).unwrap().generation > t.conns.get(x.0).unwrap().generation);
   assert_eq!(
     t.peer_routes.get(&peer).and_then(|r| r.inbound),
-    Some(y),
-    "the freshest inbound is tracked at accept over the older live one"
+    Some(x),
+    "a new inbound is not tracked at accept while the prior one is live"
   );
 
-  // The establishment chokepoint keeps the freshest inbound.
+  // The establishment chokepoint promotes the fresher established inbound.
   t.on_established_transition(y);
   assert_eq!(
     t.peer_routes.get(&peer).and_then(|r| r.inbound),
     Some(y),
-    "establishment keeps the freshest inbound tracked"
+    "establishment promotes the fresher inbound over the prior one"
   );
   let sel2 = dial_reliable(&mut t, &mut client, &cfg, now, peer).unwrap();
   assert_eq!(

--- a/memberlist-proto/src/quic/conn/tests.rs
+++ b/memberlist-proto/src/quic/conn/tests.rs
@@ -968,30 +968,27 @@ fn establish_inbound(
   ich
 }
 
-/// Drive a full QUIC handshake so `t` (acting as CLIENT, on `client_ep`) holds a
-/// freshly ESTABLISHED OUTBOUND dialed to `peer`. The peer is a throwaway
-/// server-side `ConnTable` on `server_ep`. Returns the outbound handle in `t`.
-fn establish_outbound(
+/// Drive `ch` — a CLIENT-role connection already inserted in `t` (dialed on
+/// `client_ep` to `remote`) — through a full QUIC handshake to Established by
+/// ferrying datagrams against a throwaway server endpoint built internally, so
+/// callers holding several client-role connections on one `client_ep` (hence one
+/// slab lockstep) can each be established independently.
+fn ferry_client_conn_to_established(
   t: &mut ConnTable,
   client_ep: &mut QuinnEndpoint,
-  server_ep: &mut QuinnEndpoint,
   cfg: &QuicOptions,
-  peer: SocketAddr,
-) -> ConnectionHandle {
+  ch: ConnectionHandle,
+  remote: SocketAddr,
+) {
   use quinn_proto::DatagramEvent;
   let client_addr: SocketAddr = FERRY_CLIENT_ADDR.parse().unwrap();
   let now = Instant::now().into_std();
-  let ch = t
-    .get_or_dial(
-      client_ep,
-      Instant::from_std(now),
-      cfg.client().clone(),
-      peer,
-      "localhost",
-      None,
-      Reliability::Reliable,
-    )
-    .unwrap();
+  let mut server_ep = QuinnEndpoint::new(
+    cfg.endpoint_arc(),
+    Some(cfg.server_arc()),
+    true,
+    Some([0x5a; 32]),
+  );
   let mut server_conns = ConnTable::new();
   let mut server_ch: Option<ConnectionHandle> = None;
   for _ in 0..200 {
@@ -1034,7 +1031,7 @@ fn establish_outbound(
         let data = bytes::BytesMut::from(&sbuf[..tr.size]);
         let mut scratch = Vec::new();
         if let Some(DatagramEvent::ConnectionEvent(rch, cev)) =
-          client_ep.handle(now, peer, None, None, data, &mut scratch)
+          client_ep.handle(now, remote, None, None, data, &mut scratch)
           && rch == ch
         {
           t.get_mut(ch).unwrap().conn_mut().handle_event(cev);
@@ -1090,9 +1087,52 @@ fn establish_outbound(
     }
   }
   assert!(
-    !t.get(ch).unwrap().conn_ref().is_handshaking(),
-    "the outbound must reach Established"
+    !t.get(ch).unwrap().conn_ref().is_handshaking() && !t.get(ch).unwrap().conn_ref().is_closed(),
+    "the connection must reach Established"
   );
+}
+
+/// Establish a real OUTBOUND connection in `t` (t as CLIENT) dialed to `peer`.
+fn establish_outbound(
+  t: &mut ConnTable,
+  client_ep: &mut QuinnEndpoint,
+  cfg: &QuicOptions,
+  peer: SocketAddr,
+) -> ConnectionHandle {
+  let now = Instant::now();
+  let ch = t
+    .get_or_dial(
+      client_ep,
+      now,
+      cfg.client().clone(),
+      peer,
+      "localhost",
+      None,
+      Reliability::Reliable,
+    )
+    .unwrap();
+  ferry_client_conn_to_established(t, client_ep, cfg, ch, peer);
+  ch
+}
+
+/// Establish a real connection in `t` that is LABELLED inbound (via
+/// `insert_accepted`) but dialed on `client_ep` to `remote`, so it can coexist
+/// with a client-dialed outbound in the SAME `t` under one slab lockstep. Used
+/// to build a peer whose route holds BOTH an established outbound and an
+/// established inbound.
+fn establish_client_dialed_as_inbound(
+  t: &mut ConnTable,
+  client_ep: &mut QuinnEndpoint,
+  cfg: &QuicOptions,
+  peer: SocketAddr,
+  remote: SocketAddr,
+) -> ConnectionHandle {
+  let now = Instant::now().into_std();
+  let (ch, conn) = client_ep
+    .connect(now, cfg.client().clone(), remote, "localhost")
+    .expect("client dial for the inbound-labelled connection");
+  t.insert_accepted(ch, conn, peer);
+  ferry_client_conn_to_established(t, client_ep, cfg, ch, remote);
   ch
 }
 
@@ -1157,21 +1197,19 @@ fn closed_inbound_is_non_authoritative_and_triggers_a_fresh_outbound_dial() {
   );
 }
 
-/// Establishment-chokepoint promotion (the crash-restart class). An inbound X
-/// is the tracked inbound; a NEW inbound Y accepted while X is live is declined
-/// at accept (X stays the tracked inbound); when Y establishes the promotion
-/// sets `route.inbound = Y` (newest-established-inbound wins), so the derived
-/// selection surfaces Y — not the stale X — and Y stays discoverable after X is
-/// reaped.
+/// An accept tracks the freshest inbound by generation: a newer inbound Y
+/// accepted while an older X is live becomes `route.inbound` immediately (Y is
+/// newest-created), the derived selection surfaces Y (not the stale X), the
+/// establishment chokepoint keeps Y, and Y stays discoverable after X is reaped.
 ///
-/// Negative controls: without the establishment write (revert the inbound arm
-/// of `on_established_transition`), the selection keeps surfacing the stale X;
-/// without the accept guard (`insert_accepted` always overwrites), Y would
-/// wrongly become the tracked inbound the moment it is accepted. (The
-/// end-to-end established-selection is additionally covered by
+/// Negative control: revert `insert_accepted` to never overwrite a live inbound
+/// — Y is not tracked at accept and the `route.inbound == Y` assertion fails.
+/// (The delayed-establishment freshness guard is pinned separately by
+/// `on_established_transition_rejects_a_delayed_older_inbound`; the end-to-end
+/// established-selection by
 /// `established_inbound_selected_and_promotion_supersedes_the_prior_one`.)
 #[test]
-fn establishment_promotes_the_newest_inbound_over_a_live_prior_one() {
+fn accept_tracks_the_freshest_inbound_by_generation() {
   let (mut client, _server, cfg) = quinn_pair();
   let mut t = ConnTable::new();
   let now = Instant::now();
@@ -1188,7 +1226,8 @@ fn establishment_promotes_the_newest_inbound_over_a_live_prior_one() {
   assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(x));
   assert_eq!(t.handle_for(&peer), Some(x));
 
-  // A NEW inbound Y accepted while X is live (not closed) → declined at accept.
+  // A NEWER inbound Y accepted while X is live (not closed) → tracked at accept
+  // (Y is newest-created, so it is fresher than the live older X).
   let y = accept_inbound(
     &mut t,
     &mut client,
@@ -1197,24 +1236,27 @@ fn establishment_promotes_the_newest_inbound_over_a_live_prior_one() {
     peer,
     "127.0.0.1:4501".parse().unwrap(),
   );
+  assert!(
+    t.conns.get(y.0).unwrap().generation > t.conns.get(x.0).unwrap().generation,
+    "the later accept has a strictly greater generation"
+  );
   assert_eq!(
     t.peer_routes.get(&peer).and_then(|r| r.inbound),
-    Some(x),
-    "a new inbound accepted while an inbound is live is declined at accept"
+    Some(y),
+    "the freshest inbound is tracked at accept, displacing the older live one"
+  );
+  assert_eq!(
+    t.handle_for(&peer),
+    Some(y),
+    "selection surfaces the freshest inbound"
   );
 
-  // Y reaches the establishment chokepoint → promotion sets route.inbound = Y.
+  // Y reaches the establishment chokepoint → promotion keeps route.inbound = Y.
   t.on_established_transition(y);
   assert_eq!(
     t.peer_routes.get(&peer).and_then(|r| r.inbound),
     Some(y),
-    "the newly-established inbound is promoted over the prior one"
-  );
-  // The derived selection surfaces the promoted Y, not the stale X.
-  assert_eq!(
-    t.handle_for(&peer),
-    Some(y),
-    "selection surfaces the promoted inbound, not the stale one"
+    "establishment keeps the freshest inbound tracked"
   );
 
   // After X is removed, Y is still discoverable.
@@ -1227,7 +1269,61 @@ fn establishment_promotes_the_newest_inbound_over_a_live_prior_one() {
   assert_eq!(
     t.handle_for(&peer),
     Some(y),
-    "the promoted inbound remains discoverable after the prior one is reaped"
+    "the freshest inbound remains discoverable after the older one is reaped"
+  );
+}
+
+/// F1 delayed-pre-crash: a delayed pre-crash inbound X (older generation) that
+/// finishes its handshake AFTER a fresher post-restart inbound Y is already
+/// tracked must NOT overwrite Y. Freshness is CREATION order, not establishment
+/// order — `on_established_transition` rejects the stale late establishment.
+///
+/// Negative control: drop the `>=` generation guard in the inbound arm of
+/// `on_established_transition` (unconditional set) — the late X overwrites Y and
+/// both the `route.inbound == Y` and `handle_for == Y` assertions fail.
+#[test]
+fn on_established_transition_rejects_a_delayed_older_inbound() {
+  let (mut client, _server, cfg) = quinn_pair();
+  let mut t = ConnTable::new();
+  let now = Instant::now();
+  let peer: SocketAddr = "127.0.0.1:4433".parse().unwrap();
+  // X accepted first (older generation) — the pre-crash inbound.
+  let x = accept_inbound(
+    &mut t,
+    &mut client,
+    &cfg,
+    now,
+    peer,
+    "127.0.0.1:4500".parse().unwrap(),
+  );
+  // Y accepted second (newer generation) — the post-restart inbound; tracked.
+  let y = accept_inbound(
+    &mut t,
+    &mut client,
+    &cfg,
+    now,
+    peer,
+    "127.0.0.1:4501".parse().unwrap(),
+  );
+  assert!(t.conns.get(y.0).unwrap().generation > t.conns.get(x.0).unwrap().generation);
+  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(y));
+
+  // Y establishes → stays tracked.
+  t.on_established_transition(y);
+  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(y));
+
+  // X's handshake finishes LATE (older generation) → rejected, does NOT
+  // overwrite the fresher Y.
+  t.on_established_transition(x);
+  assert_eq!(
+    t.peer_routes.get(&peer).and_then(|r| r.inbound),
+    Some(y),
+    "a delayed older inbound must not overwrite the fresher tracked inbound"
+  );
+  assert_eq!(
+    t.handle_for(&peer),
+    Some(y),
+    "selection stays on the fresher inbound"
   );
 }
 
@@ -1283,12 +1379,12 @@ fn reliable_r6_at_cap_returns_the_live_inbound_not_an_error() {
 /// matched, the reliable table trips its fresh-dial guard, and `sel == o` fails.
 #[test]
 fn established_outbound_precedes_a_live_inbound() {
-  let (mut client, mut server, cfg) = quinn_pair();
+  let (mut client, _server, cfg) = quinn_pair();
   let mut t = ConnTable::new();
   let now = Instant::now();
   let peer: SocketAddr = FERRY_SERVER_ADDR.parse().unwrap();
   // A real established outbound O (drives a full handshake).
-  let o = establish_outbound(&mut t, &mut client, &mut server, &cfg, peer);
+  let o = establish_outbound(&mut t, &mut client, &cfg, peer);
   // A live handshaking inbound I for the same peer.
   let i = accept_inbound(
     &mut t,
@@ -1304,6 +1400,61 @@ fn established_outbound_precedes_a_live_inbound() {
   assert_eq!(
     sel, o,
     "R1 (established outbound) is selected over a live inbound; no wedge"
+  );
+}
+
+/// F2 both-established hard-restart: a peer whose route holds an established
+/// OUTBOUND with an OLDER generation (a zombie to the peer's dead prior instance)
+/// and an established INBOUND with a NEWER generation (from the restarted peer).
+/// The freshest-usable tiebreak must return the fresher inbound on the reliable
+/// plane, the unreliable plane, and `handle_for` — not the stale outbound that
+/// R1 would rank first.
+///
+/// Negative control: remove the both-established generation tiebreak (R1/U1
+/// unconditional; `handle_for` fixed outbound-before-inbound) — every selection
+/// returns the stale outbound and the `== i` assertions fail.
+#[test]
+fn freshest_established_wins_over_a_same_class_zombie() {
+  let (mut client, _server, cfg) = quinn_pair();
+  let mut t = ConnTable::new();
+  let now = Instant::now();
+  let peer: SocketAddr = FERRY_SERVER_ADDR.parse().unwrap();
+  // Older established outbound O (created first → lower generation).
+  let o = establish_outbound(&mut t, &mut client, &cfg, peer);
+  // Newer established inbound I for the SAME peer (created second → higher
+  // generation), dialed to a distinct transport address but labelled inbound.
+  let remote_i: SocketAddr = "127.0.0.1:5002".parse().unwrap();
+  let i = establish_client_dialed_as_inbound(&mut t, &mut client, &cfg, peer, remote_i);
+  assert!(
+    t.conns.get(i.0).unwrap().generation > t.conns.get(o.0).unwrap().generation,
+    "the inbound was created later, so it is fresher"
+  );
+  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.outbound), Some(o));
+  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(i));
+
+  assert_eq!(
+    dial_reliable(&mut t, &mut client, &cfg, now, peer).unwrap(),
+    i,
+    "reliable selection returns the fresher established inbound, not the zombie outbound"
+  );
+  assert_eq!(
+    t.get_or_dial(
+      &mut client,
+      now,
+      cfg.client().clone(),
+      peer,
+      "localhost",
+      None,
+      Reliability::Unreliable,
+    )
+    .unwrap(),
+    i,
+    "unreliable selection returns the fresher established inbound"
+  );
+  assert_eq!(
+    t.handle_for(&peer),
+    Some(i),
+    "handle_for returns the fresher established inbound"
   );
 }
 
@@ -1346,26 +1497,28 @@ fn established_inbound_selected_and_promotion_supersedes_the_prior_one() {
     "U2 selects the established inbound"
   );
 
-  // A NEW inbound Y establishes while X is live → declined at accept.
+  // A NEWER inbound Y establishes while X is live → tracked at accept (freshest
+  // by generation), so selection follows to Y over the older established X.
   let y = establish_inbound(&mut t, &mut server, &mut client, &cfg);
   assert_ne!(x, y);
+  assert!(t.conns.get(y.0).unwrap().generation > t.conns.get(x.0).unwrap().generation);
   assert_eq!(
     t.peer_routes.get(&peer).and_then(|r| r.inbound),
-    Some(x),
-    "a new inbound accepted while X is live is declined at accept"
+    Some(y),
+    "the freshest inbound is tracked at accept over the older live one"
   );
 
-  // Y reaches the establishment chokepoint → promotion sets route.inbound = Y.
+  // The establishment chokepoint keeps the freshest inbound.
   t.on_established_transition(y);
   assert_eq!(
     t.peer_routes.get(&peer).and_then(|r| r.inbound),
     Some(y),
-    "the newly-established inbound is promoted over the prior one"
+    "establishment keeps the freshest inbound tracked"
   );
   let sel2 = dial_reliable(&mut t, &mut client, &cfg, now, peer).unwrap();
   assert_eq!(
     sel2, y,
-    "selection follows to the promoted established inbound (R2), not the stale X"
+    "selection follows to the freshest established inbound (R2), not the older X"
   );
 }
 

--- a/memberlist-proto/src/quic/conn/tests.rs
+++ b/memberlist-proto/src/quic/conn/tests.rs
@@ -1115,27 +1115,6 @@ fn establish_outbound(
   ch
 }
 
-/// Establish a real connection in `t` that is LABELLED inbound (via
-/// `insert_accepted`) but dialed on `client_ep` to `remote`, so it can coexist
-/// with a client-dialed outbound in the SAME `t` under one slab lockstep. Used
-/// to build a peer whose route holds BOTH an established outbound and an
-/// established inbound.
-fn establish_client_dialed_as_inbound(
-  t: &mut ConnTable,
-  client_ep: &mut QuinnEndpoint,
-  cfg: &QuicOptions,
-  peer: SocketAddr,
-  remote: SocketAddr,
-) -> ConnectionHandle {
-  let now = Instant::now().into_std();
-  let (ch, conn) = client_ep
-    .connect(now, cfg.client().clone(), remote, "localhost")
-    .expect("client dial for the inbound-labelled connection");
-  t.insert_accepted(ch, conn, peer);
-  ferry_client_conn_to_established(t, client_ep, cfg, ch, remote);
-  ch
-}
-
 /// Asymmetric-reachability fix: a closed never-established INBOUND (the peer's
 /// failed dial toward us) is non-authoritative — it says nothing about our
 /// egress. A reliable intent must dial our OWN independent outbound, and the
@@ -1197,16 +1176,16 @@ fn closed_inbound_is_non_authoritative_and_triggers_a_fresh_outbound_dial() {
   );
 }
 
-/// An accept never displaces a LIVE tracked inbound: a newer inbound Y accepted
-/// while an older X is live (handshaking) does NOT overwrite `route.inbound` —
-/// an accept proves only that an Initial arrived, not that the remote instance
-/// is alive. Y becomes the tracked inbound only once it establishes (the
-/// establishment chokepoint promotes the fresher connection), after which
+/// An accept never displaces a LIVE tracked inbound: a second inbound Y accepted
+/// while X is live (handshaking) does NOT overwrite `route.inbound` — an accept
+/// proves only that an Initial arrived, not that the remote instance is alive. Y
+/// becomes the tracked inbound only once it establishes (the establishment
+/// chokepoint promotes the most recently established inbound), after which
 /// selection surfaces Y and Y stays discoverable when X is reaped.
 ///
-/// Negative control: restore the accept-time displacement in `insert_accepted`
-/// (`|| generation > e.generation`) — Y then displaces the live X at accept and
-/// the `route.inbound == Some(x)` assertion fails.
+/// Negative control: make `insert_accepted` overwrite unconditionally — Y then
+/// displaces the live X at accept and the `route.inbound == Some(x)` assertion
+/// fails.
 #[test]
 fn accept_does_not_displace_a_live_inbound() {
   let (mut client, _server, cfg) = quinn_pair();
@@ -1225,8 +1204,8 @@ fn accept_does_not_displace_a_live_inbound() {
   assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(x));
   assert_eq!(t.handle_for(&peer), Some(x));
 
-  // A NEWER inbound Y accepted while X is live (not closed) → X is NOT displaced;
-  // the tracked inbound stays X even though Y has a greater generation.
+  // A second inbound Y accepted while X is live (not closed) → X is NOT displaced;
+  // the tracked inbound stays X.
   let y = accept_inbound(
     &mut t,
     &mut client,
@@ -1235,22 +1214,18 @@ fn accept_does_not_displace_a_live_inbound() {
     peer,
     "127.0.0.1:4501".parse().unwrap(),
   );
-  assert!(
-    t.conns.get(y.0).unwrap().generation > t.conns.get(x.0).unwrap().generation,
-    "the later accept has a strictly greater generation"
-  );
   assert_eq!(
     t.peer_routes.get(&peer).and_then(|r| r.inbound),
     Some(x),
     "an accept does not displace a live tracked inbound"
   );
 
-  // Y establishes → the chokepoint promotes the fresher connection to tracked.
+  // Y establishes → the chokepoint promotes the most recently established inbound.
   t.on_established_transition(y);
   assert_eq!(
     t.peer_routes.get(&peer).and_then(|r| r.inbound),
     Some(y),
-    "establishment promotes the fresher inbound"
+    "establishment promotes the newly-established inbound"
   );
   assert_eq!(
     t.handle_for(&peer),
@@ -1269,61 +1244,6 @@ fn accept_does_not_displace_a_live_inbound() {
     t.handle_for(&peer),
     Some(y),
     "the promoted inbound remains discoverable after the older one is reaped"
-  );
-}
-
-/// F1 delayed-pre-crash: a delayed pre-crash inbound X (older generation) that
-/// finishes its handshake AFTER a fresher post-restart inbound Y is already
-/// tracked must NOT overwrite Y. Freshness is CREATION order, not establishment
-/// order — `on_established_transition` rejects the stale late establishment.
-///
-/// Negative control: drop the `>=` generation guard in the inbound arm of
-/// `on_established_transition` (unconditional set) — the late X overwrites Y and
-/// both the `route.inbound == Y` and `handle_for == Y` assertions fail.
-#[test]
-fn on_established_transition_rejects_a_delayed_older_inbound() {
-  let (mut client, _server, cfg) = quinn_pair();
-  let mut t = ConnTable::new();
-  let now = Instant::now();
-  let peer: SocketAddr = "127.0.0.1:4433".parse().unwrap();
-  // X accepted first (older generation) — the pre-crash inbound.
-  let x = accept_inbound(
-    &mut t,
-    &mut client,
-    &cfg,
-    now,
-    peer,
-    "127.0.0.1:4500".parse().unwrap(),
-  );
-  // Y accepted second (newer generation) — the post-restart inbound. The live X
-  // is not displaced at accept, so the tracked inbound is still X.
-  let y = accept_inbound(
-    &mut t,
-    &mut client,
-    &cfg,
-    now,
-    peer,
-    "127.0.0.1:4501".parse().unwrap(),
-  );
-  assert!(t.conns.get(y.0).unwrap().generation > t.conns.get(x.0).unwrap().generation);
-  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(x));
-
-  // Y establishes → the chokepoint promotes the fresher connection to tracked.
-  t.on_established_transition(y);
-  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(y));
-
-  // X's handshake finishes LATE (older generation) → rejected, does NOT
-  // overwrite the fresher Y.
-  t.on_established_transition(x);
-  assert_eq!(
-    t.peer_routes.get(&peer).and_then(|r| r.inbound),
-    Some(y),
-    "a delayed older inbound must not overwrite the fresher tracked inbound"
-  );
-  assert_eq!(
-    t.handle_for(&peer),
-    Some(y),
-    "selection stays on the fresher inbound"
   );
 }
 
@@ -1403,140 +1323,74 @@ fn established_outbound_precedes_a_live_inbound() {
   );
 }
 
-/// F2 both-established hard-restart: a peer whose route holds an established
-/// OUTBOUND with an OLDER generation (a zombie to the peer's dead prior instance)
-/// and an established INBOUND with a NEWER generation (from the restarted peer).
-/// The freshest-usable tiebreak must return the fresher inbound on the reliable
-/// plane, the unreliable plane, and `handle_for` — not the stale outbound that
-/// R1 would rank first.
-///
-/// Negative control: remove the both-established generation tiebreak (R1/U1
-/// unconditional; `handle_for` fixed outbound-before-inbound) — every selection
-/// returns the stale outbound and the `== i` assertions fail.
+/// The self-healing residual the transport layer deliberately accepts: a delayed
+/// inbound that establishes into an EMPTY route is promoted (unconditionally, the
+/// most recently established inbound wins), and even if it is a zombie to a dead
+/// prior instance it is bounded — once it idle-reaps the route empties and a
+/// subsequent fresh reliable dial proceeds. No permanent wedge; the route
+/// recovers.
 #[test]
-fn freshest_established_wins_over_a_same_class_zombie() {
+fn established_inbound_into_empty_route_promotes_then_self_heals_on_reap() {
   let (mut client, _server, cfg) = quinn_pair();
   let mut t = ConnTable::new();
   let now = Instant::now();
-  let peer: SocketAddr = FERRY_SERVER_ADDR.parse().unwrap();
-  // Older established outbound O (created first → lower generation).
-  let o = establish_outbound(&mut t, &mut client, &cfg, peer);
-  // Newer established inbound I for the SAME peer (created second → higher
-  // generation), dialed to a distinct transport address but labelled inbound.
-  let remote_i: SocketAddr = "127.0.0.1:5002".parse().unwrap();
-  let i = establish_client_dialed_as_inbound(&mut t, &mut client, &cfg, peer, remote_i);
-  assert!(
-    t.conns.get(i.0).unwrap().generation > t.conns.get(o.0).unwrap().generation,
-    "the inbound was created later, so it is fresher"
-  );
-  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.outbound), Some(o));
-  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(i));
+  let peer: SocketAddr = "127.0.0.1:4433".parse().unwrap();
 
-  assert_eq!(
-    dial_reliable(&mut t, &mut client, &cfg, now, peer).unwrap(),
-    i,
-    "reliable selection returns the fresher established inbound, not the zombie outbound"
-  );
-  assert_eq!(
-    t.get_or_dial(
-      &mut client,
-      now,
-      cfg.client().clone(),
-      peer,
-      "localhost",
-      None,
-      Reliability::Unreliable,
-    )
-    .unwrap(),
-    i,
-    "unreliable selection returns the fresher established inbound"
-  );
-  assert_eq!(
-    t.handle_for(&peer),
-    Some(i),
-    "handle_for returns the fresher established inbound"
-  );
-}
-
-/// A proven-live route (an older established outbound O plus a fresher
-/// established inbound Y, tracked) must not be knocked off by a LATE accepted
-/// handshaking X (a delayed pre-crash Initial, newest generation). The accept
-/// does not displace the live Y, so every plane keeps selecting the fresher
-/// established Y — even though X outranks Y by generation, X has not proven
-/// liveness. When X later closes and reaps, Y stays tracked.
-///
-/// Negative control: restore the accept-time displacement in `insert_accepted`
-/// (`|| generation > e.generation`) — X (newest generation) displaces the live Y
-/// at accept, so `route.inbound` becomes the handshaking X, selection falls back
-/// to the established outbound O, and the `== y` assertions fail.
-#[test]
-fn a_late_accept_does_not_knock_a_proven_live_route_off_the_fresh_inbound() {
-  let (mut client, _server, cfg) = quinn_pair();
-  let mut t = ConnTable::new();
-  let now = Instant::now();
-  let peer: SocketAddr = FERRY_SERVER_ADDR.parse().unwrap();
-  // Older established outbound O (created first → lower generation).
-  let o = establish_outbound(&mut t, &mut client, &cfg, peer);
-  // Fresher established inbound Y for the same peer (tracked at accept because the
-  // inbound slot was empty).
-  let remote_y: SocketAddr = "127.0.0.1:5002".parse().unwrap();
-  let y = establish_client_dialed_as_inbound(&mut t, &mut client, &cfg, peer, remote_y);
-  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.outbound), Some(o));
-  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(y));
-
-  // A LATE accepted handshaking X (newest generation) — a delayed pre-crash
-  // Initial. It does NOT displace the live Y at accept.
+  // A delayed inbound X arrives into an EMPTY route (accept fills the empty slot).
   let x = accept_inbound(
     &mut t,
     &mut client,
     &cfg,
     now,
     peer,
-    "127.0.0.1:4700".parse().unwrap(),
+    "127.0.0.1:4500".parse().unwrap(),
   );
-  assert!(t.conns.get(x.0).unwrap().generation > t.conns.get(y.0).unwrap().generation);
-  assert!(t.conns.get(x.0).unwrap().conn_ref().is_handshaking());
+  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(x));
+
+  // It establishes → the chokepoint promotes it unconditionally; selection rides
+  // it (this is the zombie-can-capture-selection residual).
+  t.on_established_transition(x);
+  assert_eq!(t.peer_routes.get(&peer).and_then(|r| r.inbound), Some(x));
   assert_eq!(
-    t.peer_routes.get(&peer).and_then(|r| r.inbound),
-    Some(y),
-    "the late accept does not displace the proven-live inbound"
+    t.handle_for(&peer),
+    Some(x),
+    "the promoted inbound is selected"
   );
 
-  // Every plane keeps selecting the fresher established inbound Y.
-  assert_eq!(
-    dial_reliable(&mut t, &mut client, &cfg, now, peer).unwrap(),
-    y,
-    "reliable selection stays on the fresher established inbound"
-  );
-  assert_eq!(
-    t.get_or_dial(
-      &mut client,
-      now,
-      cfg.client().clone(),
-      peer,
-      "localhost",
-      None,
-      Reliability::Unreliable,
-    )
-    .unwrap(),
-    y,
-    "unreliable selection stays on the fresher established inbound"
-  );
-  assert_eq!(t.handle_for(&peer), Some(y), "handle_for stays on Y");
-
-  // X closes and reaps → Y (in neither field changed) stays tracked.
+  // The idle timeout closes it; its drained-reap empties the route (the bounded
+  // self-heal — no per-peer state survives).
   t.get_mut(x)
     .unwrap()
     .conn_mut()
     .close(now.into_std(), 0u32.into(), bytes::Bytes::new());
   drive_to_drained(&mut t, x);
   assert!(t.reap_if_drained(&mut client, x));
-  assert_eq!(
-    t.peer_routes.get(&peer).and_then(|r| r.inbound),
-    Some(y),
-    "reaping the late X leaves Y tracked"
+  assert_eq!(t.handle_for(&peer), None, "the reaped route is empty");
+  assert!(
+    !t.peer_routes.contains_key(&peer),
+    "no residual route entry"
   );
-  assert_eq!(t.handle_for(&peer), Some(y));
+
+  // A subsequent fresh reliable dial proceeds — the route recovers, no wedge.
+  // (The reaped slab slot is reused, so the new handle value may equal the old
+  // one; recovery is proven by a fresh Outbound connection being dialed, not by
+  // the handle differing.)
+  let fresh = dial_reliable(&mut t, &mut client, &cfg, now, peer)
+    .expect("a fresh reliable dial proceeds after the zombie reaps");
+  assert_eq!(
+    t.conns.len(),
+    1,
+    "exactly the fresh outbound is tracked after recovery"
+  );
+  assert_eq!(
+    t.conns.get(fresh.0).unwrap().direction,
+    ConnDirection::Outbound,
+    "the recovery dial is a self-initiated outbound"
+  );
+  assert_eq!(
+    t.peer_routes.get(&peer).and_then(|r| r.outbound),
+    Some(fresh)
+  );
 }
 
 /// A real established INBOUND is selected on both planes (R2 / U2), and a newer
@@ -1578,29 +1432,28 @@ fn established_inbound_selected_and_promotion_supersedes_the_prior_one() {
     "U2 selects the established inbound"
   );
 
-  // A NEWER inbound Y is accepted+established while X is live → NOT displaced at
+  // A second inbound Y is accepted+established while X is live → NOT displaced at
   // accept (X stays tracked); the promotion at the establishment chokepoint is
-  // what moves selection to the fresher Y.
+  // what moves selection to the newly-established Y.
   let y = establish_inbound(&mut t, &mut server, &mut client, &cfg);
   assert_ne!(x, y);
-  assert!(t.conns.get(y.0).unwrap().generation > t.conns.get(x.0).unwrap().generation);
   assert_eq!(
     t.peer_routes.get(&peer).and_then(|r| r.inbound),
     Some(x),
     "a new inbound is not tracked at accept while the prior one is live"
   );
 
-  // The establishment chokepoint promotes the fresher established inbound.
+  // The establishment chokepoint promotes the newly-established inbound.
   t.on_established_transition(y);
   assert_eq!(
     t.peer_routes.get(&peer).and_then(|r| r.inbound),
     Some(y),
-    "establishment promotes the fresher inbound over the prior one"
+    "establishment promotes the newly-established inbound over the prior one"
   );
   let sel2 = dial_reliable(&mut t, &mut client, &cfg, now, peer).unwrap();
   assert_eq!(
     sel2, y,
-    "selection follows to the freshest established inbound (R2), not the older X"
+    "selection follows to the newly-established inbound (R2), not the prior X"
   );
 }
 

--- a/memberlist-proto/src/quic/crypto/mod.rs
+++ b/memberlist-proto/src/quic/crypto/mod.rs
@@ -327,7 +327,12 @@ impl QuicOptions {
   /// direction would be a footgun). The caller controls every other
   /// tunable (`max_idle_timeout`, `stream_receive_window`, MTU
   /// discovery, congestion controller, …) by populating that
-  /// `TransportConfig` before handing it in. The constructor
+  /// `TransportConfig` before handing it in. Leaving `max_idle_timeout`
+  /// finite is recommended: disabling it (a zero transport parameter per
+  /// RFC 9000 §18.2) removes the idle-timeout bound that self-heals a stale
+  /// connection, so a zombie could persist indefinitely; the
+  /// [`QuicConfigOptions::build`](super::config::QuicConfigOptions::build)
+  /// path rejects a zero `max_idle_timeout` for that reason. The constructor
   /// unconditionally forces `max_concurrent_uni_streams = 0` on the
   /// supplied value (mutating it before moving it into a shared `Arc`,
   /// so a caller's surviving `Arc` view cannot accidentally re-enable

--- a/memberlist-proto/src/quic/crypto/mod.rs
+++ b/memberlist-proto/src/quic/crypto/mod.rs
@@ -327,12 +327,20 @@ impl QuicOptions {
   /// direction would be a footgun). The caller controls every other
   /// tunable (`max_idle_timeout`, `stream_receive_window`, MTU
   /// discovery, congestion controller, …) by populating that
-  /// `TransportConfig` before handing it in. Leaving `max_idle_timeout`
-  /// finite is recommended: disabling it (a zero transport parameter per
-  /// RFC 9000 §18.2) removes the idle-timeout bound that self-heals a stale
-  /// connection, so a zombie could persist indefinitely; the
-  /// [`QuicConfigOptions::build`](super::config::QuicConfigOptions::build)
-  /// path rejects a zero `max_idle_timeout` for that reason. The constructor
+  /// `TransportConfig` before handing it in. This raw constructor performs NO
+  /// idle-timeout enforcement — it is the advanced escape hatch, and silently
+  /// overriding a caller's explicit `TransportConfig` would defeat it. Leaving
+  /// `max_idle_timeout` finite is strongly recommended: supplying a
+  /// `TransportConfig` whose idle timeout is disabled — either `max_idle_timeout(None)`
+  /// or a value that encodes to zero (`Some(Duration::ZERO)`, or any
+  /// sub-millisecond duration, since quinn encodes the timeout in milliseconds;
+  /// a disabling zero per RFC 9000 §18.2) — removes the finite idle-timeout bound
+  /// that self-heals a stale connection, so a zombie to a dead peer instance
+  /// could hold selection indefinitely (see the residual note in the connection
+  /// table module). The higher-level
+  /// [`QuicConfigOptions::build`](super::config::QuicConfigOptions::build) path
+  /// rejects a zero/sub-millisecond `max_idle_timeout` and so guarantees the
+  /// finite bound; this raw path does not. The constructor
   /// unconditionally forces `max_concurrent_uni_streams = 0` on the
   /// supplied value (mutating it before moving it into a shared `Arc`,
   /// so a caller's surviving `Arc` view cannot accidentally re-enable

--- a/memberlist-proto/src/quic/mod.rs
+++ b/memberlist-proto/src/quic/mod.rs
@@ -2220,6 +2220,10 @@ impl<I, R> QuicEndpoint<I, R> {
       }
       None => return,
     };
+    // The slot-free wake is keyed by the connection's membership address, which
+    // must be the key its route is filed under; a `peer` that followed QUIC path
+    // migration would strand this wake against the original key.
+    self.conns.debug_assert_peer_is_route_key(ch);
     self.slot_freed_peers.insert(peer);
   }
 
@@ -5437,6 +5441,10 @@ where
     let mut ready_peers: SmallVec<SocketAddr> = SmallVec::new();
     for ch in self.conns.iter_handles() {
       let marks = self.service_one_conn(ch, now);
+      // The parked bucket is serviced by this connection's membership address,
+      // which must be the key its route is filed under (else the wake strands
+      // against the original key).
+      self.conns.debug_assert_peer_is_route_key(ch);
       // Establishment unblocks the dials parked on THIS connection's peer;
       // resolve it while `ch` is still in hand (it may have been reaped during
       // the pass, in which case there is no bucket to service — the tick is the
@@ -5475,6 +5483,13 @@ where
   /// dials; they cannot be acted on in place because the parked-dial servicing
   /// re-borrows `self.conns` through `get_or_dial`.
   fn service_one_conn(&mut self, ch: ConnectionHandle, now: Instant) -> ServiceMarks {
+    // Both the inbound-accept and the inbound-datagram drains below attribute
+    // work to this connection's membership address (`e.peer()`), which must be
+    // the key its route is filed under. Asserted once here — the whole pass
+    // holds `e`'s exclusive borrow of the table, so the check cannot sit inline
+    // at those two sites — defending against a future `peer` that follows QUIC
+    // path migration and strands peer-keyed parked dials.
+    self.conns.debug_assert_peer_is_route_key(ch);
     let Some(e) = self.conns.get_mut(ch) else {
       return ServiceMarks::default();
     };

--- a/memberlist-proto/src/quic/mod.rs
+++ b/memberlist-proto/src/quic/mod.rs
@@ -2681,26 +2681,36 @@ impl<I, R> QuicEndpoint<I, R> {
     }
   }
 
-  /// Shared tail of [`Self::run_tick`] and [`Self::flush_outbound`]:
-  /// step (5) connection drained-reap, then [`Self::collect_transmits`].
+  /// Walk every live `ConnectionHandle` and reap the ones quinn reports
+  /// `is_drained()` (fully dead — no further transport work is owed), dropping
+  /// each reaped connection's deadline key and pending-events membership so
+  /// neither lingers as a stale index term. Per-connection deferred
+  /// `ConnectionEvent`s live in each [`super::conn::ConnEntry`]'s own
+  /// `pending_events` deque (see [`super::conn::ConnEntry::queue_pending_event`]),
+  /// so a reap that drops the slab entry also drops its deferred queue by
+  /// construction — no global FIFO can survive past the reap to be re-keyed onto
+  /// a fresh connection occupying the freed slab slot.
   ///
-  /// The reap simply walks every live `ConnectionHandle` and calls
-  /// [`ConnTable::reap_if_drained`]; per-connection deferred
-  /// `ConnectionEvent`s queued by `service_quinn` live in each
-  /// [`super::conn::ConnEntry`]'s own `pending_events` deque (see
-  /// [`super::conn::ConnEntry::queue_pending_event`]) so a reap that drops
-  /// the slab entry also drops its deferred queue by construction — no
-  /// global FIFO can survive past the reap to be re-keyed onto a fresh
-  /// connection occupying the freed slab slot.
-  fn finalize_tick(&mut self, now: Instant) {
+  /// Idempotent: a handle already reaped this tick returns `false` and is skipped.
+  /// The tick runs this BEFORE `service_dials` (so a global-cap slot a reap frees
+  /// is available to the same tick's fresh dial — a reliable intent parked at the
+  /// cap opens the instant the draining connection occupying its slot dies,
+  /// rather than waiting a whole tick for a wake a strict-poll driver would not
+  /// schedule) and AGAIN in [`Self::finalize_tick`] (to catch a connection that
+  /// only reached `is_drained()` during this tick's later servicing).
+  fn reap_drained_connections(&mut self) {
     for ch in self.conns.iter_handles() {
       if self.conns.reap_if_drained(&mut self.quinn, ch) {
-        // The connection left the table: drop its deadline key and any
-        // pending-events membership so neither lingers as a stale index term.
         self.deadline_index.set(TimerKey::Conn(ch), None);
         self.conns_with_pending_events.remove(&ch);
       }
     }
+  }
+
+  /// Shared tail of [`Self::run_tick`] and [`Self::flush_outbound`]:
+  /// step (5) connection drained-reap, then [`Self::collect_transmits`].
+  fn finalize_tick(&mut self, now: Instant) {
+    self.reap_drained_connections();
     self.collect_transmits(now);
     // The global tick services every bridge directly via `pump_bridges` (which
     // clears every `queued` flag at pump entry), so any ready-queue entries a
@@ -5316,6 +5326,14 @@ where
     // parked bucket unconditionally, so a bucket a readiness event unblocked is
     // serviced there regardless.
     let _ready_peers = self.service_quinn(now);
+    // (4.5) Reap connections that reached `is_drained()` this tick BEFORE dial
+    // servicing, so a global-cap slot a reap frees is available to the same
+    // tick's fresh dial. Otherwise a reliable intent parked at the cap (its slot
+    // held by a now-draining connection) would re-park this tick and wait for its
+    // own pre-deadline service wake before retrying — under a strict-poll driver
+    // that wake can land only a service margin before the deadline, too late for
+    // a fresh handshake to complete, yielding a false Suspect of a live peer.
+    self.reap_drained_connections();
     // (5) Dial requests emitted by (3) or by accept-events, plus every parked
     // bucket (the liveness backstop for expiry and handshake-failure retirement).
     self.service_dials(now);

--- a/memberlist-proto/src/quic/mod.rs
+++ b/memberlist-proto/src/quic/mod.rs
@@ -3988,31 +3988,29 @@ where
         }
       }
       Err(conn::DialError::AtGlobalCap) => {
-        // The global connection cap is reached: this new outbound peer gets no
-        // connection this tick. Count it against the same connection-cap metric
-        // the inbound Initial path uses.
+        // The global connection cap is reached: this reliable dial fails fast.
+        // The cap is an operator ceiling, and the coordinator sheds rather than
+        // queues at its bounds. A slot already freed by a drained connection was
+        // harvested before dial servicing (the tick's step 4.5 reap), so this arm
+        // fires only when the table is genuinely full. The cost is at worst a
+        // transient false Suspect of a not-yet-connected peer at cap saturation,
+        // which the failure detector's next interval, indirect probes, and
+        // incarnation refutation heal (refutation does not depend on this node's
+        // connection-table capacity). Retaining intents against future capacity
+        // would need a deduplicated capacity-wait ledger with reap-triggered
+        // wakes — deliberately not built for this corner.
+        //
+        // Count the refusal against the same connection-cap metric the inbound
+        // Initial path uses, then retire the intent through the standard
+        // pre-bridge failure path (a Failed `ExchangeCompleted` for a UserMessage
+        // / PushPull dial resolves the parked waiter).
         self.ep.metrics_mut().quic_connections_rejected += 1;
-        // A just-closed connection still counts against the cap until
-        // `finalize_tick` reaps it later THIS tick, so a fresh dial can hit the
-        // cap on a slot that is about to free. If such a reapable connection
-        // exists and the intent's deadline still holds, repark (same front/back
-        // discipline as the handshaking / credit-exhausted paths) so the next
-        // tick — after the closing connection reaps and frees its slot — retries
-        // the dial rather than abandoning a recoverable intent one tick early;
-        // the tick's unconditional full-drain of parked buckets is the retry
-        // backstop (there is no global-cap-freed wake). Retire when the table is
-        // permanently full (no reapable connection, so no slot is coming) or the
-        // deadline has passed.
-        if now < deadline && self.conns.has_reapable_connection() {
-          self.repark_blocked_dial(id, peer, deadline, kind, now)
-        } else {
-          self.retire_failed_dial(
-            id,
-            StreamError::DialFailed("quic connection table at capacity".into()),
-            now,
-          );
-          DialAttempt::Retired
-        }
+        self.retire_failed_dial(
+          id,
+          StreamError::DialFailed("quic connection table at capacity".into()),
+          now,
+        );
+        DialAttempt::Retired
       }
       Err(conn::DialError::Connect(e)) => {
         self.retire_failed_dial(id, StreamError::DialFailed(e.to_string().into()), now);
@@ -5327,12 +5325,10 @@ where
     // serviced there regardless.
     let _ready_peers = self.service_quinn(now);
     // (4.5) Reap connections that reached `is_drained()` this tick BEFORE dial
-    // servicing, so a global-cap slot a reap frees is available to the same
-    // tick's fresh dial. Otherwise a reliable intent parked at the cap (its slot
-    // held by a now-draining connection) would re-park this tick and wait for its
-    // own pre-deadline service wake before retrying — under a strict-poll driver
-    // that wake can land only a service margin before the deadline, too late for
-    // a fresh handshake to complete, yielding a false Suspect of a live peer.
+    // servicing, so a global-cap slot a reap frees is available to the SAME
+    // tick's fresh dials. A reliable dial is therefore never refused at the cap
+    // for a slot that has already freed; the at-cap fail-fast in
+    // `process_dial_entry` fires only when the table is genuinely full.
     self.reap_drained_connections();
     // (5) Dial requests emitted by (3) or by accept-events, plus every parked
     // bucket (the liveness backstop for expiry and handshake-failure retirement).

--- a/memberlist-proto/src/quic/mod.rs
+++ b/memberlist-proto/src/quic/mod.rs
@@ -5418,6 +5418,15 @@ where
     let pre_first_pump_ids: HashSet<StreamId> = self.bridges.keys().copied().collect();
     self.pump_bridges(now);
     let ready_peers = self.service_quinn(now);
+    // Reap fully-drained (`is_drained()`) connections BEFORE dial servicing,
+    // mirroring the global tick's step-4.5 reap: a `service_quinn` pass above can
+    // transition a connection to drained, and a global-cap slot that reap frees
+    // must be available to this flush's dial buckets (the ready-peers loop AND the
+    // ready-dial ledger drain below). Without it a reliable dial to a peer whose
+    // slot is held by a now-drained connection would hit `AtGlobalCap` and be
+    // retired on a slot that has already freed. `finalize_tick`'s reap at the end
+    // stays (idempotent) to catch connections drained later in this pass.
+    self.reap_drained_connections();
     // One unbounded dial budget SHARED across the ready-peers loop, the ready-dial
     // ledger drain, and the slot-free consume: this is an O(N) flush-all path, so it
     // must never budget-exit a bucket (which would deposit into the ledger it is

--- a/memberlist-proto/src/quic/mod.rs
+++ b/memberlist-proto/src/quic/mod.rs
@@ -3978,18 +3978,31 @@ where
         }
       }
       Err(conn::DialError::AtGlobalCap) => {
-        // The global connection cap is reached: this new outbound peer gets
-        // no connection. Count it against the same connection-cap metric the
-        // inbound Initial path uses, and retire the intent through the
-        // standard pre-bridge failure path (a Failed ExchangeCompleted for a
-        // UserMessage / PushPull dial resolves the parked waiter).
+        // The global connection cap is reached: this new outbound peer gets no
+        // connection this tick. Count it against the same connection-cap metric
+        // the inbound Initial path uses.
         self.ep.metrics_mut().quic_connections_rejected += 1;
-        self.retire_failed_dial(
-          id,
-          StreamError::DialFailed("quic connection table at capacity".into()),
-          now,
-        );
-        DialAttempt::Retired
+        // A just-closed connection still counts against the cap until
+        // `finalize_tick` reaps it later THIS tick, so a fresh dial can hit the
+        // cap on a slot that is about to free. If such a reapable connection
+        // exists and the intent's deadline still holds, repark (same front/back
+        // discipline as the handshaking / credit-exhausted paths) so the next
+        // tick — after the closing connection reaps and frees its slot — retries
+        // the dial rather than abandoning a recoverable intent one tick early;
+        // the tick's unconditional full-drain of parked buckets is the retry
+        // backstop (there is no global-cap-freed wake). Retire when the table is
+        // permanently full (no reapable connection, so no slot is coming) or the
+        // deadline has passed.
+        if now < deadline && self.conns.has_reapable_connection() {
+          self.repark_blocked_dial(id, peer, deadline, kind, now)
+        } else {
+          self.retire_failed_dial(
+            id,
+            StreamError::DialFailed("quic connection table at capacity".into()),
+            now,
+          );
+          DialAttempt::Retired
+        }
       }
       Err(conn::DialError::Connect(e)) => {
         self.retire_failed_dial(id, StreamError::DialFailed(e.to_string().into()), now);

--- a/memberlist-proto/src/quic/mod.rs
+++ b/memberlist-proto/src/quic/mod.rs
@@ -1644,25 +1644,16 @@ impl<I, R> QuicEndpoint<I, R> {
     Some((from, bytes))
   }
 
-  /// Number of live (non-reaped) QUIC connections to `peer` — `0` or `1`,
-  /// since the connection table pools one connection per peer.
+  /// Number of usable QUIC connections to `peer` — `0` or `1`, since the
+  /// connection table selects one best-usable handle per peer.
   ///
-  /// Observation-only, for a driver/test to assert the drained-reap
-  /// lifecycle (a connection that idled past `max_idle_timeout` is reaped:
-  /// its slab + peers entry is removed, so this drops back to `0`). A
-  /// connection still in its closing/draining wind-down is reported live
-  /// until [`ConnTable::reap_if_drained`] removes it.
+  /// Observation-only, for a driver/test to assert the connection lifecycle.
+  /// Backed by the same derived best-usable selection the reliable/unreliable
+  /// send paths ride ([`ConnTable::handle_for`]): a peer with an established or
+  /// handshaking connection (either direction) reports `1`; a peer whose only
+  /// tracked connections are closed/draining or handshake-failed reports `0`.
   pub fn live_connections_to(&self, peer: SocketAddr) -> usize {
-    match self.conns.handle_for(&peer) {
-      Some(ch) => usize::from(
-        self
-          .conns
-          .get(ch)
-          .map(|e| !e.conn_ref().is_drained())
-          .unwrap_or(false),
-      ),
-      None => 0,
-    }
+    usize::from(self.conns.handle_for(&peer).is_some())
   }
 
   /// Number of active reliable-exchange bridges (one per in-flight push/pull
@@ -1713,8 +1704,9 @@ impl<I, R> QuicEndpoint<I, R> {
   /// `last_now` is also anchored so any wake the close requires
   /// surfaces immediately.
   ///
-  /// Returns `false` if no connection to `peer` exists, or if the
-  /// open is refused.
+  /// Targets the peer's derived best-usable connection (the same selection the
+  /// send paths ride, [`ConnTable::handle_for`]). Returns `false` if no usable
+  /// connection to `peer` exists, or if the open is refused.
   pub fn try_open_uni_stream_to(&mut self, peer: SocketAddr, now: Instant) -> bool {
     self.last_now = Some(now);
     let Some(ch) = self.conns.handle_for(&peer) else {
@@ -2992,6 +2984,7 @@ impl<I, R> QuicEndpoint<I, R> {
       peer,
       &sni_arc,
       self.cfg.max_quic_connections(),
+      conn::Reliability::Unreliable,
     ) {
       Ok(ch) => ch,
       // The datagram-fallback dial hit the global connection cap: this new
@@ -3748,6 +3741,7 @@ where
       addr,
       &sni_arc,
       self.cfg.max_quic_connections(),
+      conn::Reliability::Reliable,
     ) {
       Ok(ch) => {
         // Record every dialed connection as touched: `get_or_dial` may have
@@ -5866,6 +5860,15 @@ where
     let credit_restored_peer = credit_restored.then_some(peer);
     // `e` borrows `self.conns`; release it before touching `self.bridges`.
     let _ = e;
+    // Establishment-chokepoint promotion, run BEFORE the caller resolves this
+    // pass's wake: a newly-established inbound becomes its peer's tracked inbound
+    // route (newest-established-inbound wins), so the woken bucket's selection
+    // sees the freshly-live connection instead of a stale zombie. The one place
+    // truth changes — no promote/restore pair to desync. A no-op for a
+    // still-handshaking connection.
+    if established_transition {
+      self.conns.on_established_transition(ch);
+    }
     if lost || drained {
       // Mark every bridge on this connection fatal AND complete its D1
       // drain_then_reap synchronously, in this same tick.

--- a/memberlist-proto/src/quic/tests.rs
+++ b/memberlist-proto/src/quic/tests.rs
@@ -6618,6 +6618,112 @@ fn at_cap_reliable_dial_reparks_while_a_slot_is_about_to_free() {
   );
 }
 
+/// FIX for the strict-poll cap-recovery gap: a reliable dial parked at the global
+/// cap must open the SAME tick the draining connection occupying its slot is
+/// reaped. The tick reaps drained connections BEFORE `service_dials`, so the
+/// freed slot is available to the parked dial's fresh R7 attempt that same tick.
+///
+/// Without that ordering the reap lands only in `finalize_tick` (AFTER
+/// `service_dials`), so the parked dial re-parks this tick and — under a
+/// strict-poll driver with schedulers off — does not retry until its own
+/// pre-deadline service wake, which can arrive only a service margin before the
+/// deadline: too late for a fresh handshake to complete, yielding a false Suspect
+/// of a live peer.
+///
+/// Mutation-verify: delete the step-(4.5) `reap_drained_connections()` call in
+/// `tick` (leaving only the `finalize_tick` reap) — the parked dial to Y is not
+/// attempted the tick X reaps (X still fills the cap during `service_dials`), so
+/// `live_connections_to(y)` stays 0 and the recovery assertion fails.
+#[test]
+fn drained_slot_freed_before_dials_opens_a_cap_blocked_reliable_dial_same_tick() {
+  let a_addr: SocketAddr = "127.0.0.1:7730".parse().unwrap();
+  let now = Instant::now();
+  // Schedulers off: the tick advances membership time but arms no probe / gossip
+  // / push-pull scheduler, isolating the reap-then-dial ordering.
+  let cfg = EndpointOptions::new(SmolStr::new("a"), a_addr)
+    .with_probe_interval(Duration::ZERO)
+    .with_gossip_interval(Duration::ZERO)
+    .with_push_pull_interval(Duration::ZERO);
+  let mut a = make_endpoint_full(
+    cfg,
+    test_config().with_max_quic_connections(Some(1)),
+    a_addr,
+    now,
+  );
+
+  // Fill the single-connection cap with X, then drive X fully drained
+  // (`is_drained()`) so its slot is reapable this tick.
+  let x_addr: SocketAddr = "127.0.0.3:4000".parse().unwrap();
+  let x = a
+    .conns
+    .get_or_dial(
+      &mut a.quinn,
+      now,
+      a.cfg.client().clone(),
+      x_addr,
+      "localhost",
+      Some(1),
+      super::conn::Reliability::Reliable,
+    )
+    .unwrap();
+  a.conns
+    .get_mut(x)
+    .unwrap()
+    .conn_mut()
+    .close(now.into_std(), 0u32.into(), bytes::Bytes::new());
+  for _ in 0..5000 {
+    if a.conns.get(x).unwrap().conn_ref().is_drained() {
+      break;
+    }
+    match a.conns.get_mut(x).unwrap().conn_mut().poll_timeout() {
+      Some(d) => a.conns.get_mut(x).unwrap().conn_mut().handle_timeout(d),
+      None => break,
+    }
+  }
+  assert!(
+    a.conns.get(x).unwrap().conn_ref().is_drained(),
+    "X must be fully drained (reapable)"
+  );
+  assert_eq!(
+    a.conns.iter_handles().len(),
+    1,
+    "the drained X still occupies the cap of 1"
+  );
+
+  // A reliable ping to a live peer Y parked at the cap (deadline far). A
+  // reapable connection (X) exists, so at the cap it re-parks rather than
+  // retiring — the intent survives to the reap tick.
+  let y: SocketAddr = "127.0.0.9:5000".parse().unwrap();
+  let deadline = now + Duration::from_secs(30);
+  a.dial_parked
+    .entry(y)
+    .or_default()
+    .push_back(super::PendingDial {
+      id: StreamId::from_raw(300_000),
+      peer: y,
+      deadline,
+      wake: deadline,
+      attempted: true,
+      kind: super::ExchangeKind::ReliablePing,
+    });
+  assert_eq!(a.live_connections_to(y), 0, "Y is not yet dialed");
+
+  // One global tick: it reaps the drained X BEFORE dial servicing, so the parked
+  // ping's R7 dial opens a fresh connection to Y in the SAME tick — recovery,
+  // not a wait for the pre-deadline service wake.
+  a.run_tick(now);
+
+  assert_eq!(
+    a.live_connections_to(x_addr),
+    0,
+    "the drained X was reaped this tick"
+  );
+  assert!(
+    a.live_connections_to(y) >= 1,
+    "the cap-blocked reliable dial opened a connection to Y the same tick X was reaped"
+  );
+}
+
 /// A cold dial (to a peer with NO established connection) that `service_dials`
 /// attempts must flush its Initial AND register its deadline key in the same call
 /// — even though it mints no bridge (its `open(Bi)` returns `None`, still

--- a/memberlist-proto/src/quic/tests.rs
+++ b/memberlist-proto/src/quic/tests.rs
@@ -573,6 +573,7 @@ fn conn_entry_pending_events_drop_with_entry_on_reap() {
       c_addr,
       "localhost",
       None,
+      super::conn::Reliability::Reliable,
     )
     .expect("fresh dial after reap succeeds");
   assert_eq!(

--- a/memberlist-proto/src/quic/tests.rs
+++ b/memberlist-proto/src/quic/tests.rs
@@ -6534,6 +6534,90 @@ fn outbound_dials_cannot_exceed_global_connection_cap() {
   );
 }
 
+/// A reliable dial refused at the global cap must REPARK — retried on the next
+/// tick after a closing connection reaps and frees its slot — while its deadline
+/// holds and a reapable (closed-but-not-reaped) connection exists, rather than
+/// being retired one tick early. Driven through `service_peer_bucket`, which
+/// runs the `process_dial_entry` at-cap arm; a reparked intent stays on its
+/// `dial_parked` bucket, a retired one is consumed.
+///
+/// Mutation-verify: revert the `Err(AtGlobalCap)` arm to an immediate
+/// `retire_failed_dial` — the intent is consumed, its bucket empties, and the
+/// `dial_parked` length assertion fails.
+///
+/// (A permanently-full table — no reapable connection — still retires
+/// immediately, as the `max_quic_connections(0)` catch-up tests require.)
+#[test]
+fn at_cap_reliable_dial_reparks_while_a_slot_is_about_to_free() {
+  let a_addr: SocketAddr = "127.0.0.1:7720".parse().unwrap();
+  let now = Instant::now();
+  let cfg = EndpointOptions::new(SmolStr::new("a"), a_addr);
+  let mut a = make_endpoint_full(
+    cfg,
+    test_config().with_max_quic_connections(Some(1)),
+    a_addr,
+    now,
+  );
+
+  // Fill the single-connection cap, then CLOSE that connection so it is closed
+  // (reapable) but not yet reaped — a slot about to free this tick.
+  let filler: SocketAddr = "127.0.0.3:4000".parse().unwrap();
+  let ch = a
+    .conns
+    .get_or_dial(
+      &mut a.quinn,
+      now,
+      a.cfg.client().clone(),
+      filler,
+      "localhost",
+      Some(1),
+      super::conn::Reliability::Reliable,
+    )
+    .unwrap();
+  a.conns
+    .get_mut(ch)
+    .unwrap()
+    .conn_mut()
+    .close(now.into_std(), 0u32.into(), bytes::Bytes::new());
+  assert!(a.conns.get(ch).unwrap().conn_ref().is_closed());
+  assert!(!a.conns.get(ch).unwrap().conn_ref().is_drained());
+  assert_eq!(
+    a.conns.iter_handles().len(),
+    1,
+    "the table is at the cap of 1"
+  );
+
+  // A reliable intent to a DIFFERENT fresh peer, deadline in the future. Its R7
+  // dial hits `AtGlobalCap` (table full); a reapable connection exists, so it
+  // must repark rather than retire.
+  let fresh: SocketAddr = "127.0.0.9:5000".parse().unwrap();
+  let deadline = now + Duration::from_secs(30);
+  a.dial_parked
+    .entry(fresh)
+    .or_default()
+    .push_back(super::PendingDial {
+      id: StreamId::from_raw(200_000),
+      peer: fresh,
+      deadline,
+      wake: deadline,
+      attempted: true,
+      kind: super::ExchangeKind::UserMessage,
+    });
+  let mut dial_budget = super::MAX_DIAL_ATTEMPTS_PER_PASS;
+  let _ = a.service_peer_bucket(fresh, now, &mut dial_budget);
+
+  assert_eq!(
+    a.dial_parked.get(&fresh).map(|b| b.len()).unwrap_or(0),
+    1,
+    "the cap-blocked reliable intent reparks (retried next tick), not retired one tick early"
+  );
+  assert_eq!(
+    a.conns.iter_handles().len(),
+    1,
+    "no new connection was created at the cap"
+  );
+}
+
 /// A cold dial (to a peer with NO established connection) that `service_dials`
 /// attempts must flush its Initial AND register its deadline key in the same call
 /// — even though it mints no bridge (its `open(Bi)` returns `None`, still

--- a/memberlist-proto/src/quic/tests.rs
+++ b/memberlist-proto/src/quic/tests.rs
@@ -6737,6 +6737,107 @@ fn drained_slot_freed_before_dials_opens_a_cap_blocked_reliable_dial_same_tick()
   );
 }
 
+/// The FLUSH path (`flush_outbound` / `flush_outbound_transmits`) must harvest a
+/// drained connection's freed cap slot BEFORE its own dial servicing, mirroring
+/// the global tick's step-4.5 reap. `flush_outbound` runs `service_quinn` (which
+/// can drain a connection) and then services dials via the ready-peers loop and
+/// the ready-dial ledger drain, all BEFORE the only-other reap in
+/// `finalize_tick`. Without a reap-before-dials in the flush, a reliable dial to
+/// a peer whose slot is held by a now-drained connection hits `AtGlobalCap` and
+/// is retired (fail-fast) on a slot already fully freed.
+///
+/// Mutation-verify: delete the `reap_drained_connections()` call added to
+/// `flush_outbound` (between `service_quinn` and the dial loops) — the drained X
+/// still fills the cap when Y's ledger bucket is serviced, so Y's dial is retired
+/// at the cap and `live_connections_to(y)` stays 0, failing the assertion.
+#[test]
+fn flush_path_reaps_drained_slot_before_dials_so_a_cap_blocked_reliable_dial_opens() {
+  let a_addr: SocketAddr = "127.0.0.1:7731".parse().unwrap();
+  let now = Instant::now();
+  let cfg = EndpointOptions::new(SmolStr::new("a"), a_addr)
+    .with_probe_interval(Duration::ZERO)
+    .with_gossip_interval(Duration::ZERO)
+    .with_push_pull_interval(Duration::ZERO);
+  let mut a = make_endpoint_full(
+    cfg,
+    test_config().with_max_quic_connections(Some(1)),
+    a_addr,
+    now,
+  );
+
+  // Fill the single-connection cap with X, then drive X fully drained
+  // (`is_drained()`) so its slot is reapable during the flush.
+  let x_addr: SocketAddr = "127.0.0.3:4000".parse().unwrap();
+  let x = a
+    .conns
+    .get_or_dial(
+      &mut a.quinn,
+      now,
+      a.cfg.client().clone(),
+      x_addr,
+      "localhost",
+      Some(1),
+      super::conn::Reliability::Reliable,
+    )
+    .unwrap();
+  a.conns
+    .get_mut(x)
+    .unwrap()
+    .conn_mut()
+    .close(now.into_std(), 0u32.into(), bytes::Bytes::new());
+  for _ in 0..5000 {
+    if a.conns.get(x).unwrap().conn_ref().is_drained() {
+      break;
+    }
+    match a.conns.get_mut(x).unwrap().conn_mut().poll_timeout() {
+      Some(d) => a.conns.get_mut(x).unwrap().conn_mut().handle_timeout(d),
+      None => break,
+    }
+  }
+  assert!(
+    a.conns.get(x).unwrap().conn_ref().is_drained(),
+    "X must be fully drained (reapable)"
+  );
+  assert_eq!(
+    a.conns.iter_handles().len(),
+    1,
+    "the drained X still occupies the cap of 1"
+  );
+
+  // A ready reliable ping to peer Y deposited into the ready-dial ledger so the
+  // FLUSH path's ledger drain services its parked bucket (the flush owns no
+  // `service_dials`).
+  let y: SocketAddr = "127.0.0.9:5000".parse().unwrap();
+  let deadline = now + Duration::from_secs(30);
+  a.dial_parked
+    .entry(y)
+    .or_default()
+    .push_back(super::PendingDial {
+      id: StreamId::from_raw(310_000),
+      peer: y,
+      deadline,
+      wake: deadline,
+      attempted: true,
+      kind: super::ExchangeKind::ReliablePing,
+    });
+  a.ready_dial_peers.insert(y);
+  assert_eq!(a.live_connections_to(y), 0, "Y is not yet dialed");
+
+  // The flush reaps the drained X BEFORE its dial buckets, so Y's ledger bucket
+  // opens a fresh connection to Y rather than being retired at the cap.
+  a.flush_outbound_transmits(now);
+
+  assert_eq!(
+    a.live_connections_to(x_addr),
+    0,
+    "the drained X was reaped during the flush"
+  );
+  assert!(
+    a.live_connections_to(y) >= 1,
+    "the cap-blocked reliable dial opened a connection to Y in the same flush X was reaped"
+  );
+}
+
 /// A cold dial (to a peer with NO established connection) that `service_dials`
 /// attempts must flush its Initial AND register its deadline key in the same call
 /// — even though it mints no bridge (its `open(Bi)` returns `None`, still

--- a/memberlist-proto/src/quic/tests.rs
+++ b/memberlist-proto/src/quic/tests.rs
@@ -6534,21 +6534,22 @@ fn outbound_dials_cannot_exceed_global_connection_cap() {
   );
 }
 
-/// A reliable dial refused at the global cap must REPARK — retried on the next
-/// tick after a closing connection reaps and frees its slot — while its deadline
-/// holds and a reapable (closed-but-not-reaped) connection exists, rather than
-/// being retired one tick early. Driven through `service_peer_bucket`, which
-/// runs the `process_dial_entry` at-cap arm; a reparked intent stays on its
-/// `dial_parked` bucket, a retired one is consumed.
+/// A reliable dial refused at the global connection cap FAILS FAST: it is
+/// retired (not queued), the `quic_connections_rejected` metric is bumped, and
+/// the reliable-send waiter is resolved by a Failed `ExchangeCompleted`. The cap
+/// is a hard operator ceiling and the coordinator sheds rather than queues at its
+/// bounds; a slot already freed by a drained connection is harvested before dial
+/// servicing (tick step 4.5), so this arm fires only when the table is genuinely
+/// full.
 ///
-/// Mutation-verify: revert the `Err(AtGlobalCap)` arm to an immediate
-/// `retire_failed_dial` — the intent is consumed, its bucket empties, and the
-/// `dial_parked` length assertion fails.
-///
-/// (A permanently-full table — no reapable connection — still retires
-/// immediately, as the `max_quic_connections(0)` catch-up tests require.)
+/// Mutation-verify: restore an at-cap repark (return `repark_blocked_dial`
+/// instead of `retire_failed_dial` in the `Err(AtGlobalCap)` arm) — the intent is
+/// parked instead of resolved, so no Failed `ExchangeCompleted` is emitted and
+/// the `found` assertion fails.
 #[test]
-fn at_cap_reliable_dial_reparks_while_a_slot_is_about_to_free() {
+fn at_cap_reliable_dial_retires_and_resolves_the_waiter() {
+  use crate::event::{Event, ExchangeId, ExchangeKind, ExchangeStatus};
+
   let a_addr: SocketAddr = "127.0.0.1:7720".parse().unwrap();
   let now = Instant::now();
   let cfg = EndpointOptions::new(SmolStr::new("a"), a_addr);
@@ -6559,8 +6560,8 @@ fn at_cap_reliable_dial_reparks_while_a_slot_is_about_to_free() {
     now,
   );
 
-  // Fill the single-connection cap, then CLOSE that connection so it is closed
-  // (reapable) but not yet reaped — a slot about to free this tick.
+  // Fill the single-connection cap with a closed (not-yet-drained, so unreaped)
+  // connection, so the table is genuinely full when the reliable dial is made.
   let filler: SocketAddr = "127.0.0.3:4000".parse().unwrap();
   let ch = a
     .conns
@@ -6586,36 +6587,48 @@ fn at_cap_reliable_dial_reparks_while_a_slot_is_about_to_free() {
     1,
     "the table is at the cap of 1"
   );
+  let rejected_before = a.metrics().quic_connections_rejected;
 
-  // A reliable intent to a DIFFERENT fresh peer, deadline in the future. Its R7
-  // dial hits `AtGlobalCap` (table full); a reapable connection exists, so it
-  // must repark rather than retire.
-  let fresh: SocketAddr = "127.0.0.9:5000".parse().unwrap();
-  let deadline = now + Duration::from_secs(30);
-  a.dial_parked
-    .entry(fresh)
-    .or_default()
-    .push_back(super::PendingDial {
-      id: StreamId::from_raw(200_000),
-      peer: fresh,
-      deadline,
-      wake: deadline,
-      attempted: true,
-      kind: super::ExchangeKind::UserMessage,
-    });
-  let mut dial_budget = super::MAX_DIAL_ATTEMPTS_PER_PASS;
-  let _ = a.service_peer_bucket(fresh, now, &mut dial_budget);
+  // A reliable user-message dial to a fresh peer: its in-band R7 dial hits the
+  // cap and is retired, resolving the parked send waiter.
+  let y: SocketAddr = "127.0.0.9:5000".parse().unwrap();
+  let id = a
+    .start_user_message(y, Bytes::from_static(b"hi"), now)
+    .expect("issued while running");
+  let expected_eid = ExchangeId::from(id);
 
-  assert_eq!(
-    a.dial_parked.get(&fresh).map(|b| b.len()).unwrap_or(0),
-    1,
-    "the cap-blocked reliable intent reparks (retried next tick), not retired one tick early"
+  assert!(
+    a.metrics().quic_connections_rejected > rejected_before,
+    "the at-cap refusal bumps quic_connections_rejected"
   );
   assert_eq!(
-    a.conns.iter_handles().len(),
-    1,
+    a.dial_parked.get(&y).map(|b| b.len()).unwrap_or(0),
+    0,
+    "a cap-refused reliable dial is retired (fail-fast), not queued"
+  );
+  assert_eq!(
+    a.live_connections_to(y),
+    0,
     "no new connection was created at the cap"
   );
+
+  // The reliable-send waiter is resolved by a Failed ExchangeCompleted.
+  let mut found = None;
+  while let Some(ev) = a.poll_event() {
+    if let Event::ExchangeCompleted(payload) = ev
+      && payload.eid() == expected_eid
+    {
+      found = Some(payload);
+      break;
+    }
+  }
+  let payload = found.expect(
+    "a reliable dial refused at the global cap MUST resolve its parked waiter \
+       via Event::ExchangeCompleted(Failed) — without it the send hangs forever",
+  );
+  assert_eq!(payload.kind(), ExchangeKind::UserMessage);
+  assert_eq!(payload.outcome(), ExchangeStatus::Failed);
+  assert_eq!(payload.peer(), &y);
 }
 
 /// FIX for the strict-poll cap-recovery gap: a reliable dial parked at the global


### PR DESCRIPTION
Closes #163.
