### PR TITLE
fix(proto): honest inbound stream attribution + total dial lifecycle with leave terminality (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ machine, with the async runtime concerns moved into thin per-runtime drivers.
 This release line forms new↔new clusters only; it does not interoperate on the
 wire with the legacy `0.x` hand-rolled codec below.
 
+### API notes
+
+- `Event` gains a `DialAborted` variant (with a `DialAborted<A>` payload and a
+  `DialAbortReason` enum). It completes the stream backend's dial-lifecycle
+  totality: every `start_*`-returned `StreamId` now receives exactly one
+  machine-emitted terminal — a synchronous `Err`, a `DialAborted` (retired
+  before its `Connect` was drained, including a graceful leave that cancels a
+  still-queued `Connect`), or an `eid`-keyed `ExchangeCompleted` once the
+  `Connect` has been drained. A graceful `leave` now also promptly terminalizes
+  every cancelled outbound reliable exchange (`ExchangeCompleted(Failed)` for a
+  drained `Connect`, `DialAborted(Leaving)` for a still-queued one) so a parked
+  reliable-send / join waiter resolves at leave rather than hanging until
+  shutdown. `Event` is deliberately exhaustive and gains variants in `0.x`
+  minor releases; match it exhaustively.
+
 ## 0.6.0
 
 ### Features

--- a/memberlist-compio/src/driver/stream/mod.rs
+++ b/memberlist-compio/src/driver/stream/mod.rs
@@ -2617,6 +2617,23 @@ where
         }
       }
     }
+    // Pre-connect dial abort: the coordinator retired a `start_*` id before any
+    // `Connect`. No synchronous waiter is keyed on a `StreamId` — the join /
+    // send waiter tables are `ExchangeId`-keyed and capture their ids from the
+    // surfaced `Connect` — so a `DialAborted` never resolves one and
+    // double-reporting is structurally impossible. Trace it; the event still
+    // flows to the observation task below.
+    if let Event::DialAborted(ref _p) = ev {
+      // `A` is generic here with no `Display`/`Debug` bound, so the peer is not
+      // formatted; the concrete `stream_id`/`kind`/`reason` identify the abort.
+      #[cfg(feature = "tracing")]
+      tracing::trace!(
+        stream_id = _p.stream_id().as_u64(),
+        kind = ?_p.kind(),
+        reason = ?_p.reason(),
+        "stream dial aborted before Connect",
+      );
+    }
     // Payload-bearing events (`UserPacket` / `RemoteStateReceived`) can each
     // own up to `max_stream_frame_size` bytes; size this one for the byte
     // backstop (`None` for small membership / control events).

--- a/memberlist-compio/src/driver/stream/tests.rs
+++ b/memberlist-compio/src/driver/stream/tests.rs
@@ -1050,6 +1050,108 @@ async fn drain_events_drops_on_closed_obs_channel_but_still_drains() {
   );
 }
 
+/// A parked reliable directed send resolves `Err(SendFailed)` PROMPTLY at
+/// `leave()` — NOT only at shutdown. The send parks a `PendingUserSend` and
+/// leaves its request queued in `out_transmit`; `leave()` then cancels the
+/// unsent exchange and terminalizes it (`ExchangeCompleted(Failed,
+/// UserMessage)`), which `drain_events`'s synchronous accounting folds into the
+/// waiter.
+#[compio::test]
+async fn leave_resolves_parked_reliable_send_as_send_failed() {
+  let mut endpoint = test_endpoint();
+  let mut pending = empty_pending();
+
+  let (tx, rx) = unit_reply();
+  dispatch_one(
+    &mut endpoint,
+    &mut pending,
+    Command::SendReliable(SendReliableCmd::new(
+      addr(7250),
+      vec![Bytes::from_static(b"reliable")],
+      tx,
+    )),
+  )
+  .await;
+  assert_eq!(pending.user_sends.len(), 1, "the send parked one waiter");
+
+  // Leave (NOT shutdown) cancels the unsent exchange and terminalizes it Failed.
+  endpoint.leave(Instant::now()).expect("leave");
+
+  let (obs_tx, _obs_rx) = mpsc::unbounded::<memberlist_proto::event::Event<SmolStr, SocketAddr>>();
+  let observation_dropped = Cell::new(0u64);
+  let obs_payload_bytes = Rc::new(Cell::new(0u64));
+  drain_events::<SmolStr, SocketAddr, RawRecords, _>(
+    &mut endpoint,
+    &obs_tx,
+    &observation_dropped,
+    &obs_payload_bytes,
+    None,
+    &mut pending,
+  )
+  .await;
+
+  assert!(
+    pending.user_sends.is_empty(),
+    "leave resolved the parked send"
+  );
+  assert!(
+    matches!(rx.await, Ok(Err(MemberlistError::SendFailed))),
+    "leave resolves the parked reliable send as SendFailed",
+  );
+}
+
+/// A parked wait-`join` resolves PROMPTLY at `leave()` with its partial
+/// contacted set — NOT only at shutdown. Both seeds' push/pull exchanges are
+/// cancelled + terminalized `Failed` by `leave()`, so the contacted set is empty
+/// and `join_reply` yields `Err((empty, JoinFailed))`, folded in by
+/// `drain_events`.
+#[compio::test]
+async fn leave_resolves_parked_wait_join_with_partial_set() {
+  let mut endpoint = test_endpoint();
+  let mut pending = empty_pending();
+
+  let (tx, rx) = futures_channel::oneshot::channel::<super::JoinReply>();
+  dispatch_one(
+    &mut endpoint,
+    &mut pending,
+    Command::Join(JoinCmd {
+      addrs: vec![addr(7260), addr(7261)],
+      kind: JoinKind::WaitForCompletion(WaitForCompletionArgs {
+        deadline: Instant::now() + Duration::from_secs(30),
+      }),
+      reply: tx,
+    }),
+  )
+  .await;
+  assert_eq!(pending.joins.len(), 1, "wait-join parked one waiter");
+
+  endpoint.leave(Instant::now()).expect("leave");
+
+  let (obs_tx, _obs_rx) = mpsc::unbounded::<memberlist_proto::event::Event<SmolStr, SocketAddr>>();
+  let observation_dropped = Cell::new(0u64);
+  let obs_payload_bytes = Rc::new(Cell::new(0u64));
+  drain_events::<SmolStr, SocketAddr, RawRecords, _>(
+    &mut endpoint,
+    &obs_tx,
+    &observation_dropped,
+    &obs_payload_bytes,
+    None,
+    &mut pending,
+  )
+  .await;
+
+  assert!(pending.joins.is_empty(), "leave resolved the parked join");
+  match rx.await {
+    Ok(Err((set, MemberlistError::JoinFailed(_)))) => {
+      assert!(
+        set.is_empty(),
+        "the leave-cancelled join has an empty partial set"
+      );
+    }
+    other => panic!("expected JoinFailed with an empty set, got {other:?}"),
+  }
+}
+
 /// `reap_pending_leave` replies `LeaveTimeout` to every joined replier once
 /// the deadline elapses and clears the slot; a not-yet-expired leave stays
 /// parked with no reply.

--- a/memberlist-proto/src/endpoint/mod.rs
+++ b/memberlist-proto/src/endpoint/mod.rs
@@ -3445,6 +3445,12 @@ where
   /// The driver accepted an inbound stream from `from`. Endpoint mints a
   /// fresh `StreamId` and returns an inbound-phase `Stream<I, A>`. The
   /// driver feeds bytes via `stream.handle_data(bytes, now)`.
+  ///
+  /// `from` is the accepted connection's remote transport socket, echoed
+  /// verbatim as the best-effort transport-origin hint on this stream's inbound
+  /// events (`UserPacket::from` / `RemoteStateReceived::peer`) — NOT the peer's
+  /// advertised membership address. Identity-critical consumers read the
+  /// advertised address from the push/pull payload instead.
   pub fn accept_stream(&mut self, from: A, now: Instant) -> Option<Stream<I, A>> {
     // Reliable-inbound lifecycle chokepoint, the stream-plane twin of
     // `handle_packet` refusing gossip-plane inbound once not Running. A

--- a/memberlist-proto/src/event/mod.rs
+++ b/memberlist-proto/src/event/mod.rs
@@ -226,6 +226,96 @@ impl<A> ExchangeCompleted<A> {
   }
 }
 
+/// Why a [`StreamId`] was retired before any [`StreamAction::Connect`] was
+/// surfaced, carried on [`Event::DialAborted`].
+///
+/// [`StreamAction::Connect`]: crate::streams::StreamAction::Connect
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DialAbortReason {
+  /// The dial intent's deadline had already elapsed when the coordinator
+  /// serviced it, so no connection was opened.
+  DeadlineElapsed,
+  /// The per-dial record-layer context was rejected (e.g. the TLS SNI provider
+  /// returned `None` for this peer).
+  DialContext,
+  /// The dialer record layer could not be constructed (a misconfigured
+  /// transport cannot dial).
+  RecordLayer,
+  /// The endpoint is leaving or has left, so no dial was initiated for the
+  /// (inert) id the `start_*` call returned.
+  NotRunning,
+}
+
+/// Payload for [`Event::DialAborted`]: a [`StreamId`] returned by a `start_*`
+/// call was retired before any [`StreamAction::Connect`] surfaced for it, so no
+/// bridge, [`ExchangeId`], or [`Event::ExchangeCompleted`] will ever refer to
+/// it. Keyed by the originating [`StreamId`] (not an [`ExchangeId`], which is
+/// allocated only once a dial reaches `Connect`), it makes the stream-backend
+/// lifecycle total: a driver correlating a `start_*` handle sees exactly one
+/// terminal outcome per id.
+///
+/// Emitted by the STREAM-transport coordinator only. The QUIC coordinator
+/// reports its pre-`Connect` dial failures as a `Failed`
+/// [`Event::ExchangeCompleted`] keyed `ExchangeId::from(stream_id)` instead
+/// (`retire_failed_dial`).
+///
+/// [`StreamAction::Connect`]: crate::streams::StreamAction::Connect
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DialAborted<A> {
+  stream_id: StreamId,
+  peer: A,
+  kind: ExchangeKind,
+  reason: DialAbortReason,
+}
+
+impl<A> DialAborted<A> {
+  /// Construct a new payload. Crate-internal: only the stream coordinator's
+  /// dial-service path produces it, so the constructor has no caller without
+  /// `tcp` / `tls`.
+  #[cfg_attr(
+    not(any(feature = "tls", feature = "tcp")),
+    allow(dead_code, reason = "only constructed by the stream coordinator")
+  )]
+  #[inline(always)]
+  pub(crate) const fn new(
+    stream_id: StreamId,
+    peer: A,
+    kind: ExchangeKind,
+    reason: DialAbortReason,
+  ) -> Self {
+    Self {
+      stream_id,
+      peer,
+      kind,
+      reason,
+    }
+  }
+
+  /// The originating `start_*` [`StreamId`] that was retired.
+  #[inline(always)]
+  pub const fn stream_id(&self) -> StreamId {
+    self.stream_id
+  }
+
+  /// The peer the aborted dial targeted.
+  #[inline(always)]
+  pub const fn peer_ref(&self) -> &A {
+    &self.peer
+  }
+
+  /// The originating exchange kind.
+  #[inline(always)]
+  pub const fn kind(&self) -> ExchangeKind {
+    self.kind
+  }
+
+  /// Why the dial was aborted.
+  #[inline(always)]
+  pub const fn reason(&self) -> DialAbortReason {
+    self.reason
+  }
+}
+
 /// Correlation token for an application ping (`Endpoint::ping`), echoed on the
 /// terminal `Event::PingCompleted` / `Event::PingFailed`. Mirrors how
 /// `StreamId` correlates reliable exchanges.
@@ -391,10 +481,12 @@ impl<I, A> NodeConflict<I, A> {
 /// Payload for [`Event::UserPacket`]: an application-level user-data packet.
 #[derive(Debug)]
 pub struct UserPacket<A> {
-  /// The logical peer identity the packet arrived from — the membership
-  /// address, a best-effort transport-origin hint. It is explicitly NOT the raw
-  /// post-migration transport 4-tuple: a QUIC connection may migrate its egress
-  /// path, but the identity here stays the membership address the connection was
+  /// The peer address this packet arrived on — a best-effort transport-origin
+  /// hint, direction-aware: for a reliable delivery, the advertised membership
+  /// address we dialed (outbound) or the accept-time transport source
+  /// (inbound); for an unreliable delivery, the datagram source socket. It is
+  /// explicitly NOT the raw post-migration transport 4-tuple: a QUIC connection
+  /// may migrate its egress path, but this stays the address the connection was
   /// keyed on. Identity-critical routing uses the advertised SWIM-payload
   /// address rather than this hint.
   from: A,
@@ -443,6 +535,15 @@ impl<A> UserPacket<A> {
 /// Surfaces the `user_data` the FSM layer does not itself consult, so the
 /// driver can hand it to the application (the Sans-I/O analog of Go
 /// memberlist's `MergeRemoteState`).
+///
+/// The [`peer`](Self::peer_ref) address is direction-aware: the address the
+/// delivering connection was keyed on — the advertised membership address we
+/// dialed for an OUTBOUND exchange, the accept-time transport source (typically
+/// the peer's ephemeral socket) for an INBOUND one. It is a best-effort
+/// transport-origin hint, stable for the connection's life and immutable under
+/// QUIC migration. Identity-critical consumers use the push/pull payload
+/// `states` (each entry carries its own advertised address) and
+/// [`originating_stream_id`](Self::originating_stream_id), never this hint.
 #[derive(Debug)]
 pub struct RemoteStateReceived<A> {
   peer: A,
@@ -478,7 +579,12 @@ impl<A> RemoteStateReceived<A> {
     }
   }
 
-  /// The peer that supplied the state.
+  /// The peer address this merge's connection was keyed on: the advertised
+  /// membership address we dialed for an OUTBOUND exchange, the accept-time
+  /// transport source (typically the peer's ephemeral socket) for an INBOUND
+  /// one — a best-effort transport-origin hint. Identity-critical consumers use
+  /// the push/pull payload `states` and
+  /// [`originating_stream_id`](Self::originating_stream_id), never this hint.
   #[inline(always)]
   pub const fn peer_ref(&self) -> &A {
     &self.peer
@@ -781,6 +887,22 @@ pub enum Event<I, A> {
   /// emit this event — synchronous-join drivers observe only their
   /// own outbound exchange's terminal outcome.
   ExchangeCompleted(ExchangeCompleted<A>),
+  /// A `start_*`-returned [`StreamId`] was retired before any
+  /// [`StreamAction::Connect`] surfaced for it (expired intent, rejected
+  /// record-layer context, dialer construction failure, or a not-running
+  /// endpoint). Emitted by the STREAM-transport coordinator ONLY, exactly once
+  /// per such id — so the stream lifecycle is total: every `start_*` id reaches
+  /// exactly one of `Connect` (whose terminal later arrives as
+  /// [`Event::ExchangeCompleted`]), [`Event::DialAborted`], or — for
+  /// `start_user_message` only — a synchronous `Err`. The QUIC coordinator
+  /// instead reports a pre-bridge dial failure as a `Failed`
+  /// [`Event::ExchangeCompleted`] keyed `ExchangeId::from(stream_id)`
+  /// (`retire_failed_dial`), so it never emits this. Machine-scheduled dials
+  /// (anti-entropy push/pull, probe fallbacks with no staged kind) carry no
+  /// public start id and do NOT emit it; they self-heal on their schedulers.
+  ///
+  /// [`StreamAction::Connect`]: crate::streams::StreamAction::Connect
+  DialAborted(DialAborted<A>),
 }
 
 /// Payload for [`EndpointEvent::PushPullRequestReceived`]: an inbound

--- a/memberlist-proto/src/event/mod.rs
+++ b/memberlist-proto/src/event/mod.rs
@@ -244,6 +244,11 @@ pub enum DialAbortReason {
   /// The endpoint is leaving or has left, so no dial was initiated for the
   /// (inert) id the `start_*` call returned.
   NotRunning,
+  /// The dial was cancelled by a graceful leave that began after it was started:
+  /// its `Connect` was queued but never drained by the driver, so the leave
+  /// retires the id here. Distinct from [`Self::NotRunning`], which is a dial
+  /// started while the endpoint was already leaving/left.
+  Leaving,
 }
 
 /// Payload for [`Event::DialAborted`]: a [`StreamId`] returned by a `start_*`
@@ -842,6 +847,10 @@ impl<A> DialIntent<A> {
 }
 
 /// Application-facing event drained from [`Endpoint::poll_event`].
+///
+/// This enum is deliberately exhaustive and gains variants in 0.x minor
+/// releases; match it exhaustively so a new lifecycle event is a compile-time
+/// decision at upgrade, never a silently discarded runtime event.
 #[derive(Debug)]
 pub enum Event<I, A> {
   /// A peer transitioned `Dead`/`Left` → `Alive`, or appeared for the first time.
@@ -887,16 +896,25 @@ pub enum Event<I, A> {
   /// emit this event — synchronous-join drivers observe only their
   /// own outbound exchange's terminal outcome.
   ExchangeCompleted(ExchangeCompleted<A>),
-  /// A `start_*`-returned [`StreamId`] was retired before any
-  /// [`StreamAction::Connect`] surfaced for it (expired intent, rejected
-  /// record-layer context, dialer construction failure, or a not-running
-  /// endpoint). Emitted by the STREAM-transport coordinator ONLY, exactly once
-  /// per such id — so the stream lifecycle is total: every `start_*` id reaches
-  /// exactly one of `Connect` (whose terminal later arrives as
-  /// [`Event::ExchangeCompleted`]), [`Event::DialAborted`], or — for
-  /// `start_user_message` only — a synchronous `Err`. The QUIC coordinator
-  /// instead reports a pre-bridge dial failure as a `Failed`
-  /// [`Event::ExchangeCompleted`] keyed `ExchangeId::from(stream_id)`
+  /// A `start_*`-returned [`StreamId`] was retired before its
+  /// [`StreamAction::Connect`] was drained by the driver (expired intent,
+  /// rejected record-layer context, dialer construction failure, a not-running
+  /// endpoint, or a graceful leave that cancels a still-queued `Connect`).
+  /// Emitted by the STREAM-transport coordinator ONLY.
+  ///
+  /// This is one arm of the stream backend's TOTALITY guarantee: every
+  /// `start_*`-returned [`StreamId`] receives exactly one machine-emitted
+  /// terminal — a synchronous `Err` (`start_user_message` only), a
+  /// [`Event::DialAborted`] (retired before its `Connect` was drained, including
+  /// a leave that cancels a still-queued `Connect`), or — once its `Connect` has
+  /// been drained — exactly one `eid`-keyed [`Event::ExchangeCompleted`].
+  /// Correlate by draining [`poll_action`](crate::streams::StreamEndpoint::poll_action)
+  /// after each `start_*` (the `Connect` is queued in-band within the call). The
+  /// guarantee is emission into the event queue; a driver that stops polling
+  /// forfeits delivery.
+  ///
+  /// The QUIC coordinator instead reports a pre-bridge dial failure as a
+  /// `Failed` [`Event::ExchangeCompleted`] keyed `ExchangeId::from(stream_id)`
   /// (`retire_failed_dial`), so it never emits this. Machine-scheduled dials
   /// (anti-entropy push/pull, probe fallbacks with no staged kind) carry no
   /// public start id and do NOT emit it; they self-heal on their schedulers.

--- a/memberlist-proto/src/streams/mod.rs
+++ b/memberlist-proto/src/streams/mod.rs
@@ -766,16 +766,48 @@ where
   /// (its `Connect` never drained) and by the post-leave inbound mint guard for
   /// an un-minted acceptor bridge — so a cancelled exchange leaves no live
   /// bridge (no stream deadline, no record-layer buffer) and emits no bytes.
-  fn cancel_exchange(&mut self, id: ExchangeId) {
+  ///
+  /// When `emit_terminal` is `true` and the exchange carries a start-originated
+  /// kind (an outbound `start_*` exchange whose `Connect` the driver already
+  /// drained, so it holds the `eid`), this emits the exchange's ONE machine
+  /// terminal: a `Failed` [`Event::ExchangeCompleted`] — a leave-cancel is
+  /// honestly `Failed`. Pass `false` when the caller already emitted this id's
+  /// terminal (a still-queued `Connect` retired with a
+  /// [`Event::DialAborted`]); its DialAborted is the one terminal, so a second
+  /// emission here would break the one-terminal-per-`StreamId` invariant.
+  /// Inbound exchanges carry `kind == None` and never emit either way.
+  fn cancel_exchange(&mut self, id: ExchangeId, emit_terminal: bool)
+  where
+    A: crate::CheapClone,
+  {
     // Ignoring the removed bridge: a never-opened exchange owes the peer no
     // clean-close bytes, and dropping it clears its record-layer state.
     let _ = self.conns.remove(id);
-    // No `ExchangeCompleted` here. This path runs on leave, where a driver
-    // resolves a parked waiter via its own leave/shutdown drain with the clearer
-    // `Shutdown` signal; emitting a generic `Failed` would double-resolve it and
-    // mask that. The genuinely-stranding case (a dial that retired without a
-    // drain covering it) emits from the `dial_succeeded(None)` reap instead.
-    self.exchanges.remove(&id);
+    let removed = self.exchanges.remove(&id);
+    // Emit the exchange's single terminal for a kind-bearing outbound exchange
+    // the driver already correlated (its `Connect` was drained, so it holds the
+    // `eid`): a leave-cancel is a `Failed` `ExchangeCompleted`, the same
+    // kind-gated payload discipline `reap_bridge` uses. This resolves a parked
+    // reliable-send / join waiter PROMPTLY at leave. The reactor has NO leave
+    // drain — only a shutdown drain — so without this terminal such a waiter
+    // hangs from leave until shutdown; QUIC is already total at leave via
+    // `retire_failed_dial`, and this brings the stream backend to parity. A
+    // double-resolve is impossible: driver `account_event` resolve-and-removes
+    // the `eid`-keyed entry once, so a later terminal for the same `eid` finds
+    // nothing to resolve.
+    if emit_terminal
+      && let Some(meta) = &removed
+      && let Some(kind) = meta.kind
+    {
+      self
+        .ep
+        .emit_event(Event::ExchangeCompleted(ExchangeCompleted::new(
+          id,
+          crate::CheapClone::cheap_clone(&meta.peer),
+          ExchangeStatus::Failed,
+          kind,
+        )));
+    }
     self.purge_transmit_for(id);
     // Replace any teardown already queued for this id with an Abort, so the
     // driver tears down a transport connection it may have already opened (the
@@ -1518,19 +1550,89 @@ where
   /// [`leave`](Self::leave) with an explicit farewell payload reserved into
   /// every dead-self compound ahead of the ordinary queue drain (see
   /// [`Endpoint::leave_with`](crate::Endpoint::leave_with)).
+  ///
+  /// A graceful leave TERMINALIZES every cancelled outbound exchange so a parked
+  /// reliable-send / join waiter resolves promptly — an `ExchangeCompleted`
+  /// (`Failed`) for one whose `Connect` was already drained, a
+  /// [`Event::DialAborted`] (`Leaving`) for one whose `Connect` was still
+  /// queued. The driver's own hard-shutdown teardown instead uses
+  /// [`leave_silent`](Self::leave_silent), which cancels identically but emits
+  /// no application terminals (shutdown reaps every parked waiter with its own
+  /// `Shutdown` outcome, which a leave-cancel terminal would otherwise preempt).
   pub fn leave_with(&mut self, now: Instant, farewell: Option<Bytes>) -> Result<(), Error> {
+    self.leave_inner(now, farewell, true)
+  }
+
+  /// Non-terminalizing sibling of [`leave_with`](Self::leave_with) for the
+  /// driver's hard-shutdown teardown: cancels every unsent outbound exchange
+  /// identically (so no pre-leave request reaches the wire during the drain) but
+  /// emits NO per-exchange application terminal. Shutdown fails every parked
+  /// waiter with its own `Shutdown` outcome; a leave-cancel `ExchangeCompleted` /
+  /// [`Event::DialAborted`] here would resolve the waiter FIRST with the
+  /// less-specific `SendFailed` / `JoinFailed`, changing the observed
+  /// shutdown result.
+  pub fn leave_silent(&mut self, now: Instant) -> Result<(), Error> {
+    self.leave_inner(now, None, false)
+  }
+
+  /// Shared body of [`leave_with`](Self::leave_with) and
+  /// [`leave_silent`](Self::leave_silent). `terminalize` gates whether the
+  /// cancelled outbound exchanges emit their application terminal
+  /// (`ExchangeCompleted(Failed)` / [`Event::DialAborted`]); the cancellation
+  /// itself (bridge drop, transmit purge, `Abort` teardown) is identical either
+  /// way.
+  fn leave_inner(
+    &mut self,
+    now: Instant,
+    farewell: Option<Bytes>,
+    terminalize: bool,
+  ) -> Result<(), Error> {
     self.last_now = Some(now);
     self.dial_pending.clear();
     self.pending_outbound_kinds.clear();
-    self.pending_connects.clear();
+    // Drain the still-queued `Connect` directives BEFORE clearing them. Each
+    // names an outbound exchange whose `Connect` the driver never observed
+    // (queued == un-polled), so it never received a `Connect` to later complete
+    // as an `ExchangeCompleted`: under `terminalize`, its ONE terminal is a
+    // `DialAborted { Leaving }` keyed by the originating `StreamId`.
+    // `cancel_exchange(_, false)` then tears it down WITHOUT a second
+    // (ExchangeCompleted) terminal and removes it from `exchanges`, so the
+    // unsent-outbound sweep below no longer sees it. A machine-scheduled dial
+    // (kind `None`) emits nothing, per the totality contract. `Vec` keeps this
+    // no_std-clean (the queue is small).
+    let queued_connects: Vec<StreamAction> = self.pending_connects.drain(..).collect();
+    for action in queued_connects {
+      if let StreamAction::Connect(info) = action {
+        let id = info.id();
+        if terminalize {
+          let terminal = self.exchanges.get(&id).and_then(|meta| {
+            meta
+              .kind
+              .map(|kind| (crate::CheapClone::cheap_clone(&meta.peer), kind))
+          });
+          if let Some((peer, kind)) = terminal {
+            self.ep.emit_event(Event::DialAborted(DialAborted::new(
+              info.stream_id(),
+              peer,
+              kind,
+              DialAbortReason::Leaving,
+            )));
+          }
+        }
+        self.cancel_exchange(id, false);
+      }
+    }
     // Drop inbound gossip buffered before leave — handle_packet would drop it
     // anyway once not Running, so it must not linger or later decode.
     self.mem_ingress.clear();
     // Cancel every OUTBOUND exchange (kind is Some) whose request bytes are still
-    // queued in out_transmit: its `Connect` may already be drained, but the
-    // request is not yet on the wire, so writing it after leave would advertise
-    // our pre-leave Alive. Inbound exchanges and request-sent outbound exchanges
-    // are left to drain. A `Vec` keeps this no_std-clean (the set is small).
+    // queued in out_transmit: its `Connect` was already drained (the queued ones
+    // were retired above), but the request is not yet on the wire, so writing it
+    // after leave would advertise our pre-leave Alive. Under `terminalize` the
+    // driver holds this exchange's `eid`, so its terminal is the one
+    // `ExchangeCompleted(Failed)` `cancel_exchange(_, true)` emits. Inbound
+    // exchanges and request-sent outbound exchanges are left to drain. A `Vec`
+    // keeps this no_std-clean.
     let unsent_outbound: Vec<ExchangeId> = self
       .exchanges
       .iter()
@@ -1539,7 +1641,7 @@ where
       .collect();
     for eid in unsent_outbound {
       if self.exchange_has_pending_bytes(eid) {
-        self.cancel_exchange(eid);
+        self.cancel_exchange(eid, terminalize);
       }
     }
     self.ep.leave_with(now, farewell)
@@ -1938,7 +2040,9 @@ where
             // settles during the drain is fully cancelled, so its record layer
             // queues and emits no bytes and it holds no buffers to the deadline.
             // `accept_stream` owns the lifecycle decision; `None` is the signal.
-            self.cancel_exchange(id);
+            // Inbound exchanges carry `kind == None`, so `emit_terminal` here is
+            // a no-op — no start id ever correlated this stream.
+            self.cancel_exchange(id, true);
           }
         },
       }

--- a/memberlist-proto/src/streams/mod.rs
+++ b/memberlist-proto/src/streams/mod.rs
@@ -1625,22 +1625,37 @@ where
     // Drop inbound gossip buffered before leave — handle_packet would drop it
     // anyway once not Running, so it must not linger or later decode.
     self.mem_ingress.clear();
-    // Cancel every OUTBOUND exchange (kind is Some) whose request bytes are still
-    // queued in out_transmit: its `Connect` was already drained (the queued ones
-    // were retired above), but the request is not yet on the wire, so writing it
-    // after leave would advertise our pre-leave Alive. Under `terminalize` the
-    // driver holds this exchange's `eid`, so its terminal is the one
-    // `ExchangeCompleted(Failed)` `cancel_exchange(_, true)` emits. Inbound
-    // exchanges and request-sent outbound exchanges are left to drain. A `Vec`
-    // keeps this no_std-clean.
-    let unsent_outbound: Vec<ExchangeId> = self
+    // Cancel every OUTBOUND exchange whose APPLICATION request has not reached
+    // the wire — its `Connect` was already drained (the queued ones were retired
+    // above), so writing its request after leave would advertise our pre-leave
+    // Alive. Two states qualify:
+    //   (a) request bytes still queued in `out_transmit`; or
+    //   (b) the bridge is still an unminted `PendingMint::Outbound` — a
+    //       handshaking dialer whose record-layer prefix (e.g. a TLS ClientHello)
+    //       has already flushed (`out_transmit` empty) while the application
+    //       request is still held in the inner endpoint's pending intent, unsent.
+    //       `leave` clears that intent, so without cancelling here the
+    //       handshaking bridge would linger with no terminal until its stream
+    //       deadline, leaving a parked reliable-send / join unresolved.
+    // A MINTED bridge with an empty `out_transmit` has handed its request to the
+    // transport and is genuinely in-flight; it (and inbound exchanges) is left to
+    // drain — its terminal arrives from `reap_bridge`, never here, so it is not
+    // double-terminalized. Under `terminalize` the driver holds a drained-Connect
+    // exchange's `eid`, so its one terminal is the `ExchangeCompleted(Failed)`
+    // `cancel_exchange(_, true)` emits; `cancel_exchange` also tears the
+    // handshaking bridge down. A `Vec` keeps this no_std-clean.
+    let outbound: Vec<ExchangeId> = self
       .exchanges
       .iter()
       .filter(|(_, meta)| meta.outbound)
       .map(|(eid, _)| *eid)
       .collect();
-    for eid in unsent_outbound {
-      if self.exchange_has_pending_bytes(eid) {
+    for eid in outbound {
+      let unminted_outbound = matches!(
+        self.exchanges.get(&eid).map(|meta| &meta.mint),
+        Some(Some(PendingMint::Outbound(_)))
+      );
+      if self.exchange_has_pending_bytes(eid) || unminted_outbound {
         self.cancel_exchange(eid, terminalize);
       }
     }

--- a/memberlist-proto/src/streams/mod.rs
+++ b/memberlist-proto/src/streams/mod.rs
@@ -101,7 +101,8 @@ use crate::{
   endpoint::Endpoint,
   error::{Error, StreamError},
   event::{
-    Event, ExchangeCompleted, ExchangeKind, ExchangeStatus, PushPullKind, StreamId, Transmit,
+    DialAbortReason, DialAborted, Event, ExchangeCompleted, ExchangeKind, ExchangeStatus,
+    PushPullKind, StreamId, Transmit,
   },
 };
 use bridge::StreamBridge;
@@ -155,10 +156,11 @@ struct ExchangeMeta<A> {
   /// tagged with so the driver writes the bytes on the right transport
   /// connection.
   peer_socket: SocketAddr,
-  /// The membership address (`A`) of the peer. Carried alongside
-  /// `peer_socket` so the bridge-reap path can emit the generic
-  /// [`Event::ExchangeCompleted`] payload without a back-conversion from
-  /// `SocketAddr` to `A`.
+  /// The address this exchange is keyed on: the dialed advertised address
+  /// (outbound) or the accept-time transport source (inbound); echoed on this
+  /// exchange's events. Carried alongside `peer_socket` so the bridge-reap path
+  /// can emit the generic [`Event::ExchangeCompleted`] payload without a
+  /// back-conversion from `SocketAddr` to `A`.
   peer: A,
   /// `Some` until the label / handshake step settles and the coordinator mints
   /// + promotes the `Stream`; `None` afterwards (an `Established` bridge needs
@@ -1972,6 +1974,14 @@ where
   /// with. The `Stream` is minted later (at label / handshake settled, via
   /// `Endpoint::accept_stream`).
   ///
+  /// `from` is the accepted connection's remote transport socket (typically the
+  /// peer's ephemeral source), echoed verbatim as the best-effort
+  /// transport-origin hint on this stream's inbound events
+  /// ([`UserPacket::from_ref`](crate::event::UserPacket::from_ref),
+  /// [`RemoteStateReceived::peer_ref`](crate::event::RemoteStateReceived::peer_ref)) —
+  /// NOT the peer's advertised membership address. Identity-critical consumers
+  /// read the advertised address from the push/pull payload instead.
+  ///
   /// Returns `None` when the connection is NOT admitted: the node is
   /// leaving/left, the optional `max_inbound_streams` ceiling is reached, or the
   /// record-layer acceptor is misconfigured. No bridge is built, so the driver
@@ -2075,22 +2085,36 @@ where
       // emitted outside this coordinator's start path — kept defensive
       // (reap then does not emit a kind-specific event for this exchange).
       let exchange_kind = self.pending_outbound_kinds.remove(&id);
+      // Clone the membership address up front: every pre-`ExchangeMeta` failure
+      // path below emits a `DialAborted` (which consumes it) after
+      // `dial_failed`, and the success path stamps it onto the `ExchangeMeta`.
+      // Each failure branch `continue`s, so the clone survives to the success
+      // path.
+      let peer_a = crate::CheapClone::cheap_clone(&peer);
       // Retire the intent without opening a connection if its own deadline
       // has already elapsed (mirrors the sibling coordinators'
-      // expired-intent gate).
+      // expired-intent gate). Emit `DialAborted` when the kind is
+      // start-originated so the returned `StreamId` reaches a terminal.
       if now >= deadline {
         self.ep.dial_failed(
           id,
           StreamError::DialFailed("stream dial deadline elapsed".into()),
           now,
         );
+        if let Some(kind) = exchange_kind {
+          self.ep.emit_event(Event::DialAborted(DialAborted::new(
+            id,
+            peer_a,
+            kind,
+            DialAbortReason::DeadlineElapsed,
+          )));
+        }
         continue;
       }
       // SocketAddr conversion needed: `peer_socket` tags entries on
       // `out_transmit` and the `StreamAction::Connect(ConnectInfo)` payload
       // (both driver-facing SocketAddr-typed surfaces).
       let peer_socket = (self.peer_to_socket)(&peer);
-      let peer_a = crate::CheapClone::cheap_clone(&peer);
       // Resolve the per-dial record-layer context (e.g. the TLS verification
       // identity). An `Err` is the soft-fail-via-dial_failed path —
       // retire the intent for this one peer and move on.
@@ -2101,6 +2125,14 @@ where
           self
             .ep
             .dial_failed(id, StreamError::DialFailed(msg.into()), now);
+          if let Some(kind) = exchange_kind {
+            self.ep.emit_event(Event::DialAborted(DialAborted::new(
+              id,
+              peer_a,
+              kind,
+              DialAbortReason::DialContext,
+            )));
+          }
           continue;
         }
       };
@@ -2115,6 +2147,14 @@ where
             StreamError::DialFailed(format!("record-layer construction failed: {e}").into()),
             now,
           );
+          if let Some(kind) = exchange_kind {
+            self.ep.emit_event(Event::DialAborted(DialAborted::new(
+              id,
+              peer_a,
+              kind,
+              DialAbortReason::RecordLayer,
+            )));
+          }
           continue;
         }
       };
@@ -2406,10 +2446,25 @@ where
   /// `handle_timeout` pre-pump.
   pub fn start_push_pull(&mut self, peer: A, kind: PushPullKind, now: Instant) -> StreamId {
     self.last_now = Some(now);
+    // The inner endpoint returns an inert id (no `DialRequested` enqueued) when
+    // leaving/left. Clone the address up front so the not-running branch can
+    // terminate that id with a `DialAborted` without staging it — staging would
+    // leave a `pending_outbound_kinds` entry that `service_dials` never drains
+    // while not running.
+    let peer_a = crate::CheapClone::cheap_clone(&peer);
     let id = self.ep.start_push_pull(peer, kind, now);
+    if !self.ep.is_running() {
+      self.ep.emit_event(Event::DialAborted(DialAborted::new(
+        id,
+        peer_a,
+        ExchangeKind::PushPull,
+        DialAbortReason::NotRunning,
+      )));
+      return id;
+    }
     self
       .pending_outbound_kinds
-      .insert(id, crate::event::ExchangeKind::PushPull);
+      .insert(id, ExchangeKind::PushPull);
     self.service_dials(now);
     self.flush_outbound(now);
     id
@@ -2433,12 +2488,24 @@ where
     now: Instant,
   ) -> StreamId {
     self.last_now = Some(now);
+    // See `start_push_pull`: a not-running endpoint hands back an inert id.
+    // Terminate it with a `DialAborted` and do not stage its kind.
+    let peer_a = crate::CheapClone::cheap_clone(&peer_addr);
     let id = self
       .ep
       .start_reliable_ping(peer_id, peer_addr, probe_seq, deadline);
+    if !self.ep.is_running() {
+      self.ep.emit_event(Event::DialAborted(DialAborted::new(
+        id,
+        peer_a,
+        ExchangeKind::ReliablePing,
+        DialAbortReason::NotRunning,
+      )));
+      return id;
+    }
     self
       .pending_outbound_kinds
-      .insert(id, crate::event::ExchangeKind::ReliablePing);
+      .insert(id, ExchangeKind::ReliablePing);
     self.service_dials(now);
     self.flush_outbound(now);
     id

--- a/memberlist-proto/src/streams/tests.rs
+++ b/memberlist-proto/src/streams/tests.rs
@@ -17,9 +17,11 @@ mod tcp {
   use bytes::Bytes;
   use smol_str::SmolStr;
 
+  use std::collections::HashMap;
+
   use crate::{
     RawRecords,
-    event::{DialAbortReason, Event, ExchangeKind, PushPullKind, StreamId},
+    event::{DialAbortReason, Event, ExchangeKind, ExchangeStatus, PushPullKind, StreamId},
     streams::{
       LabelOptions, StreamAction, StreamEndpoint,
       bridge::StreamBridge,
@@ -704,6 +706,212 @@ mod tcp {
     assert!(
       coord.poll_action().is_none(),
       "no Connect surfaces for the expired kind-None dial",
+    );
+  }
+
+  /// Leave terminality (drained-Connect path): two outbound exchanges whose
+  /// `Connect` the driver has already drained (observed) are, on `leave()`,
+  /// terminalized as exactly one `ExchangeCompleted(Failed, kind)` each — the
+  /// driver holds each `eid`, so its parked waiter resolves at leave — plus one
+  /// `Abort` teardown; NO `DialAborted`.
+  #[test]
+  fn leave_after_draining_connects_terminalizes_each_unsent_exchange_as_failed() {
+    let now = Instant::now();
+    let mut coord = coord(7130);
+    let um_sid = coord
+      .start_user_message(addr(7001), Bytes::from_static(b"m"), now)
+      .expect("issued while running");
+    let pp_sid = coord.start_push_pull(addr(7002), PushPullKind::Join, now);
+
+    // Drain (observe) the Connect actions, recording each StreamId -> ExchangeId.
+    let mut eid_by_sid = HashMap::new();
+    while let Some(a) = coord.poll_action() {
+      if let StreamAction::Connect(info) = a {
+        eid_by_sid.insert(info.stream_id(), info.id());
+      }
+    }
+    assert_eq!(eid_by_sid.len(), 2, "both dials surfaced a Connect");
+
+    coord.leave(now).expect("leave from a running node");
+
+    let mut completed = Vec::new();
+    let mut aborts = 0;
+    while let Some(ev) = coord.poll_event() {
+      match ev {
+        Event::ExchangeCompleted(c) => completed.push((c.eid(), c.outcome(), c.kind())),
+        Event::DialAborted(_) => aborts += 1,
+        _ => {}
+      }
+    }
+    assert_eq!(
+      aborts, 0,
+      "a drained-Connect exchange completes, never DialAborted"
+    );
+    completed.sort_by_key(|(eid, _, _)| eid.get());
+    // Exactly one Failed completion per exchange, carrying the originating kind.
+    assert_eq!(
+      completed.len(),
+      2,
+      "exactly one terminal per drained exchange"
+    );
+    let um_eid = eid_by_sid[&um_sid];
+    let pp_eid = eid_by_sid[&pp_sid];
+    assert!(
+      completed.iter().any(|&(e, s, k)| e == um_eid
+        && s == ExchangeStatus::Failed
+        && k == ExchangeKind::UserMessage),
+      "the user-message exchange completed Failed with its kind",
+    );
+    assert!(
+      completed.iter().any(|&(e, s, k)| e == pp_eid
+        && s == ExchangeStatus::Failed
+        && k == ExchangeKind::PushPull),
+      "the push/pull exchange completed Failed with its kind",
+    );
+
+    // One Abort teardown per cancelled exchange; nothing further.
+    let mut abort_actions = 0;
+    while let Some(a) = coord.poll_action() {
+      match a {
+        StreamAction::Abort(_) => abort_actions += 1,
+        StreamAction::Connect(_) => panic!("a left node surfaces no Connect"),
+        _ => {}
+      }
+    }
+    assert_eq!(
+      abort_actions, 2,
+      "one Abort teardown per cancelled exchange"
+    );
+    assert_eq!(coord.live_bridge_count(), 0, "no bridge survives the leave");
+  }
+
+  /// Leave terminality (queued-Connect path): two outbound exchanges whose
+  /// `Connect` the driver has NEVER drained are, on `leave()`, terminalized as
+  /// exactly one `DialAborted { Leaving }` each (keyed by the originating
+  /// `StreamId`); NO `ExchangeCompleted`, and no `Connect` ever surfaces.
+  #[test]
+  fn leave_without_draining_connects_aborts_each_with_leaving_reason() {
+    let now = Instant::now();
+    let mut coord = coord(7131);
+    let um_sid = coord
+      .start_user_message(addr(7001), Bytes::from_static(b"m"), now)
+      .expect("issued while running");
+    let pp_sid = coord.start_push_pull(addr(7002), PushPullKind::Join, now);
+
+    // Do NOT drain the Connect actions: they stay queued until leave.
+    coord.leave(now).expect("leave from a running node");
+
+    let mut completed = 0;
+    let mut aborts = Vec::new();
+    while let Some(ev) = coord.poll_event() {
+      match ev {
+        Event::ExchangeCompleted(_) => completed += 1,
+        Event::DialAborted(a) => aborts.push((a.stream_id(), a.kind(), a.reason())),
+        _ => {}
+      }
+    }
+    assert_eq!(
+      completed, 0,
+      "a still-queued Connect is DialAborted, never completed"
+    );
+    assert_eq!(aborts.len(), 2, "exactly one DialAborted per started id");
+    assert!(
+      aborts.contains(&(um_sid, ExchangeKind::UserMessage, DialAbortReason::Leaving)),
+      "the user-message id was aborted with the Leaving reason",
+    );
+    assert!(
+      aborts.contains(&(pp_sid, ExchangeKind::PushPull, DialAbortReason::Leaving)),
+      "the push/pull id was aborted with the Leaving reason",
+    );
+
+    while let Some(a) = coord.poll_action() {
+      assert!(
+        !matches!(a, StreamAction::Connect(_)),
+        "a left node surfaces no Connect for a still-queued dial",
+      );
+    }
+    assert_eq!(coord.live_bridge_count(), 0, "no bridge survives the leave");
+  }
+
+  /// Totality invariant across a mixed interleaving: every kind-bearing
+  /// `StreamId` receives EXACTLY ONE machine-emitted terminal at leave — an
+  /// `ExchangeCompleted(Failed)` for an exchange whose `Connect` was drained, a
+  /// `DialAborted(Leaving)` for one whose `Connect` was still queued.
+  #[test]
+  fn leave_emits_exactly_one_terminal_per_kind_bearing_stream_id() {
+    let now = Instant::now();
+    let mut coord = coord(7140);
+
+    // Two exchanges whose Connect the driver drains (observes) before leave.
+    let drained = [
+      coord
+        .start_user_message(addr(7001), Bytes::from_static(b"a"), now)
+        .expect("issued while running"),
+      coord.start_push_pull(addr(7002), PushPullKind::Join, now),
+    ];
+    let mut eid_by_sid = HashMap::new();
+    while let Some(a) = coord.poll_action() {
+      if let StreamAction::Connect(info) = a {
+        eid_by_sid.insert(info.stream_id(), info.id());
+      }
+    }
+
+    // Two more started AFTER that drain: their Connect stays queued at leave.
+    let queued = [
+      coord
+        .start_user_message(addr(7003), Bytes::from_static(b"c"), now)
+        .expect("issued while running"),
+      coord.start_push_pull(addr(7004), PushPullKind::Refresh, now),
+    ];
+
+    coord.leave(now).expect("leave from a running node");
+
+    let mut completed_eids = Vec::new();
+    let mut aborted_sids = Vec::new();
+    while let Some(ev) = coord.poll_event() {
+      match ev {
+        Event::ExchangeCompleted(c) if c.outcome() == ExchangeStatus::Failed => {
+          completed_eids.push(c.eid());
+        }
+        Event::DialAborted(a) if a.reason() == DialAbortReason::Leaving => {
+          aborted_sids.push(a.stream_id());
+        }
+        _ => {}
+      }
+    }
+
+    // Each drained sid: exactly one ExchangeCompleted(Failed) via its eid, and
+    // never a DialAborted.
+    for sid in drained {
+      let eid = eid_by_sid[&sid];
+      assert_eq!(
+        completed_eids.iter().filter(|&&e| e == eid).count(),
+        1,
+        "a drained-Connect id completes exactly once",
+      );
+      assert!(
+        !aborted_sids.contains(&sid),
+        "a drained-Connect id is not also DialAborted",
+      );
+    }
+    // Each queued sid: exactly one DialAborted(Leaving); its eid was never
+    // allocated to the driver, so it cannot appear as a completion.
+    for sid in queued {
+      assert_eq!(
+        aborted_sids.iter().filter(|&&s| s == sid).count(),
+        1,
+        "a queued-Connect id is aborted exactly once",
+      );
+      assert!(
+        !eid_by_sid.contains_key(&sid),
+        "a queued-Connect id never surfaced an eid",
+      );
+    }
+    // Exactly four terminals — one per started kind-bearing StreamId.
+    assert_eq!(
+      completed_eids.len() + aborted_sids.len(),
+      4,
+      "exactly one machine terminal per kind-bearing StreamId",
     );
   }
 }

--- a/memberlist-proto/src/streams/tests.rs
+++ b/memberlist-proto/src/streams/tests.rs
@@ -1233,6 +1233,139 @@ mod tls {
     );
   }
 
+  /// Completeness of the leave-cancellation sweep: a drained-`Connect` outbound
+  /// TLS exchange whose ClientHello has ALREADY flushed (`out_transmit` empty)
+  /// while the bridge is still an unminted `PendingMint::Outbound` — the peer
+  /// crash-stopped after the ClientHello, sending no handshake response and no
+  /// FIN — is terminalized PROMPTLY by `leave()`, with NO dependence on the
+  /// stream deadline. The sweep's second predicate (unminted `PendingMint::
+  /// Outbound`, not just non-empty `out_transmit`) catches it: exactly one
+  /// `ExchangeCompleted(Failed)`, the handshaking bridge torn down, an `Abort`
+  /// queued, and no duplicate terminal.
+  #[test]
+  fn leave_terminalizes_flushed_unminted_tls_handshake_exchange() {
+    let now = Instant::now();
+    let mut coord = tls_coord(7330);
+    let _sid = coord.start_push_pull(addr(7000), PushPullKind::Join, now);
+    let exchange = match coord.poll_action().expect("the dial surfaces a Connect") {
+      StreamAction::Connect(c) => c.id(),
+      other => panic!("expected Connect, got {other:?}"),
+    };
+    while coord.poll_action().is_some() {}
+
+    // Drain the flushed ClientHello so `out_transmit` is empty; feed NO server
+    // response, so the bridge stays Handshaking (unminted `PendingMint::Outbound`).
+    let mut hello_bytes = 0usize;
+    while let Some((_id, _peer, bytes)) = coord.poll_transport_transmit() {
+      hello_bytes += bytes.len();
+    }
+    assert!(hello_bytes > 0, "the TLS dialer flushed a ClientHello");
+    assert_eq!(
+      coord.live_bridge_count(),
+      1,
+      "the handshaking bridge is live (unminted) before leave",
+    );
+
+    // Leave WITHOUT advancing time or firing a timeout.
+    coord.leave(now).expect("leave from a running node");
+
+    let mut completed = Vec::new();
+    let mut aborts = 0;
+    while let Some(ev) = coord.poll_event() {
+      match ev {
+        Event::ExchangeCompleted(c) => completed.push((c.eid(), c.outcome(), c.kind())),
+        Event::DialAborted(_) => aborts += 1,
+        _ => {}
+      }
+    }
+    assert_eq!(
+      aborts, 0,
+      "a drained-Connect exchange completes, never DialAborted"
+    );
+    assert_eq!(
+      completed.as_slice(),
+      &[(exchange, ExchangeStatus::Failed, ExchangeKind::PushPull)],
+      "one immediate Failed completion for the flushed-but-unminted TLS exchange",
+    );
+    assert_eq!(
+      coord.live_bridge_count(),
+      0,
+      "the handshaking bridge is torn down by the leave cancel",
+    );
+
+    // The teardown surfaces an Abort (the half-open TLS connection is not left
+    // live); no `Connect` and no duplicate terminal.
+    let mut aborted = false;
+    while let Some(a) = coord.poll_action() {
+      match a {
+        StreamAction::Abort(r) if r.id() == exchange => aborted = true,
+        StreamAction::Connect(_) => panic!("a left node surfaces no Connect"),
+        _ => {}
+      }
+    }
+    assert!(
+      aborted,
+      "leave queues an Abort to tear the half-open TLS connection down"
+    );
+    let mut duplicate_terminals = 0;
+    while let Some(ev) = coord.poll_event() {
+      if matches!(ev, Event::ExchangeCompleted(_) | Event::DialAborted(_)) {
+        duplicate_terminals += 1;
+      }
+    }
+    assert_eq!(
+      duplicate_terminals, 0,
+      "no duplicate terminal after the leave"
+    );
+  }
+
+  /// The `leave_silent` twin (the driver's hard-shutdown teardown path): the same
+  /// flushed-but-unminted TLS exchange is cancelled and its handshaking bridge
+  /// torn down (the connection is not left live), but NO application terminal is
+  /// emitted — the shutdown drain reaps the parked waiter with its own `Shutdown`
+  /// outcome, which a leave-cancel terminal would preempt.
+  #[test]
+  fn leave_silent_cancels_flushed_unminted_tls_handshake_without_terminal() {
+    let now = Instant::now();
+    let mut coord = tls_coord(7331);
+    let _sid = coord.start_push_pull(addr(7000), PushPullKind::Join, now);
+    let exchange = match coord.poll_action().expect("the dial surfaces a Connect") {
+      StreamAction::Connect(c) => c.id(),
+      other => panic!("expected Connect, got {other:?}"),
+    };
+    while coord.poll_action().is_some() {}
+    while coord.poll_transport_transmit().is_some() {}
+    assert_eq!(
+      coord.live_bridge_count(),
+      1,
+      "the handshaking bridge is live before leave_silent",
+    );
+
+    coord.leave_silent(now).expect("silent leave");
+
+    let mut terminals = 0;
+    while let Some(ev) = coord.poll_event() {
+      if matches!(ev, Event::ExchangeCompleted(_) | Event::DialAborted(_)) {
+        terminals += 1;
+      }
+    }
+    assert_eq!(terminals, 0, "leave_silent emits no application terminal");
+    assert_eq!(
+      coord.live_bridge_count(),
+      0,
+      "leave_silent still tears the handshaking bridge down",
+    );
+    let mut aborted = false;
+    while let Some(a) = coord.poll_action() {
+      if let StreamAction::Abort(r) = a
+        && r.id() == exchange
+      {
+        aborted = true;
+      }
+    }
+    assert!(aborted, "leave_silent still queues the Abort teardown");
+  }
+
   /// A TLS dial whose SNI provider returns `None` is rejected at
   /// `TlsRecords::dial_context` inside `service_dials`, retiring the intent via
   /// the pre-`ExchangeMeta` `dial_failed` path and draining the

--- a/memberlist-proto/src/streams/tests.rs
+++ b/memberlist-proto/src/streams/tests.rs
@@ -19,7 +19,7 @@ mod tcp {
 
   use crate::{
     RawRecords,
-    event::{Event, PushPullKind, StreamId},
+    event::{DialAbortReason, Event, ExchangeKind, PushPullKind, StreamId},
     streams::{
       LabelOptions, StreamAction, StreamEndpoint,
       bridge::StreamBridge,
@@ -625,6 +625,197 @@ mod tcp {
       "a compression-policy change never fails or reaps a live bridge",
     );
   }
+
+  /// STR-A001: a `start_reliable_ping` whose probe deadline has already elapsed
+  /// is retired inside `service_dials`' expired-intent gate — no connection is
+  /// opened — and, because the kind is start-originated (`ReliablePing`),
+  /// surfaces exactly one `Event::DialAborted{ReliablePing, DeadlineElapsed}`
+  /// keyed by the returned `StreamId`. The probe FSM's own fallback retirement
+  /// is preserved (`dial_failed` still routes for `ReliablePing`).
+  #[test]
+  fn reliable_ping_elapsed_deadline_emits_dialaborted_deadline_elapsed() {
+    let now = Instant::now();
+    let mut coord = coord(7108);
+    // `deadline == now` is already elapsed at the `now >= deadline` gate.
+    let sid = coord.start_reliable_ping(SmolStr::new("p"), addr(7000), 7, now, now);
+
+    let mut aborts = Vec::new();
+    while let Some(ev) = coord.poll_event() {
+      if let Event::DialAborted(a) = ev {
+        aborts.push((a.stream_id(), a.kind(), a.reason()));
+      }
+    }
+    assert_eq!(
+      aborts.as_slice(),
+      &[(
+        sid,
+        ExchangeKind::ReliablePing,
+        DialAbortReason::DeadlineElapsed
+      )],
+      "exactly one DialAborted, keyed by the returned StreamId",
+    );
+    assert_eq!(
+      coord.live_bridge_count(),
+      0,
+      "no bridge is built for an already-elapsed reliable-ping dial",
+    );
+    assert!(
+      coord.poll_action().is_none(),
+      "no Connect surfaces for an expired reliable-ping dial",
+    );
+  }
+
+  /// STR-A001 kind-gating non-vacuity: a `DialRequested` fed straight into the
+  /// inner endpoint (bypassing the `start_*` wrappers, so no
+  /// `pending_outbound_kinds` entry — kind `None`) whose dial fails pre-`Connect`
+  /// emits NO `DialAborted`. The abort is reported only for start-originated
+  /// ids; machine-scheduled dials self-heal on their schedulers.
+  #[test]
+  fn kind_none_dial_failing_pre_connect_emits_no_dialaborted() {
+    let now = Instant::now();
+    let mut coord = coord(7109);
+    // A real inner intent + `DialRequested`, allocated OUTSIDE the wrappers, so
+    // `pending_outbound_kinds` never gains an entry for its id.
+    coord
+      .endpoint_mut()
+      .start_push_pull(addr(7000), PushPullKind::Join, now);
+    // Sieve the `DialRequested` into the private dial deque.
+    while coord.poll_event().is_some() {}
+
+    // Service the dial well past its deadline so it retires pre-`Connect`.
+    let later = now + Duration::from_secs(86_400);
+    coord.service_dials(later);
+
+    let mut saw_abort = false;
+    while let Some(ev) = coord.poll_event() {
+      if matches!(ev, Event::DialAborted(_)) {
+        saw_abort = true;
+      }
+    }
+    assert!(
+      !saw_abort,
+      "a kind-None (machine-scheduled) dial failure emits no DialAborted",
+    );
+    assert_eq!(
+      coord.live_bridge_count(),
+      0,
+      "the expired kind-None dial built no bridge",
+    );
+    assert!(
+      coord.poll_action().is_none(),
+      "no Connect surfaces for the expired kind-None dial",
+    );
+  }
+}
+
+/// STR-A001 test 3: a record layer whose `dialer` constructor fails drives the
+/// `R::dialer` `Err` arm of `service_dials`, surfacing a
+/// `DialAborted{.., RecordLayer}`. Uses a minimal record layer whose only
+/// reachable methods are `dial_context` (Ok) and `dialer` (Err); the dial fails
+/// before any bridge is built, so the transport I/O methods are never called.
+#[cfg(any(feature = "tcp", feature = "tls"))]
+mod fallible {
+  use crate::Instant;
+
+  use bytes::Bytes;
+  use core::net::SocketAddr;
+  use smol_str::SmolStr;
+
+  use crate::{
+    event::{DialAbortReason, Event, ExchangeKind},
+    streams::{
+      StreamEndpoint,
+      test_support::{addr, endpoint, test_peer_to_socket, test_sni_provider},
+      transport::{Intake, StreamTransport},
+    },
+  };
+
+  /// A record layer whose dialer construction always fails. Only `dial_context`
+  /// and `dialer` are reachable in the record-layer-construction-failure path;
+  /// every transport method is unreachable because no bridge is ever built.
+  struct FallibleDialer;
+
+  impl StreamTransport for FallibleDialer {
+    type Options = ();
+    type DialContext = ();
+    type ConstructError = &'static str;
+
+    fn dial_context<A>(_addr: &A, _server_name: Option<&str>) -> Result<(), &'static str> {
+      Ok(())
+    }
+
+    fn dialer(_opts: &(), _ctx: ()) -> Result<Self, &'static str> {
+      Err("test: dialer construction always fails")
+    }
+
+    fn acceptor(_opts: &()) -> Result<Self, &'static str> {
+      Err("test: acceptor construction always fails")
+    }
+
+    fn handle_transport_data(&mut self, _input: &[u8], _now: Instant) -> Intake {
+      unreachable!("no bridge is built when the dialer fails")
+    }
+    fn poll_transport_transmit(&mut self, _out: &mut std::vec::Vec<u8>) -> usize {
+      unreachable!("no bridge is built when the dialer fails")
+    }
+    fn is_handshaking(&self) -> bool {
+      unreachable!("no bridge is built when the dialer fails")
+    }
+    fn read_plaintext(&mut self, _out: &mut std::vec::Vec<u8>) -> usize {
+      unreachable!("no bridge is built when the dialer fails")
+    }
+    fn write_plaintext(&mut self, _plaintext: &[u8]) -> bool {
+      unreachable!("no bridge is built when the dialer fails")
+    }
+    fn send_close_notify(&mut self) {
+      unreachable!("no bridge is built when the dialer fails")
+    }
+    fn peer_has_closed(&self) -> bool {
+      unreachable!("no bridge is built when the dialer fails")
+    }
+    fn clear_outbound(&mut self) {
+      unreachable!("no bridge is built when the dialer fails")
+    }
+    fn is_secure() -> bool {
+      false
+    }
+  }
+
+  #[test]
+  fn dialer_construction_failure_emits_dialaborted_record_layer() {
+    let now = Instant::now();
+    let mut coord: StreamEndpoint<SmolStr, SocketAddr, FallibleDialer> = StreamEndpoint::new(
+      endpoint(7120),
+      (),
+      test_sni_provider(),
+      test_peer_to_socket(),
+    );
+
+    let sid = coord
+      .start_user_message(addr(7000), Bytes::from_static(b"x"), now)
+      .expect("issued while running");
+
+    let mut aborts = Vec::new();
+    while let Some(ev) = coord.poll_event() {
+      if let Event::DialAborted(a) = ev {
+        aborts.push((a.stream_id(), a.kind(), a.reason()));
+      }
+    }
+    assert_eq!(
+      aborts.as_slice(),
+      &[(sid, ExchangeKind::UserMessage, DialAbortReason::RecordLayer)],
+      "a dialer-construction failure surfaces one DialAborted with RecordLayer",
+    );
+    assert_eq!(
+      coord.live_bridge_count(),
+      0,
+      "no bridge is built when the dialer constructor fails",
+    );
+    assert!(
+      coord.poll_action().is_none(),
+      "no Connect surfaces for a failed dialer construction",
+    );
+  }
 }
 
 #[cfg(feature = "tls")]
@@ -642,11 +833,13 @@ mod tls {
     version::TLS13,
   };
 
+  use bytes::Bytes;
+
   use crate::{
     TlsOptions, TlsRecords,
-    event::{Event, ExchangeKind, ExchangeStatus, PushPullKind},
+    event::{DialAbortReason, Event, ExchangeKind, ExchangeStatus, PushPullKind},
     streams::{
-      LabelOptions, Labeled, StreamEndpoint,
+      LabelOptions, Labeled, StreamAction, StreamEndpoint,
       test_support::{addr, endpoint, test_peer_to_socket, test_sni_provider},
     },
   };
@@ -908,6 +1101,144 @@ mod tls {
       acceptor.bridge_is_established_pre_fin(missing),
       None,
       "an unknown exchange id has no bridge to inspect",
+    );
+  }
+
+  /// STR-A001 test 1: a `start_user_message` whose per-peer SNI provider returns
+  /// `None` returns `Ok(sid)` (the id is allocated before the fallible dial
+  /// setup), then the dial is rejected at `TlsRecords::dial_context` inside
+  /// `service_dials`. Exactly one `DialAborted{UserMessage, DialContext}` keyed
+  /// by `sid` surfaces; no `Connect`, no transmit, no retained exchange
+  /// metadata, and no leaked `pending_outbound_kinds` entry.
+  #[test]
+  fn sni_none_user_message_emits_dialaborted_dialcontext() {
+    let now = Instant::now();
+    let cfg = LabelOptions::new_in(None, TlsOptions::new(test_server(), test_client()));
+    let sni: Box<dyn Fn(&SocketAddr) -> Option<String> + Send + Sync> = Box::new(|_| None);
+    let mut coord: StreamEndpoint<SmolStr, SocketAddr, Labeled<TlsRecords>> =
+      StreamEndpoint::new(endpoint(7320), cfg, sni, test_peer_to_socket());
+
+    let sid = coord
+      .start_user_message(addr(7000), Bytes::from_static(b"x"), now)
+      .expect("start_user_message returns Ok while running");
+
+    assert!(
+      coord.poll_action().is_none(),
+      "no Connect surfaces for an SNI-rejected user-message dial",
+    );
+    assert!(
+      coord.poll_transport_transmit().is_none(),
+      "no bytes transmit for an SNI-rejected dial",
+    );
+
+    let mut aborts = Vec::new();
+    while let Some(ev) = coord.poll_event() {
+      if let Event::DialAborted(a) = ev {
+        aborts.push((a.stream_id(), a.kind(), a.reason()));
+      }
+    }
+    assert_eq!(
+      aborts.as_slice(),
+      &[(sid, ExchangeKind::UserMessage, DialAbortReason::DialContext)],
+      "exactly one DialAborted (UserMessage, DialContext) keyed by the returned id",
+    );
+    assert_eq!(
+      coord.live_bridge_count(),
+      0,
+      "no exchange metadata / bridge is retained after the rejected dial",
+    );
+    assert_eq!(
+      coord.pending_outbound_kinds_len(),
+      0,
+      "the pending_outbound_kinds entry drained on the dial_context-failure exit",
+    );
+  }
+
+  /// STR-A001 test 4: a mixed batch of two `start_user_message`s — the first
+  /// peer's SNI resolves (`Some`), the second's does not (`None`) — surfaces
+  /// exactly one `Connect` (the first id) and exactly one `DialAborted` (the
+  /// second id), with disjoint ids. Proves the abort is per-id and only for the
+  /// dial that actually failed pre-`Connect`.
+  #[test]
+  fn mixed_sni_batch_emits_one_connect_and_one_dialaborted() {
+    let now = Instant::now();
+    let cfg = LabelOptions::new_in(None, TlsOptions::new(test_server(), test_client()));
+    // Resolve SNI for port 7001 only; port 7002 gets `None`.
+    let sni: Box<dyn Fn(&SocketAddr) -> Option<String> + Send + Sync> =
+      Box::new(|a: &SocketAddr| (a.port() == 7001).then(|| "localhost".to_string()));
+    let mut coord: StreamEndpoint<SmolStr, SocketAddr, Labeled<TlsRecords>> =
+      StreamEndpoint::new(endpoint(7321), cfg, sni, test_peer_to_socket());
+
+    let ok_sid = coord
+      .start_user_message(addr(7001), Bytes::from_static(b"a"), now)
+      .expect("issued while running");
+    let bad_sid = coord
+      .start_user_message(addr(7002), Bytes::from_static(b"b"), now)
+      .expect("issued while running");
+    assert_ne!(ok_sid, bad_sid, "the two starts allocate disjoint ids");
+
+    let mut connects = Vec::new();
+    while let Some(action) = coord.poll_action() {
+      if let StreamAction::Connect(info) = action {
+        connects.push(info.stream_id());
+      }
+    }
+    assert_eq!(
+      connects.as_slice(),
+      &[ok_sid],
+      "exactly one Connect, for the SNI-resolved (first) id",
+    );
+
+    let mut aborts = Vec::new();
+    while let Some(ev) = coord.poll_event() {
+      if let Event::DialAborted(a) = ev {
+        aborts.push((a.stream_id(), a.kind(), a.reason()));
+      }
+    }
+    assert_eq!(
+      aborts.as_slice(),
+      &[(
+        bad_sid,
+        ExchangeKind::UserMessage,
+        DialAbortReason::DialContext
+      )],
+      "exactly one DialAborted, for the SNI-rejected (second) id",
+    );
+  }
+
+  /// STR-A001 test 5: `leave()` then `start_push_pull` — the inner endpoint
+  /// hands back an inert id (no dial initiated while not running) — surfaces one
+  /// `DialAborted{PushPull, NotRunning}` and leaves `pending_outbound_kinds`
+  /// empty (the wrapper does NOT stage a not-running dial, closing the latent
+  /// lingering-entry wart).
+  #[test]
+  fn not_running_push_pull_emits_dialaborted_not_running() {
+    let now = Instant::now();
+    let mut coord = tls_coord(7322);
+    coord.leave(now).expect("leave from a running node");
+
+    let sid = coord.start_push_pull(addr(7000), PushPullKind::Join, now);
+
+    let mut aborts = Vec::new();
+    while let Some(ev) = coord.poll_event() {
+      if let Event::DialAborted(a) = ev {
+        aborts.push((a.stream_id(), a.kind(), a.reason()));
+      }
+    }
+    assert_eq!(
+      aborts.as_slice(),
+      &[(sid, ExchangeKind::PushPull, DialAbortReason::NotRunning)],
+      "one DialAborted (PushPull, NotRunning) keyed by the inert id",
+    );
+    assert_eq!(
+      coord.pending_outbound_kinds_len(),
+      0,
+      "a not-running dial stages no pending_outbound_kinds entry",
+    );
+    assert_eq!(
+      coord.live_bridge_count(),
+      0,
+      "no bridge is built while not running",
     );
   }
 }

--- a/memberlist-proto/src/tcp/tests.rs
+++ b/memberlist-proto/src/tcp/tests.rs
@@ -3509,12 +3509,16 @@ fn coordinator_pair(
 /// (an empty `read == 0`) to the peer. Runs to mutual quiescence (both sides
 /// reaped their bridge) or the iteration cap.
 ///
-/// `acceptor_addr` is the socket the dialer dials; the acceptor accepts the
-/// connection as coming `from` the dialer's advertised address.
+/// `accept_from` is the transport source the acceptor sees the inbound
+/// connection arriving `from` — fed straight into `accept_connection`. A real
+/// listener reports the peer's kernel-selected ephemeral socket here, which is
+/// generally DISTINCT from the peer's advertised membership address; callers
+/// that want the historical "acceptor sees the advertised address" behavior
+/// pass the dialer's advertised address.
 fn drive_exchange(
   dialer: &mut StreamEndpoint<SmolStr, SocketAddr, RawRecords>,
   acceptor: &mut StreamEndpoint<SmolStr, SocketAddr, RawRecords>,
-  dialer_addr: SocketAddr,
+  accept_from: SocketAddr,
   now: Instant,
 ) {
   // Per-side connection handle, established when the dialer's Connect fires.
@@ -3536,7 +3540,7 @@ fn drive_exchange(
           dial_eid = Some(c.id());
           acc_eid = Some(
             acceptor
-              .accept_connection(dialer_addr, now)
+              .accept_connection(accept_from, now)
               .expect("test: connection admitted"),
           );
         }
@@ -3695,6 +3699,99 @@ fn end_to_end_reliable_user_message_delivers_on_acceptor() {
     Some(payload.as_ref()),
     "the reliable user message surfaced on the acceptor as UserPacket",
   );
+}
+
+/// STR-001 regression: on an INBOUND connection the acceptor's reliable events
+/// attribute the accept-time transport source (the peer's ephemeral socket),
+/// NOT the peer's advertised membership address — while the membership merge
+/// still lands the peer under its advertised address (merge unpoisoned). The
+/// event `.peer` / `.from` is a best-effort transport-origin hint; the two
+/// address domains are deliberately distinct on the inbound path. The
+/// in-memory harness previously masked this by feeding the advertised address
+/// as the accept source.
+#[test]
+fn inbound_reliable_events_report_transport_source_not_advertised_addr() {
+  // One push/pull (RemoteStateReceived) + one reliable user-message
+  // (UserPacket) exchange with the acceptor fed `ephemeral` as the connection
+  // source, distinct from the dialer's advertised `n-7820` @ `dialer_addr`.
+  fn drive_and_assert(ephemeral: SocketAddr) {
+    let now = Instant::now();
+    let dialer_addr = addr(7820);
+    let acceptor_addr = addr(7821);
+    assert_ne!(
+      ephemeral, dialer_addr,
+      "the ephemeral source must differ from the advertised address",
+    );
+    let (mut dialer, mut acceptor) = coordinator_pair(dialer_addr.port(), acceptor_addr.port());
+
+    // Non-empty local state so the merge emits `RemoteStateReceived`.
+    dialer
+      .set_local_state_snapshot(Bytes::from_static(b"dialer-state"))
+      .expect("set_local_state_snapshot forwards");
+
+    // (push/pull)
+    let _sid = dialer.start_push_pull(acceptor_addr, PushPullKind::Join, now);
+    drive_exchange(&mut dialer, &mut acceptor, ephemeral, now);
+
+    let mut rsr_peer = None;
+    while let Some(ev) = acceptor.poll_event() {
+      if let Event::RemoteStateReceived(rs) = ev {
+        rsr_peer = Some(*rs.peer_ref());
+      }
+    }
+    // (a) the merge event attributes the fed transport source.
+    assert_eq!(
+      rsr_peer,
+      Some(ephemeral),
+      "RemoteStateReceived.peer is the accept-time transport source",
+    );
+
+    // (c) the acceptor merged the dialer under its ADVERTISED address, and no
+    // member sits at the ephemeral source (the merge is unpoisoned).
+    let merged = acceptor
+      .endpoint_ref()
+      .member(&SmolStr::new("n-7820"))
+      .expect("the acceptor merged the dialer's advertised membership entry");
+    assert_eq!(
+      *merged.address_ref(),
+      dialer_addr,
+      "the dialer is merged at its advertised address, not the ephemeral source",
+    );
+    assert!(
+      acceptor
+        .endpoint_ref()
+        .members()
+        .all(|m| *m.address_ref() != ephemeral),
+      "no membership entry is poisoned with the ephemeral transport source",
+    );
+
+    // (reliable user data)
+    let payload = Bytes::from_static(b"reliable-hello");
+    dialer
+      .start_user_message(acceptor_addr, payload.clone(), now)
+      .expect("issued while running");
+    drive_exchange(&mut dialer, &mut acceptor, ephemeral, now);
+
+    let mut up_from = None;
+    while let Some(ev) = acceptor.poll_event() {
+      if let Event::UserPacket(p) = ev {
+        let (from, data, _) = p.into_parts();
+        assert_eq!(data.as_ref(), payload.as_ref(), "payload round-trips");
+        up_from = Some(from);
+      }
+    }
+    // (b) the reliable user packet attributes the fed transport source.
+    assert_eq!(
+      up_from,
+      Some(ephemeral),
+      "UserPacket(Reliable).from is the accept-time transport source",
+    );
+  }
+
+  // Repeat from a second, distinct ephemeral source: the logical attribution
+  // tracks whatever transport source the acceptor was fed.
+  drive_and_assert(addr(49152));
+  drive_and_assert(addr(49153));
 }
 
 /// `poll_timeout` folds in a pending-dial intent's own deadline AND returns an

--- a/memberlist-proto/src/tls/tests.rs
+++ b/memberlist-proto/src/tls/tests.rs
@@ -423,7 +423,7 @@ fn dial_context_failure_does_not_leak_pending_outbound_kinds() {
 
   use super::{TlsOptions, TlsRecords};
   use crate::{
-    event::PushPullKind,
+    event::{DialAbortReason, Event, ExchangeKind, PushPullKind},
     streams::{
       LabelOptions, Labeled, StreamEndpoint,
       test_support::{addr, endpoint, test_peer_to_socket},
@@ -441,7 +441,7 @@ fn dial_context_failure_does_not_leak_pending_outbound_kinds() {
   let mut coord: StreamEndpoint<SmolStr, SocketAddr, Labeled<TlsRecords>> =
     StreamEndpoint::new(ep, cfg, sni, test_peer_to_socket());
 
-  let _sid = coord.start_push_pull(addr(7000), PushPullKind::Refresh, now);
+  let sid = coord.start_push_pull(addr(7000), PushPullKind::Refresh, now);
 
   assert_eq!(
     coord.pending_outbound_kinds_len(),
@@ -452,6 +452,19 @@ fn dial_context_failure_does_not_leak_pending_outbound_kinds() {
     coord.live_bridge_count(),
     0,
     "no bridge is allocated when dial_context rejects the per-peer SNI",
+  );
+  // STR-A001: the retired dial surfaces exactly one terminal `DialAborted`
+  // keyed by the returned id, carrying the originating kind + reason.
+  let mut aborts = Vec::new();
+  while let Some(ev) = coord.poll_event() {
+    if let Event::DialAborted(a) = ev {
+      aborts.push((a.stream_id(), a.kind(), a.reason()));
+    }
+  }
+  assert_eq!(
+    aborts.as_slice(),
+    &[(sid, ExchangeKind::PushPull, DialAbortReason::DialContext)],
+    "the dial_context rejection surfaces one DialAborted (PushPull, DialContext)",
   );
 }
 
@@ -801,6 +814,210 @@ fn tls_two_same_label_nodes_complete_a_reliable_exchange() {
        (num_members={})",
     acceptor.endpoint_ref().num_members(),
   );
+}
+
+/// STR-001 TLS twin: on an INBOUND TLS connection the acceptor's reliable
+/// events attribute the accept-time transport source (the client's ephemeral
+/// socket), NOT the peer's advertised membership address — while the membership
+/// merge still lands the peer under its advertised address. Mirrors the
+/// plain-TCP `inbound_reliable_events_report_transport_source_not_advertised_addr`.
+#[test]
+fn tls_inbound_reliable_events_report_transport_source_not_advertised_addr() {
+  use crate::Instant;
+  use core::{net::SocketAddr, time::Duration};
+
+  use bytes::Bytes;
+  use smol_str::SmolStr;
+
+  use super::{TlsOptions, TlsRecords};
+  use crate::{
+    event::{Event, PushPullKind},
+    streams::{
+      ExchangeId, LabelOptions, Labeled, StreamAction, StreamEndpoint,
+      test_support::{addr, endpoint, test_peer_to_socket, test_sni_provider},
+    },
+    tls::options::tests::{test_client, test_server},
+  };
+
+  fn build() -> (
+    StreamEndpoint<SmolStr, SocketAddr, Labeled<TlsRecords>>,
+    StreamEndpoint<SmolStr, SocketAddr, Labeled<TlsRecords>>,
+    SocketAddr,
+    SocketAddr,
+  ) {
+    let dialer_addr = addr(8120);
+    let acceptor_addr = addr(8121);
+    let label = || Some(b"cluster-x".to_vec());
+    let dialer = StreamEndpoint::new(
+      endpoint(dialer_addr.port()),
+      LabelOptions::new_in(label(), TlsOptions::new(test_server(), test_client())),
+      test_sni_provider(),
+      test_peer_to_socket(),
+    );
+    let acceptor = StreamEndpoint::new(
+      endpoint(acceptor_addr.port()),
+      LabelOptions::new_in(label(), TlsOptions::new(test_server(), test_client())),
+      test_sni_provider(),
+      test_peer_to_socket(),
+    );
+    (dialer, acceptor, dialer_addr, acceptor_addr)
+  }
+
+  // Drive the pair to quiescence, feeding `accept_from` as the acceptor's
+  // inbound connection source, and return every event the acceptor surfaced.
+  fn drive(
+    dialer: &mut StreamEndpoint<SmolStr, SocketAddr, Labeled<TlsRecords>>,
+    acceptor: &mut StreamEndpoint<SmolStr, SocketAddr, Labeled<TlsRecords>>,
+    accept_from: SocketAddr,
+    start: Instant,
+  ) -> Vec<Event<SmolStr, SocketAddr>> {
+    let mut now = start;
+    let mut dialer_ex: Option<ExchangeId> = None;
+    let mut acceptor_ex: Option<ExchangeId> = None;
+    let mut acc_events = Vec::new();
+    for _ in 0..256 {
+      dialer.handle_timeout(now);
+      acceptor.handle_timeout(now);
+
+      while let Some(action) = dialer.poll_action() {
+        match action {
+          StreamAction::Connect(info) => {
+            dialer_ex = Some(info.id());
+            if acceptor_ex.is_none() {
+              acceptor_ex = Some(
+                acceptor
+                  .accept_connection(accept_from, now)
+                  .expect("test: connection admitted"),
+              );
+            }
+          }
+          StreamAction::Shutdown(r) | StreamAction::Close(r) => {
+            if Some(r.id()) == dialer_ex
+              && let Some(ax) = acceptor_ex
+            {
+              acceptor.handle_transport_data(ax, &[], true, now);
+            }
+          }
+          StreamAction::Abort(_) => panic!("the labeled dialer must not abort a same-label peer"),
+        }
+      }
+      while let Some(action) = acceptor.poll_action() {
+        match action {
+          StreamAction::Connect(_) => panic!("the acceptor never dials"),
+          StreamAction::Shutdown(r) | StreamAction::Close(r) => {
+            if Some(r.id()) == acceptor_ex
+              && let Some(dx) = dialer_ex
+            {
+              dialer.handle_transport_data(dx, &[], true, now);
+            }
+          }
+          StreamAction::Abort(_) => panic!("the labeled acceptor must not abort a same-label peer"),
+        }
+      }
+
+      if let Some(ax) = acceptor_ex {
+        let mut to_acceptor = Vec::new();
+        while let Some((id, _peer, bytes)) = dialer.poll_transport_transmit() {
+          if Some(id) == dialer_ex {
+            to_acceptor.extend_from_slice(&bytes);
+          }
+        }
+        if !to_acceptor.is_empty() {
+          acceptor.handle_transport_data(ax, &to_acceptor, false, now);
+        }
+      }
+      if let Some(dx) = dialer_ex {
+        let mut to_dialer = Vec::new();
+        while let Some((id, _peer, bytes)) = acceptor.poll_transport_transmit() {
+          if Some(id) == acceptor_ex {
+            to_dialer.extend_from_slice(&bytes);
+          }
+        }
+        if !to_dialer.is_empty() {
+          dialer.handle_transport_data(dx, &to_dialer, false, now);
+        }
+      }
+
+      while dialer.poll_event().is_some() {}
+      while let Some(ev) = acceptor.poll_event() {
+        acc_events.push(ev);
+      }
+
+      now += Duration::from_millis(5);
+    }
+    acc_events
+  }
+
+  let assert_source = |ephemeral: SocketAddr| {
+    let now = Instant::now();
+    let (mut dialer, mut acceptor, dialer_addr, acceptor_addr) = build();
+    assert_ne!(
+      ephemeral, dialer_addr,
+      "ephemeral source differs from advertised"
+    );
+
+    dialer
+      .set_local_state_snapshot(Bytes::from_static(b"dialer-state"))
+      .expect("set_local_state_snapshot forwards");
+
+    // (push/pull) — RemoteStateReceived.peer is the fed transport source.
+    let _sid = dialer.start_push_pull(acceptor_addr, PushPullKind::Join, now);
+    let events = drive(&mut dialer, &mut acceptor, ephemeral, now);
+    let rsr_peer = events.iter().find_map(|ev| match ev {
+      Event::RemoteStateReceived(rs) => Some(*rs.peer_ref()),
+      _ => None,
+    });
+    assert_eq!(
+      rsr_peer,
+      Some(ephemeral),
+      "RemoteStateReceived.peer is the accept-time TLS transport source",
+    );
+
+    // (c) merge unpoisoned: the dialer is at its advertised address, and no
+    // member sits at the ephemeral source.
+    let merged = acceptor
+      .endpoint_ref()
+      .member(&SmolStr::new("n-8120"))
+      .expect("the acceptor merged the dialer's advertised membership entry");
+    assert_eq!(
+      *merged.address_ref(),
+      dialer_addr,
+      "the dialer is merged at its advertised address, not the ephemeral source",
+    );
+    assert!(
+      acceptor
+        .endpoint_ref()
+        .members()
+        .all(|m| *m.address_ref() != ephemeral),
+      "no membership entry is poisoned with the ephemeral transport source",
+    );
+
+    // (reliable user data) — UserPacket.from is the fed transport source.
+    let payload = Bytes::from_static(b"reliable-hello");
+    dialer
+      .start_user_message(acceptor_addr, payload.clone(), now)
+      .expect("issued while running");
+    let events = drive(&mut dialer, &mut acceptor, ephemeral, now);
+    let up_from = events.iter().find_map(|ev| match ev {
+      Event::UserPacket(p) => {
+        assert_eq!(
+          p.data_ref().as_ref(),
+          payload.as_ref(),
+          "payload round-trips"
+        );
+        Some(*p.from_ref())
+      }
+      _ => None,
+    });
+    assert_eq!(
+      up_from,
+      Some(ephemeral),
+      "UserPacket(Reliable).from is the accept-time TLS transport source",
+    );
+  };
+
+  assert_source(addr(49152));
+  assert_source(addr(49153));
 }
 
 /// A labeled acceptor rejects a peer that completes the TLS handshake and

--- a/memberlist-reactor/src/driver/stream/mod.rs
+++ b/memberlist-reactor/src/driver/stream/mod.rs
@@ -1137,6 +1137,21 @@ where
           }
         }
       }
+      // Pre-connect dial abort: the coordinator retired a `start_*` id before
+      // any `Connect`. No synchronous waiter is keyed on a `StreamId` — the
+      // join / send waiter tables are `ExchangeId`-keyed and capture their ids
+      // from the surfaced `Connect` — so a `DialAborted` never resolves one and
+      // double-reporting is structurally impossible. Trace it for visibility.
+      Event::DialAborted(_p) => {
+        #[cfg(feature = "tracing")]
+        tracing::trace!(
+          stream_id = _p.stream_id().as_u64(),
+          peer = %_p.peer_ref(),
+          kind = ?_p.kind(),
+          reason = ?_p.reason(),
+          "stream dial aborted before Connect",
+        );
+      }
       _ => {}
     }
   }

--- a/memberlist-reactor/src/driver/stream/mod.rs
+++ b/memberlist-reactor/src/driver/stream/mod.rs
@@ -1490,8 +1490,11 @@ where
       // `accept_shutdown_tx` still being `Some`; taking it below clears the guard so
       // this runs once.
       if this.accept_shutdown_tx.is_some() {
-        // Ignoring Err: best-effort leave during shutdown.
-        let _ = this.endpoint.leave(Instant::now());
+        // Ignoring Err: best-effort leave during shutdown. `leave_silent` cancels
+        // every unsent outbound exchange WITHOUT emitting its application terminal
+        // — the shutdown reap below fails each parked waiter with `Shutdown`, which
+        // a leave-cancel `SendFailed` / `JoinFailed` would otherwise preempt.
+        let _ = this.endpoint.leave_silent(Instant::now());
         // FREEZE every live bridge. `cancel_tx.send(())` resolves each bridge's
         // biased-first cancel arm, so a bridge about to read breaks BEFORE it can
         // fold a racing peer-FIN into a fabricated EOF, and a bridge stalled

--- a/memberlist-reactor/src/driver/stream/tests.rs
+++ b/memberlist-reactor/src/driver/stream/tests.rs
@@ -1187,6 +1187,80 @@ async fn shutdown_fails_parked_reliable_send() {
   );
 }
 
+/// A parked reliable directed send resolves `Err(SendFailed)` PROMPTLY at
+/// `leave()` — NOT only at shutdown. When the send and the leave land in the
+/// same command drain, `leave` sees the request still queued in `out_transmit`,
+/// cancels the exchange, and terminalizes it (`ExchangeCompleted(Failed,
+/// UserMessage)`), which `account_event` folds into the waiter in the same
+/// poll. The dial targets an unreachable address (RFC 5737 TEST-NET-1) so the
+/// eventual dial teardown is a no-op on the already-cancelled exchange, leaving
+/// the leave terminal the sole resolver.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn leave_resolves_parked_reliable_send_promptly_as_send_failed() {
+  let (mut driver, _obs_rx, shared, _bytes) = build_driver(16, Some(1 << 20)).await;
+  let (tx, rx) = oneshot::channel::<Result<(), Error>>();
+  // Enqueue the send and the leave together: one command drain dispatches the
+  // send (request queued in out_transmit) then the leave (cancels + terminalizes
+  // it) BEFORE the same poll's transport-byte drain empties out_transmit.
+  shared.push_command(Command::SendReliable(SendReliableCmd {
+    to: "192.0.2.1:80".parse::<SocketAddr>().unwrap(),
+    payloads: vec![Bytes::from_static(b"reliable")],
+    reply: tx,
+  }));
+  let (leave_tx, _leave_rx) = oneshot::channel::<Result<(), Error>>();
+  shared.push_command(Command::Leave(LeaveCmd { reply: leave_tx }));
+
+  // NO shutdown: the driver stays alive (Pending). A couple of passes drain the
+  // queued terminal into account_event.
+  assert!(
+    poll_once(&mut driver).is_pending(),
+    "driver alive after send+leave"
+  );
+  let _ = poll_once(&mut driver);
+  let _ = poll_once(&mut driver);
+
+  let got = tokio::time::timeout(Duration::from_secs(5), rx).await;
+  assert!(
+    matches!(got, Ok(Ok(Err(Error::SendFailed)))),
+    "leave resolves the parked reliable send as SendFailed without shutdown, got {got:?}",
+  );
+}
+
+/// A parked wait-`join` resolves PROMPTLY at `leave()` with its partial
+/// contacted set — NOT only at shutdown. With the join and the leave in the same
+/// command drain, both seeds' push/pull exchanges are cancelled + terminalized
+/// `Failed` before the transport drain, so the contacted set is empty and
+/// `join_reply` yields `Err((empty, JoinFailed))`. Unreachable seeds keep the
+/// dials stalled so the leave terminal is the sole resolver.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn leave_resolves_parked_wait_join_with_partial_contacted_set() {
+  let (mut driver, _obs_rx, shared, _bytes) = build_driver(16, Some(1 << 20)).await;
+  let (tx, rx) = oneshot::channel::<crate::command::JoinReply>();
+  shared.push_command(Command::Join(JoinCmd {
+    addrs: vec![
+      "192.0.2.1:80".parse::<SocketAddr>().unwrap(),
+      "192.0.2.2:80".parse::<SocketAddr>().unwrap(),
+    ],
+    wait: true,
+    reply: tx,
+  }));
+  let (leave_tx, _leave_rx) = oneshot::channel::<Result<(), Error>>();
+  shared.push_command(Command::Leave(LeaveCmd { reply: leave_tx }));
+
+  assert!(
+    poll_once(&mut driver).is_pending(),
+    "driver alive after join+leave"
+  );
+  let _ = poll_once(&mut driver);
+  let _ = poll_once(&mut driver);
+
+  let got = tokio::time::timeout(Duration::from_secs(5), rx).await;
+  assert!(
+    matches!(&got, Ok(Ok(Err((set, Error::JoinFailed(_))))) if set.is_empty()),
+    "leave resolves the parked wait-join with its (empty) partial set, got {got:?}",
+  );
+}
+
 /// The shutdown branch's `close_and_drain` loop fails EVERY queued command
 /// variant: a handle that pushed a command in the race window between the
 /// poll's top-of-poll command drain and the shutdown `close_and_drain` gets a


### PR DESCRIPTION
Closes #164 