### PR TITLE
fix(proto): readiness-gate QUIC inbound effects on caller-enabled 0-RTT early data (#173)

### DIFF
--- a/memberlist-proto/src/quic/config/mod.rs
+++ b/memberlist-proto/src/quic/config/mod.rs
@@ -58,6 +58,19 @@ fn default_server_name() -> String {
   DEFAULT_SERVER_NAME.to_string()
 }
 
+/// Force QUIC 0-RTT (early data) OFF on the managed path's rustls pair. The
+/// coordinator's effect-finality boundary defers every application effect to a
+/// connection's establishment, so early data buys nothing here, and the shared
+/// TLS assembly must never re-enable it. rustls already defaults these off
+/// (client `enable_early_data = false`, server `max_early_data_size = 0`), but
+/// forcing them keeps that guarantee independent of any future default or
+/// shared-builder change — the config-path analogue of the `IdleTimeoutZero`
+/// guard in [`QuicConfigOptions::build`].
+fn force_early_data_off(client: &mut rustls::ClientConfig, server: &mut rustls::ServerConfig) {
+  client.enable_early_data = false;
+  server.max_early_data_size = 0;
+}
+
 /// Construct a [`QuicOptions`] from cert / key / CA files on disk plus a single
 /// [`ClientAuthMode`](crate::tls::ClientAuthMode) choice and a few transport
 /// tunables.
@@ -222,15 +235,7 @@ impl QuicConfigOptions {
     let mut rustls_server = build_server_config(&provider, &roots, &certs, &key, self.client_auth)?;
     let mut rustls_client = build_client_config(provider, roots, certs, key, self.client_auth)?;
 
-    // Force QUIC 0-RTT (early data) off on the managed path. The coordinator's
-    // effect-finality boundary defers every application effect to a connection's
-    // establishment, so early data buys nothing here, and the shared TLS assembly
-    // must never re-enable it. rustls already defaults these off (client
-    // `enable_early_data = false`, server `max_early_data_size = 0`), but forcing
-    // them keeps that guarantee independent of any future default or shared-builder
-    // change — the config-path analogue of the `IdleTimeoutZero` guard below.
-    rustls_client.enable_early_data = false;
-    rustls_server.max_early_data_size = 0;
+    force_early_data_off(&mut rustls_client, &mut rustls_server);
 
     Ok((rustls_server, rustls_client))
   }

--- a/memberlist-proto/src/quic/config/mod.rs
+++ b/memberlist-proto/src/quic/config/mod.rs
@@ -201,15 +201,16 @@ impl QuicConfigOptions {
     self.unreliable_transport
   }
 
-  /// Load the PEM files and assemble a [`QuicOptions`] under the configured
-  /// [`ClientAuthMode`](crate::tls::ClientAuthMode) and transport tunables.
+  /// Load the PEM material and assemble the rustls server/client pair under the
+  /// configured [`ClientAuthMode`](crate::tls::ClientAuthMode), with
+  /// memberlist's QUIC 0-RTT (early-data) policy FORCED off on both sides.
   ///
-  /// Reuses the rustls server/client assembly from
-  /// [`crate::tls::TlsConfigOptions`], wraps the result into quinn's QUIC crypto
-  /// configs, builds an `EndpointConfig` with a random stateless-reset key, and
-  /// installs a cluster-uniform SNI. Requires the process default
-  /// `CryptoProvider` to be installed (see the module docs).
-  pub fn build(&self) -> Result<QuicOptions, QuicConfigError> {
+  /// Factored out of [`Self::build`] so a unit test can introspect the rustls
+  /// configs BEFORE quinn's `QuicServerConfig`/`QuicClientConfig` `try_from`
+  /// wrapping hides those fields.
+  fn assemble_rustls_configs(
+    &self,
+  ) -> Result<(rustls::ServerConfig, rustls::ClientConfig), QuicConfigError> {
     let provider = rustls::crypto::CryptoProvider::get_default()
       .cloned()
       .ok_or(TlsConfigError::NoCryptoProvider)?;
@@ -218,8 +219,33 @@ impl QuicConfigOptions {
     let key = load_private_key(&self.key_file)?;
     let roots = load_roots(&self.ca_file)?;
 
-    let rustls_server = build_server_config(&provider, &roots, &certs, &key, self.client_auth)?;
-    let rustls_client = build_client_config(provider, roots, certs, key, self.client_auth)?;
+    let mut rustls_server = build_server_config(&provider, &roots, &certs, &key, self.client_auth)?;
+    let mut rustls_client = build_client_config(provider, roots, certs, key, self.client_auth)?;
+
+    // Force QUIC 0-RTT (early data) off on the managed path. The coordinator's
+    // effect-finality boundary defers every application effect to a connection's
+    // establishment, so early data buys nothing here, and the shared TLS assembly
+    // must never re-enable it. rustls already defaults these off (client
+    // `enable_early_data = false`, server `max_early_data_size = 0`), but forcing
+    // them keeps that guarantee independent of any future default or shared-builder
+    // change — the config-path analogue of the `IdleTimeoutZero` guard below.
+    rustls_client.enable_early_data = false;
+    rustls_server.max_early_data_size = 0;
+
+    Ok((rustls_server, rustls_client))
+  }
+
+  /// Load the PEM files and assemble a [`QuicOptions`] under the configured
+  /// [`ClientAuthMode`](crate::tls::ClientAuthMode) and transport tunables.
+  ///
+  /// Reuses the rustls server/client assembly from
+  /// [`crate::tls::TlsConfigOptions`], wraps the result into quinn's QUIC crypto
+  /// configs, builds an `EndpointConfig` with a random stateless-reset key, and
+  /// installs a cluster-uniform SNI. Requires the process default
+  /// `CryptoProvider` to be installed (see the module docs). Forces QUIC 0-RTT
+  /// (early data) off on both sides — see [`Self::assemble_rustls_configs`].
+  pub fn build(&self) -> Result<QuicOptions, QuicConfigError> {
+    let (rustls_server, rustls_client) = self.assemble_rustls_configs()?;
 
     let qsc = QuicServerConfig::try_from(Arc::new(rustls_server))?;
     let server = QuinnServerConfig::with_crypto(Arc::new(qsc));

--- a/memberlist-proto/src/quic/config/tests.rs
+++ b/memberlist-proto/src/quic/config/tests.rs
@@ -372,6 +372,56 @@ fn build_forces_early_data_off_on_both_sides() {
   );
 }
 
+/// Load-bearing mutation anchor for the force-off. rustls already DEFAULTS early
+/// data off, so the introspection test above stays green even if a force-off
+/// write is deleted. Here we DELIBERATELY PRE-ENABLE early data on both configs
+/// (mirroring the caller escape hatch that opts in) and run them THROUGH
+/// [`force_early_data_off`] — so deleting either assignment leaves the pre-enabled
+/// value in place and fails an assertion below.
+#[test]
+fn force_early_data_off_disables_pre_enabled_early_data() {
+  install_provider();
+  let dir = unique_dir();
+  let (cert, key, ca) = write_self_signed(&dir);
+
+  let provider = rustls::crypto::CryptoProvider::get_default()
+    .cloned()
+    .expect("a default CryptoProvider is installed by install_provider()");
+  let certs = load_certs(&cert).unwrap();
+  let priv_key = load_private_key(&key).unwrap();
+  let roots = load_roots(&ca).unwrap();
+
+  let mode = ClientAuthMode::TrustedNetwork;
+  // `build_server_config` borrows; `build_client_config` consumes — so build the
+  // server first, then move the material into the client.
+  let mut server = build_server_config(&provider, &roots, &certs, &priv_key, mode).unwrap();
+  let mut client = build_client_config(provider, roots, certs, priv_key, mode).unwrap();
+
+  // Deliberately pre-ENABLE 0-RTT on both, the state a caller opting into early
+  // data would produce.
+  client.enable_early_data = true;
+  server.max_early_data_size = u32::MAX;
+  assert!(
+    client.enable_early_data,
+    "precondition: the client config must start with early data ENABLED"
+  );
+  assert_ne!(
+    server.max_early_data_size, 0,
+    "precondition: the server config must start with early data ENABLED"
+  );
+
+  // The force-off helper must disable BOTH regardless of the incoming state.
+  force_early_data_off(&mut client, &mut server);
+  assert!(
+    !client.enable_early_data,
+    "force_early_data_off must set client `enable_early_data = false`"
+  );
+  assert_eq!(
+    server.max_early_data_size, 0,
+    "force_early_data_off must set server `max_early_data_size = 0`"
+  );
+}
+
 #[test]
 fn build_missing_cert_file_errors() {
   install_provider();

--- a/memberlist-proto/src/quic/config/tests.rs
+++ b/memberlist-proto/src/quic/config/tests.rs
@@ -351,6 +351,28 @@ fn build_with_timeout_tuning_is_usable() {
 }
 
 #[test]
+fn build_forces_early_data_off_on_both_sides() {
+  install_provider();
+  let dir = unique_dir();
+  let (cert, key, ca) = write_self_signed(&dir);
+
+  // The managed builder must force QUIC 0-RTT (early data) OFF on both rustls
+  // configs it assembles, regardless of rustls's own defaults. Introspect the
+  // pair BEFORE quinn's `try_from` wrapping hides those fields.
+  let (server, client) = QuicConfigOptions::new(cert, key, ca)
+    .assemble_rustls_configs()
+    .expect("assembling the rustls pair should succeed");
+  assert!(
+    !client.enable_early_data,
+    "the managed build path must force client `enable_early_data = false`"
+  );
+  assert_eq!(
+    server.max_early_data_size, 0,
+    "the managed build path must force server `max_early_data_size = 0`"
+  );
+}
+
+#[test]
 fn build_missing_cert_file_errors() {
   install_provider();
   let dir = unique_dir();

--- a/memberlist-proto/src/quic/crypto/mod.rs
+++ b/memberlist-proto/src/quic/crypto/mod.rs
@@ -340,7 +340,34 @@ impl QuicOptions {
   /// table module). The higher-level
   /// [`QuicConfigOptions::build`](super::config::QuicConfigOptions::build) path
   /// rejects a zero/sub-millisecond `max_idle_timeout` and so guarantees the
-  /// finite bound; this raw path does not. The constructor
+  /// finite bound; this raw path does not.
+  ///
+  /// # 0-RTT / early data (DEFERRAL, not a delegated obligation)
+  ///
+  /// A caller MAY enable rustls early data on the configs it hands in (client
+  /// `rustls::ClientConfig::enable_early_data = true`, server
+  /// `rustls::ServerConfig::max_early_data_size > 0`); this constructor neither
+  /// inspects nor overrides those fields. Enabling it transfers NO replay or
+  /// transactional obligation to `MergeDelegate`s or event consumers. The
+  /// coordinator DEFERS every application-effect commitment to the connection's
+  /// establishment boundary (its own `quinn_proto::Event::Connected`) regardless
+  /// of the early-data policy:
+  ///
+  /// - An accepted 0-RTT bidi STREAM is held un-accepted inside quinn until the
+  ///   handshake completes, then processed normally — still a full round-trip
+  ///   earlier than a non-early resumed exchange, but never before establishment,
+  ///   so a handshake that fails mid-flight (the crash-stop trigger) commits no
+  ///   membership, push/pull, user, or probe effect.
+  /// - An accepted 0-RTT application DATAGRAM is DROPPED and counted (the
+  ///   unreliable plane is loss-tolerant — ordinary gossip redundancy re-delivers
+  ///   within a round).
+  ///
+  /// The higher-level
+  /// [`QuicConfigOptions::build`](super::config::QuicConfigOptions::build) path
+  /// forces early data OFF on both sides, so a managed deployment is never exposed
+  /// to the trigger at all.
+  ///
+  /// The constructor
   /// unconditionally forces `max_concurrent_uni_streams = 0` on the
   /// supplied value (mutating it before moving it into a shared `Arc`,
   /// so a caller's surviving `Arc` view cannot accidentally re-enable
@@ -419,6 +446,10 @@ impl QuicOptions {
   /// `unreliable_transport` governs the datagram extension exactly as for
   /// [`Self::new`]: enabled in [`UnreliableTransport::Datagram`] mode, left at
   /// quinn defaults (disabled, unadvertised) in [`UnreliableTransport::Udp`].
+  ///
+  /// The 0-RTT / early-data deferral semantics documented on [`Self::new`] apply
+  /// verbatim to this constructor: caller-enabled early data commits no
+  /// application effect before a connection's establishment boundary.
   pub fn new_with_sni_provider(
     mut endpoint: quinn_proto::EndpointConfig,
     mut server: quinn_proto::ServerConfig,

--- a/memberlist-proto/src/quic/crypto/tests.rs
+++ b/memberlist-proto/src/quic/crypto/tests.rs
@@ -94,6 +94,46 @@ pub(crate) fn test_client() -> quinn_proto::ClientConfig {
   quinn_proto::ClientConfig::new(Arc::new(qcc))
 }
 
+/// A shared quinn `QuicClientConfig` Arc whose underlying rustls `ClientConfig`
+/// has 0-RTT early data ENABLED (`enable_early_data = true`) and the default
+/// in-memory resumption store. Cloning the returned Arc into two
+/// `quinn_proto::ClientConfig`s shares ONE resumption store, so a session ticket
+/// a first connection stores becomes available to a second connection built from
+/// the same Arc — the setup a real 0-RTT resume needs in the coordinator harness.
+/// Test-only: production callers never opt into early data on the managed path.
+pub(crate) fn early_data_client_arc() -> Arc<quinn_proto::crypto::rustls::QuicClientConfig> {
+  let provider = Arc::new(rustls::crypto::ring::default_provider());
+  let mut cfg = rustls::ClientConfig::builder_with_provider(provider)
+    .with_protocol_versions(&[&TLS13])
+    .unwrap()
+    .dangerous()
+    .with_custom_certificate_verifier(Arc::new(AnyServer))
+    .with_no_client_auth();
+  cfg.enable_early_data = true;
+  Arc::new(quinn_proto::crypto::rustls::QuicClientConfig::try_from(Arc::new(cfg)).unwrap())
+}
+
+/// A test-only server config that ACCEPTS 0-RTT early data
+/// (`max_early_data_size = u32::MAX`). The default `std` server session storage
+/// is the stateful in-memory cache with `NeverProducesTickets`, which is exactly
+/// what rustls requires to advertise early data on a resumed session. Test-only:
+/// the managed [`QuicConfigOptions::build`](super::super::config::QuicConfigOptions::build)
+/// path forces `max_early_data_size = 0`.
+pub(crate) fn test_server_early() -> quinn_proto::ServerConfig {
+  let (chain, key) = self_signed();
+  let provider = Arc::new(rustls::crypto::ring::default_provider());
+  let mut rustls_server = rustls::ServerConfig::builder_with_provider(provider)
+    .with_protocol_versions(&[&TLS13])
+    .unwrap()
+    .with_no_client_auth()
+    .with_single_cert(chain, key)
+    .unwrap();
+  rustls_server.max_early_data_size = u32::MAX;
+  let qsc =
+    quinn_proto::crypto::rustls::QuicServerConfig::try_from(Arc::new(rustls_server)).unwrap();
+  quinn_proto::ServerConfig::with_crypto(Arc::new(qsc))
+}
+
 #[test]
 fn builds_a_usable_config_bundle() {
   let cfg = QuicOptions::new(

--- a/memberlist-proto/src/quic/mod.rs
+++ b/memberlist-proto/src/quic/mod.rs
@@ -811,6 +811,19 @@ pub struct QuicEndpoint<I, R = SmallRng> {
   /// bounded here by popping-and-dropping past either limit. Best-effort
   /// accounting only — never a membership signal.
   datagram_ingress_dropped: u64,
+  /// Count of inbound application datagrams the `service_quinn` receive drain
+  /// popped from quinn but DROPPED because the connection had not yet reached
+  /// its application-readiness boundary (`established_at_least_once()` still
+  /// false — the QUIC 0-RTT readiness gate). Distinct from
+  /// [`Self::datagram_ingress_dropped`], which counts drops past the ingress
+  /// cap: this counts drops that precede the connection's own establishment,
+  /// so a caller-enabled early-data datagram cannot reach `mem_ingress` before
+  /// the handshake completes. Zero on every non-early-data path (without
+  /// accepted 0-RTT no application datagram arrives pre-establishment). The
+  /// unreliable plane is loss-tolerant, so the drop is recovered by ordinary
+  /// gossip redundancy. Best-effort accounting only — never a membership
+  /// signal.
+  pre_established_datagrams_dropped: u64,
   /// Incremental earliest-deadline index backing [`Self::poll_timeout`]. Holds
   /// the next deadline for every connection, bridge, and pending dial (plus the
   /// membership endpoint and the immediate-due anchor) so `poll_timeout` reads
@@ -1173,6 +1186,7 @@ impl<I, R> QuicEndpoint<I, R> {
       last_now: None,
       datagram_dropped: 0,
       datagram_ingress_dropped: 0,
+      pre_established_datagrams_dropped: 0,
       deadline_index: DeadlineIndex::new(),
       conns_with_pending_events: HashSet::new(),
       next_catchup_at: None,
@@ -2949,6 +2963,15 @@ impl<I, R> QuicEndpoint<I, R> {
   #[cfg(test)]
   pub(crate) fn datagram_ingress_dropped(&self) -> u64 {
     self.datagram_ingress_dropped
+  }
+
+  /// Count of inbound application datagrams dropped by the receive drain
+  /// because the connection had not yet reached its application-readiness
+  /// boundary (the QUIC 0-RTT readiness gate; best-effort accounting; never a
+  /// membership signal).
+  #[cfg(test)]
+  pub(crate) fn pre_established_datagrams_dropped(&self) -> u64 {
+    self.pre_established_datagrams_dropped
   }
 
   /// Count of membership-time advances ([`Endpoint::handle_timeout`] calls).
@@ -5501,6 +5524,142 @@ where
     ready_peers
   }
 
+  /// Accept every un-accepted inbound bidi stream on connection `ch`, minting a
+  /// [`Bridge`] for each and enqueueing it for this pass's pump drain. Re-acquires
+  /// the `self.conns` borrow internally so it can run at either of its two call
+  /// sites in [`Self::service_one_conn`] (an already-established connection whose
+  /// one-shot `Opened` fired this pass, or the establishment chokepoint re-driving
+  /// a coalesced `Opened`) — both AFTER the poll loop releases its `e` borrow.
+  /// A no-op when quinn reports no acceptable stream (`accept` returns `None`).
+  ///
+  /// This is the accept-drain factored out of the `StreamEvent::Opened { dir: Bi }`
+  /// arm so it can be readiness-gated: it must run ONLY once the connection has
+  /// reached its application-readiness boundary (`established_at_least_once()`),
+  /// so a caller-enabled 0-RTT stream accepted while handshaking is left
+  /// quarantined inside quinn until the handshake completes.
+  fn accept_inbound_streams(&mut self, ch: ConnectionHandle, now: Instant) {
+    // Cross-connection inbound-stream cap. Each accepted bidi stream mints a
+    // Bridge that pins up to ~3x the max reliable frame size, so admission-gate
+    // every inbound bridge against the QUIC-specific
+    // `QuicOptions::max_inbound_streams` (a bounded nonzero default) BEFORE
+    // minting — the QUIC twin of the stream coordinator's `accept_connection`
+    // gate (`streams::StreamEndpoint`, which counts `exchanges.filter(|m|
+    // !m.outbound)`). The QUIC ceiling is its own option, not the shared TCP/TLS
+    // `EndpointOptions::max_inbound_streams` (which defaults to unlimited), so a
+    // default QUIC endpoint is bounded without changing TCP/TLS behaviour. This
+    // bounds inbound bridge state ACROSS all connections; quinn's per-connection
+    // `max_concurrent_bidi_streams` is a separate, per-connection limit.
+    let max_inbound = self.cfg.max_inbound_streams();
+    let Some(e) = self.conns.get_mut(ch) else {
+      return;
+    };
+    // `StreamEvent::Opened` is an idempotent signal ("one or more streams
+    // opened"), not a per-stream event, so accept until the peer's bidi backlog
+    // is drained — otherwise concurrently opened inbound exchanges are stranded
+    // with no further wake-up. quinn opens remote streams IMPLICITLY: one STREAM
+    // (or MAX_STREAM_DATA) frame naming a high in-credit index advances
+    // `next_remote`, so this loop can accept the whole remaining bidi window in a
+    // single datagram — up to the per-connection bidi credit, capped by the
+    // `max_inbound_streams` headroom above. That is a per-credit-window BATCH
+    // bound: config-bounded and independent of the connection/bridge tables, not
+    // amplifiable per datagram beyond the configured caps. An operator wanting a
+    // tighter per-datagram batch lowers quinn's `max_concurrent_bidi_streams` —
+    // gossip needs only a handful of concurrent reliable exchanges per
+    // connection. An outbound bridge is registered in `pending_outbound_kinds`
+    // for the life of its exchange and an accepted (inbound) bridge never is (see
+    // that field's docs), so the inbound population is exactly the bridges absent
+    // from that map — tracked incrementally as `inbound_bridge_count`. Read that
+    // O(1) count instead of filtering the whole bridge table on every peer-driven
+    // `Opened` (one datagram could otherwise force an O(all bridges) fold); the
+    // mint below bumps it in place, so a later connection's accept loop this same
+    // pass sees the updated total — the cap is ACROSS all connections. The
+    // `e = self.conns.get_mut(ch)` borrow is field-disjoint from every
+    // `self.<other field>` access below, exactly as when this loop ran inline in
+    // the poll loop.
+    while let Some(sid) = e.conn_mut().streams().accept(Dir::Bi) {
+      let peer = e.peer();
+      // At the inbound ceiling: refuse this stream instead of minting a
+      // bridge. Reset both halves so the peer is notified and quinn
+      // releases the stream slot, and bump `inbound_streams_rejected`.
+      // Ignoring Err: `ClosedStream` means the half is already gone,
+      // which is the desired end state.
+      if max_inbound.is_some_and(|max| self.inbound_bridge_count >= max) {
+        self.ep.metrics_mut().inbound_streams_rejected += 1;
+        let _ = e
+          .conn_mut()
+          .send_stream(sid)
+          .reset(quinn_proto::VarInt::from_u32(0));
+        let _ = e
+          .conn_mut()
+          .recv_stream(sid)
+          .stop(quinn_proto::VarInt::from_u32(0));
+        continue;
+      }
+      let Some(stream) = self.ep.accept_stream(peer, now) else {
+        // Leaving/Left: admit no new inbound reliable stream. Reset both
+        // halves of the just-accepted QUIC stream so the peer is notified
+        // and the connection's stream slot is released instead of left
+        // orphaned with no Bridge to own it. Ignoring Err: `ClosedStream`
+        // means the half is already gone, which is the desired end state.
+        let _ = e
+          .conn_mut()
+          .send_stream(sid)
+          .reset(quinn_proto::VarInt::from_u32(0));
+        let _ = e
+          .conn_mut()
+          .recv_stream(sid)
+          .stop(quinn_proto::VarInt::from_u32(0));
+        continue;
+      };
+      let id = stream.id();
+      let reliable_max = self.ep.max_stream_frame_size();
+      self.bridges.insert(
+        id,
+        Bridge::new(
+          stream,
+          ch,
+          sid,
+          #[cfg(compression)]
+          self.compression,
+          #[cfg(encryption)]
+          self.encryption.clone(),
+          reliable_max,
+          self.label.clone(),
+          self.skip_inbound_label_check,
+          false,
+        ),
+      );
+      // Mirror the mint into both bridge indexes (each borrows only its own
+      // field, disjoint from the live `e`/`self.conns` borrow), and bump
+      // the incremental inbound population this accept gate reads. An
+      // accepted bridge is never in `pending_outbound_kinds`, so the guard
+      // is always true here — but keeping the SAME `!contains` predicate the
+      // reap-time decrement uses makes the count provably balanced no matter
+      // how the id spaces evolve.
+      index_bridge_mint(&mut self.bridges, &mut self.bridges_by_conn, ch, id);
+      self.bridge_by_conn_sid.insert((ch, sid), id);
+      if !self.pending_outbound_kinds.contains_key(&id) {
+        self.inbound_bridge_count += 1;
+      }
+      #[cfg(test)]
+      {
+        self.counters.max_inbound_bridges_live = self
+          .counters
+          .max_inbound_bridges_live
+          .max(self.inbound_bridge_count);
+      }
+      // T1 (inbound mint): a freshly-accepted inbound bridge already holds
+      // its first request bytes in quinn's per-stream assembler (this
+      // datagram delivered them), yet a new remote stream's first frames
+      // set only the coalesced `Opened` flag and emit no `Readable`, so no
+      // later event re-announces those bytes. Enqueue it here so the pass
+      // drain pumps the buffered request the same pass it was accepted.
+      // Disjoint from the live `e`/`self.conns` borrow — see
+      // `enqueue_ready_bridge`.
+      enqueue_ready_bridge(&mut self.bridges, &mut self.ready_bridges, id);
+    }
+  }
+
   /// Service exactly one connection `ch`: apply its deferred feedback, drive its
   /// timers, drain its `poll()` (accepting inbound bidi streams into bridges,
   /// routing per-stream Finished/Stopped, reaping its bridges on a
@@ -5556,6 +5715,13 @@ where
     // raised its MAX_STREAMS bidi limit, so a dial requeued on this peer's
     // exhausted bidi credit can now open. Consumed after the borrow drops.
     let mut credit_restored = false;
+    // Set when this pass drains an inbound `StreamEvent::Opened { dir: Bi }`. The
+    // accept-drain it triggers needs `&mut self` (it re-borrows the connection
+    // table plus the endpoint and bridge tables), which cannot run while the
+    // outer `e` borrow of `self.conns` is held by this poll loop — so record the
+    // one-shot signal here and run the drain after the borrow releases, gated on
+    // the connection's application-readiness (the QUIC 0-RTT readiness gate).
+    let mut inbound_opened = false;
     while let Some(ev) = e.conn_mut().poll() {
       match ev {
         quinn_proto::Event::ConnectionLost { .. } => {
@@ -5565,124 +5731,19 @@ where
           lost = true;
         }
         quinn_proto::Event::Stream(quinn_proto::StreamEvent::Opened { dir: Dir::Bi }) => {
-          // `StreamEvent::Opened` is an idempotent signal ("one or more
-          // streams opened"), not a per-stream event, so accept until the
-          // peer's bidi backlog is drained — otherwise concurrently opened
-          // inbound exchanges are stranded with no further wake-up.
-          //
-          // Cross-connection inbound-stream cap. Each accepted bidi stream
-          // mints a Bridge that pins up to ~3x the max reliable frame size, so
-          // admission-gate every inbound bridge against the QUIC-specific
-          // `QuicOptions::max_inbound_streams` (a bounded nonzero default)
-          // BEFORE minting — the QUIC twin of the stream coordinator's
-          // `accept_connection` gate (`streams::StreamEndpoint`, which counts
-          // `exchanges.filter(|m| !m.outbound)`). The QUIC ceiling is its own
-          // option, not the shared TCP/TLS `EndpointOptions::max_inbound_streams`
-          // (which defaults to unlimited), so a default QUIC endpoint is bounded
-          // without changing TCP/TLS behaviour. This bounds inbound bridge state
-          // ACROSS all connections; quinn's per-connection
-          // `max_concurrent_bidi_streams` is a separate, per-connection limit.
-          // quinn opens remote streams IMPLICITLY: one STREAM (or MAX_STREAM_DATA)
-          // frame naming a high in-credit index advances `next_remote`, so this
-          // loop can accept the whole remaining bidi window in a single datagram —
-          // up to the per-connection bidi credit, capped by the `max_inbound_streams`
-          // headroom above. That is a per-credit-window BATCH bound: config-bounded
-          // and independent of the connection/bridge tables, not amplifiable per
-          // datagram beyond the configured caps. An operator wanting a tighter
-          // per-datagram batch lowers quinn's `max_concurrent_bidi_streams` — gossip
-          // needs only a handful of concurrent reliable exchanges per connection.
-          // An outbound bridge is registered in `pending_outbound_kinds` for
-          // the life of its exchange and an accepted (inbound) bridge never is
-          // (see that field's docs), so the inbound population is exactly the
-          // bridges absent from that map — tracked incrementally as
-          // `inbound_bridge_count`. Read that O(1) count instead of filtering
-          // the whole bridge table on every peer-driven `Opened` (one datagram
-          // could otherwise force an O(all bridges) fold); the mint below bumps
-          // it in place, so a later connection's accept loop this same pass sees
-          // the updated total — the cap is ACROSS all connections.
-          let max_inbound = self.cfg.max_inbound_streams();
-          while let Some(sid) = e.conn_mut().streams().accept(Dir::Bi) {
-            let peer = e.peer();
-            // At the inbound ceiling: refuse this stream instead of minting a
-            // bridge. Reset both halves so the peer is notified and quinn
-            // releases the stream slot, and bump `inbound_streams_rejected`.
-            // Ignoring Err: `ClosedStream` means the half is already gone,
-            // which is the desired end state.
-            if max_inbound.is_some_and(|max| self.inbound_bridge_count >= max) {
-              self.ep.metrics_mut().inbound_streams_rejected += 1;
-              let _ = e
-                .conn_mut()
-                .send_stream(sid)
-                .reset(quinn_proto::VarInt::from_u32(0));
-              let _ = e
-                .conn_mut()
-                .recv_stream(sid)
-                .stop(quinn_proto::VarInt::from_u32(0));
-              continue;
-            }
-            let Some(stream) = self.ep.accept_stream(peer, now) else {
-              // Leaving/Left: admit no new inbound reliable stream. Reset both
-              // halves of the just-accepted QUIC stream so the peer is notified
-              // and the connection's stream slot is released instead of left
-              // orphaned with no Bridge to own it. Ignoring Err: `ClosedStream`
-              // means the half is already gone, which is the desired end state.
-              let _ = e
-                .conn_mut()
-                .send_stream(sid)
-                .reset(quinn_proto::VarInt::from_u32(0));
-              let _ = e
-                .conn_mut()
-                .recv_stream(sid)
-                .stop(quinn_proto::VarInt::from_u32(0));
-              continue;
-            };
-            let id = stream.id();
-            let reliable_max = self.ep.max_stream_frame_size();
-            self.bridges.insert(
-              id,
-              Bridge::new(
-                stream,
-                ch,
-                sid,
-                #[cfg(compression)]
-                self.compression,
-                #[cfg(encryption)]
-                self.encryption.clone(),
-                reliable_max,
-                self.label.clone(),
-                self.skip_inbound_label_check,
-                false,
-              ),
-            );
-            // Mirror the mint into both bridge indexes (each borrows only its own
-            // field, disjoint from the live `e`/`self.conns` borrow), and bump
-            // the incremental inbound population this accept gate reads. An
-            // accepted bridge is never in `pending_outbound_kinds`, so the guard
-            // is always true here — but keeping the SAME `!contains` predicate the
-            // reap-time decrement uses makes the count provably balanced no matter
-            // how the id spaces evolve.
-            index_bridge_mint(&mut self.bridges, &mut self.bridges_by_conn, ch, id);
-            self.bridge_by_conn_sid.insert((ch, sid), id);
-            if !self.pending_outbound_kinds.contains_key(&id) {
-              self.inbound_bridge_count += 1;
-            }
-            #[cfg(test)]
-            {
-              self.counters.max_inbound_bridges_live = self
-                .counters
-                .max_inbound_bridges_live
-                .max(self.inbound_bridge_count);
-            }
-            // T1 (inbound mint): a freshly-accepted inbound bridge already holds
-            // its first request bytes in quinn's per-stream assembler (this
-            // datagram delivered them), yet a new remote stream's first frames
-            // set only the coalesced `Opened` flag and emit no `Readable`, so no
-            // later event re-announces those bytes. Enqueue it here so the pass
-            // drain pumps the buffered request the same pass it was accepted.
-            // Disjoint from the live `e`/`self.conns` borrow — see
-            // `enqueue_ready_bridge`.
-            enqueue_ready_bridge(&mut self.bridges, &mut self.ready_bridges, id);
-          }
+          // `StreamEvent::Opened` is an idempotent one-shot signal ("one or more
+          // streams opened"), NOT a per-stream event: it fires once and is not
+          // re-raised while un-accepted streams remain. Record it and drain after
+          // the poll loop releases `e` (see `accept_inbound_streams`) — gated on
+          // the connection's application-readiness. While the connection is still
+          // handshaking (the QUIC 0-RTT readiness gate), the accept-drain does
+          // NOT run: quinn holds the un-accepted bidi streams, bounded by the
+          // connection's own `max_concurrent_bidi_streams` credit and discarded
+          // with the connection on loss (quinn IS the quarantine — no new
+          // buffer). The one-shot signal is re-driven at the establishment
+          // chokepoint so a stream opened pre-establishment is still accepted and
+          // pumped the pass the handshake completes.
+          inbound_opened = true;
         }
         quinn_proto::Event::Stream(quinn_proto::StreamEvent::Readable { id: sid }) => {
           // T2 (readable): new inbound data, a peer FIN, or a peer RESET for a
@@ -5876,21 +5937,47 @@ where
     // another peer's probe Ack. recv() returns an owned Bytes, so the
     // e.conn_mut() borrow releases before the disjoint-field pushes.
     let peer = e.peer();
+    // QUIC 0-RTT readiness gate (datagram plane). Sample the connection's
+    // application-readiness ONCE before the drain: a caller who enables rustls
+    // early data can have quinn accept 0-RTT DATAGRAM frames while this
+    // connection is still handshaking (before it emits `Event::Connected`), so
+    // an ungated push would commit probe/membership/user effects with no
+    // rollback if the handshake later fails (the crash-stop trigger). The
+    // sticky flag is monotonic — `established_before` implies it — and every
+    // `conn_mut()` above has had its chance to flip it, so this reflects the
+    // connection's final state for the pass.
+    let established = established_before || e.established_at_least_once();
     while let Some(payload) = e.conn_mut().datagrams().recv() {
-      // Pop quinn to empty so a zero-length-frame flood cannot accumulate
-      // inside quinn; admission (per-peer + global caps, dropped+counted past
-      // either bound so one flooding peer cannot fill the shared queue and
-      // starve another peer's probe Ack) is enforced by the shared helper —
-      // the SAME bound `handle_memberlist_udp` applies, so neither source can
-      // exceed it. The three `&mut self.<field>` args are disjoint from the
-      // `self.conns` borrow `e` holds.
-      push_mem_ingress_capped(
-        &mut self.mem_ingress,
-        &mut self.mem_ingress_per_peer,
-        &mut self.datagram_ingress_dropped,
-        peer,
-        move || payload,
-      );
+      // Pop quinn to EMPTY regardless of readiness so a zero-length-frame flood
+      // cannot accumulate inside quinn (the DoS bound). Only the disposition of
+      // each popped payload is gated.
+      if established {
+        // Pop quinn to empty so a zero-length-frame flood cannot accumulate
+        // inside quinn; admission (per-peer + global caps, dropped+counted past
+        // either bound so one flooding peer cannot fill the shared queue and
+        // starve another peer's probe Ack) is enforced by the shared helper —
+        // the SAME bound `handle_memberlist_udp` applies, so neither source can
+        // exceed it. The three `&mut self.<field>` args are disjoint from the
+        // `self.conns` borrow `e` holds.
+        push_mem_ingress_capped(
+          &mut self.mem_ingress,
+          &mut self.mem_ingress_per_peer,
+          &mut self.datagram_ingress_dropped,
+          peer,
+          move || payload,
+        );
+      } else {
+        // Pre-establishment 0-RTT datagram: DROP and count on the dedicated
+        // metric (distinct from `datagram_ingress_dropped`, which means "ingress
+        // cap exceeded"). Quarantine-and-release is rejected — the unreliable
+        // plane is loss-tolerant, so ordinary gossip redundancy re-delivers
+        // within a round; a release buffer would add an adversarial lifecycle
+        // for one saved gossip round on a rare opt-in config. `payload` is
+        // dropped here. The `&mut self.<field>` bump is disjoint from the
+        // `self.conns` borrow `e` holds.
+        self.pre_established_datagrams_dropped =
+          self.pre_established_datagrams_dropped.saturating_add(1);
+      }
     }
     // Also reap when the connection has reached `is_drained()` even if
     // `poll()` never yielded `Event::ConnectionLost` for it in this
@@ -5919,6 +6006,25 @@ where
     // still-handshaking connection.
     if established_transition {
       self.conns.on_established_transition(ch);
+    }
+    // Inbound accept-drain (QUIC 0-RTT readiness gate), run now that `e`'s borrow
+    // of `self.conns` is released so the `&mut self` method can re-borrow the
+    // connection table plus the endpoint and bridge tables. Two triggers, both
+    // requiring the connection to have reached its application-readiness
+    // boundary:
+    //   * `inbound_opened && established_before`: a one-shot `Opened` fired this
+    //     pass on an already-established connection — the normal 1-RTT inbound
+    //     accept. (When still handshaking, `inbound_opened` alone does NOT drain:
+    //     quinn quarantines the streams until the handshake completes.)
+    //   * `established_transition`: the handshake completed THIS pass, so re-drive
+    //     the coalesced one-shot `Opened` that fired while handshaking and never
+    //     re-fires — mint AND enqueue the quarantined streams at the establishment
+    //     boundary (the T1 first-frames-emit-no-Readable rationale applies
+    //     verbatim). An empty `accept` here is a no-op.
+    // Placed before the `lost || drained` reap so any bridge minted here is swept
+    // into that connection's O(K) reap if the connection also failed this pass.
+    if (inbound_opened && established_before) || established_transition {
+      self.accept_inbound_streams(ch, now);
     }
     if lost || drained {
       // Mark every bridge on this connection fatal AND complete its D1

--- a/memberlist-proto/src/quic/tests.rs
+++ b/memberlist-proto/src/quic/tests.rs
@@ -12587,3 +12587,448 @@ fn quic_options_ping_exempt_cap_default_and_validation() {
     .validate()
     .expect("the default config validates");
 }
+
+// ===================================================================
+// QUIC 0-RTT readiness gate (#173)
+// ===================================================================
+
+/// Build an early-data-capable coordinator: server ACCEPTS 0-RTT
+/// (`max_early_data_size = u32::MAX`), client is built from the SHARED
+/// `client_arc` (0-RTT enabled + a resumption store shared across every endpoint
+/// built from the same Arc). Datagram unreliable mode + a finite idle timeout,
+/// matching [`test_config`].
+fn make_endpoint_early(
+  id: &str,
+  addr: SocketAddr,
+  now: Instant,
+  client_arc: std::sync::Arc<quinn_proto::crypto::rustls::QuicClientConfig>,
+) -> QuicEndpoint<SmolStr> {
+  make_endpoint_early_capped(id, addr, now, client_arc, None)
+}
+
+/// [`make_endpoint_early`] with an explicit `max_inbound` override: `Some(n)`
+/// sets [`QuicOptions::with_max_inbound_streams`] `Some(n)`; `None` leaves the
+/// default (`DEFAULT_MAX_QUIC_INBOUND_STREAMS`).
+fn make_endpoint_early_capped(
+  id: &str,
+  addr: SocketAddr,
+  now: Instant,
+  client_arc: std::sync::Arc<quinn_proto::crypto::rustls::QuicClientConfig>,
+  max_inbound: Option<usize>,
+) -> QuicEndpoint<SmolStr> {
+  let cfg = EndpointOptions::new(SmolStr::new(id), addr);
+  let mut ep: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg);
+  ep.start_scheduling(now);
+  let mut transport = quinn_proto::TransportConfig::default();
+  transport.max_idle_timeout(Some(
+    quinn_proto::IdleTimeout::try_from(Duration::from_secs(20)).unwrap(),
+  ));
+  let mut qc = QuicOptions::new(
+    crate::quic::crypto::tests::test_endpoint_config(&[0x5au8; 32]),
+    crate::quic::crypto::tests::test_server_early(),
+    quinn_proto::ClientConfig::new(client_arc),
+    transport,
+    "localhost",
+    UnreliableTransport::Datagram,
+  );
+  if let Some(n) = max_inbound {
+    qc = qc.with_max_inbound_streams(Some(n));
+  }
+  let mut seed = [0u8; 32];
+  seed[..2].copy_from_slice(&addr.port().to_le_bytes());
+  QuicEndpoint::<SmolStr>::with_quinn_rng_seed(ep, qc, Some(seed))
+}
+
+/// Drive a full push/pull JOIN `a` -> `b` at a fixed instant to membership
+/// completion, ferrying both directions and draining both event queues (so `b`
+/// issues + `a` stores a session ticket in the shared resumption store).
+fn ferry_join_to_completion(
+  a: &mut QuicEndpoint<SmolStr>,
+  b: &mut QuicEndpoint<SmolStr>,
+  a_addr: SocketAddr,
+  b_addr: SocketAddr,
+  now: Instant,
+) {
+  let _ = a.start_push_pull(b_addr, PushPullKind::Join, now);
+  for _ in 0..512 {
+    let mut moved = false;
+    while let Some((to, bytes)) = a.poll_transmit() {
+      if to == b_addr {
+        b.handle_udp(a_addr, &bytes, now);
+        moved = true;
+      }
+    }
+    while let Some((to, bytes)) = b.poll_transmit() {
+      if to == a_addr {
+        a.handle_udp(b_addr, &bytes, now);
+        moved = true;
+      }
+    }
+    a.handle_timeout(now);
+    b.handle_timeout(now);
+    while a.poll_event().is_some() {}
+    while b.poll_event().is_some() {}
+    if !moved {
+      break;
+    }
+  }
+}
+
+/// Establish a first connection `a1 <-> b` so `a1`'s SHARED resumption store
+/// captures a session ticket `b` issued, then return a FRESH `a2` (sharing the
+/// same store) ready to resume `b` with 0-RTT, plus `b`, their addrs, and the
+/// fixed instant. `max_inbound` overrides `b`'s (and `a2`'s) inbound-stream cap.
+/// `a1` is kept alive by the returned tuple's store references (its own binding
+/// is dropped — the ticket lives in the store, not the connection).
+fn setup_for_zero_rtt_resume(
+  base_port: u16,
+  max_inbound: Option<usize>,
+) -> (
+  QuicEndpoint<SmolStr>,
+  QuicEndpoint<SmolStr>,
+  SocketAddr,
+  SocketAddr,
+  Instant,
+) {
+  let a1_addr: SocketAddr = format!("127.0.0.1:{base_port}").parse().unwrap();
+  let a2_addr: SocketAddr = format!("127.0.0.1:{}", base_port + 1).parse().unwrap();
+  let b_addr: SocketAddr = format!("127.0.0.1:{}", base_port + 2).parse().unwrap();
+  let now = Instant::now();
+  let client_arc = crate::quic::crypto::tests::early_data_client_arc();
+  let mut a1 = make_endpoint_early("a1", a1_addr, now, client_arc.clone());
+  let a2 = make_endpoint_early_capped("a2", a2_addr, now, client_arc.clone(), max_inbound);
+  let mut b = make_endpoint_early_capped("b", b_addr, now, client_arc, max_inbound);
+
+  ferry_join_to_completion(&mut a1, &mut b, a1_addr, b_addr, now);
+  assert_eq!(
+    b.endpoint_mut().num_members(),
+    2,
+    "precondition: the first (non-resumed) a1<->b JOIN must fully merge"
+  );
+  assert!(
+    b.bridges.is_empty(),
+    "precondition: a1's push/pull bridge on b must be reaped after the merge"
+  );
+  assert_eq!(
+    b.inbound_bridge_count(),
+    0,
+    "precondition: no inbound bridge remains live on b after the first merge"
+  );
+  (a2, b, a2_addr, b_addr, now)
+}
+
+/// Flush `a2` and deliver every `a2 -> b` transmit to `b` WITHOUT ferrying `b`'s
+/// reply back, so `b` processes the (0-RTT) first flight but cannot complete its
+/// handshake. Returns the number of datagrams delivered.
+fn deliver_a2_first_flight_to_b(
+  a2: &mut QuicEndpoint<SmolStr>,
+  b: &mut QuicEndpoint<SmolStr>,
+  a2_addr: SocketAddr,
+  b_addr: SocketAddr,
+  now: Instant,
+) -> usize {
+  a2.flush_outbound_transmits(now);
+  let mut delivered = 0usize;
+  while let Some((to, bytes)) = a2.poll_transmit() {
+    if to == b_addr {
+      b.handle_udp(a2_addr, &bytes, now);
+      delivered += 1;
+    }
+  }
+  // Service b a few times so any (ungated) accepted stream would mint AND pump.
+  for _ in 0..4 {
+    b.handle_timeout(now);
+    while b.poll_event().is_some() {}
+  }
+  delivered
+}
+
+/// Complete a2<->b's handshake by ferrying both directions to quiescence.
+fn complete_a2_b_handshake(
+  a2: &mut QuicEndpoint<SmolStr>,
+  b: &mut QuicEndpoint<SmolStr>,
+  a2_addr: SocketAddr,
+  b_addr: SocketAddr,
+  now: Instant,
+) {
+  for _ in 0..512 {
+    let mut moved = false;
+    while let Some((to, bytes)) = a2.poll_transmit() {
+      if to == b_addr {
+        b.handle_udp(a2_addr, &bytes, now);
+        moved = true;
+      }
+    }
+    while let Some((to, bytes)) = b.poll_transmit() {
+      if to == a2_addr {
+        a2.handle_udp(b_addr, &bytes, now);
+        moved = true;
+      }
+    }
+    a2.handle_timeout(now);
+    b.handle_timeout(now);
+    while a2.poll_event().is_some() {}
+    while b.poll_event().is_some() {}
+    if !moved {
+      break;
+    }
+  }
+}
+
+/// Test 1 — 0-RTT deferral, end-to-end over the public `QuicOptions` path with
+/// early data enabled both sides and a real resumption ticket. `a2` resumes `b`
+/// and, IN 0-RTT (before `b`'s handshake completes), opens a push/pull JOIN
+/// stream (with FIN) AND queues an application datagram. While `b` is still
+/// handshaking the coordinator commits NO effect — no membership merge, no
+/// inbound bridge, and the early datagram is dropped and counted. Only once `b`
+/// establishes does the quarantined stream's push/pull merge (exactly once); the
+/// dropped datagram is not recovered (the unreliable plane is loss-tolerant).
+///
+/// Mutation-anchor (stream gate): revert the accept-drain gate in
+/// `service_one_conn` to accept while handshaking and `a2`'s JOIN merges into `b`
+/// BEFORE establishment — the `member_liveness("a2") == None` while-handshaking
+/// assertion fails. Mutation-anchor (datagram gate): revert the datagram gate to
+/// push while handshaking and `pre_established_datagrams_dropped` stays 0 while
+/// the payload reaches `mem_ingress`.
+#[test]
+fn zero_rtt_stream_and_datagram_defer_until_establishment() {
+  let (mut a2, mut b, a2_addr, b_addr, now) = setup_for_zero_rtt_resume(9320, None);
+  let a2_id = SmolStr::new("a2");
+
+  // a2 resumes b: a 0-RTT push/pull JOIN stream AND a 0-RTT application datagram.
+  let _ = a2.start_push_pull(b_addr, PushPullKind::Join, now);
+  let dstatus = a2.queue_unreliable_datagram(b_addr, Bytes::from_static(b"\x01probe0rtt"), now);
+  assert_eq!(
+    dstatus,
+    crate::quic::DatagramSendStatus::Queued,
+    "the 0-RTT resume must make datagram credit available (cached peer params), \
+       so the application datagram is queued in early data"
+  );
+
+  let delivered = deliver_a2_first_flight_to_b(&mut a2, &mut b, a2_addr, b_addr, now);
+  assert!(delivered >= 1, "a2's 0-RTT first flight must reach b");
+
+  // b's connection to a2 exists and is still handshaking.
+  let ch = b
+    .conns
+    .handle_for(&a2_addr)
+    .expect("b must hold a (handshaking) connection from a2's 0-RTT flight");
+  let e = b.conns.get(ch).expect("b's a2 connection is present");
+  assert!(
+    e.conn_ref().is_handshaking(),
+    "b's a2 connection must still be handshaking (b's reply was withheld)"
+  );
+  assert!(
+    !e.established_at_least_once(),
+    "b's a2 connection must NOT have reached its establishment boundary yet"
+  );
+
+  // NO effect committed while handshaking: no merge, no inbound bridge.
+  assert_eq!(
+    b.endpoint_mut().num_members(),
+    2,
+    "no membership merge may commit before b's establishment (still {} known)",
+    b.endpoint_mut().num_members()
+  );
+  assert_eq!(
+    b.endpoint_mut().member_liveness(&a2_id),
+    None,
+    "a2 must NOT be a known member before b establishes its connection"
+  );
+  assert!(
+    b.bridges.is_empty(),
+    "no inbound bridge may be minted for a 0-RTT stream while b is handshaking \
+       (quinn quarantines it)"
+  );
+  assert_eq!(
+    b.inbound_bridge_count(),
+    0,
+    "the quarantined 0-RTT stream must count against no inbound-bridge budget"
+  );
+  // The 0-RTT datagram was dropped and counted, NOT delivered to ingress.
+  assert!(
+    b.pre_established_datagrams_dropped() >= 1,
+    "the 0-RTT application datagram must be dropped and counted while handshaking"
+  );
+  assert!(
+    b.poll_memberlist_ingress().is_none(),
+    "no pre-establishment datagram may reach mem_ingress"
+  );
+
+  // Complete b's handshake: the quarantined push/pull is re-driven and merges.
+  complete_a2_b_handshake(&mut a2, &mut b, a2_addr, b_addr, now);
+  let ch = b
+    .conns
+    .handle_for(&a2_addr)
+    .expect("b still holds the a2 connection post-handshake");
+  assert!(
+    b.conns.get(ch).unwrap().established_at_least_once(),
+    "b's a2 connection must have reached establishment"
+  );
+  assert_eq!(
+    b.endpoint_mut().num_members(),
+    3,
+    "after establishment the deferred 0-RTT push/pull JOIN must merge a2 exactly once"
+  );
+  assert_eq!(
+    b.endpoint_mut().member_liveness(&a2_id),
+    Some(State::Alive),
+    "a2 must be a known Alive member only after b's establishment"
+  );
+  // The dropped datagram is not recovered by the stream path; the count stands.
+  assert!(
+    b.pre_established_datagrams_dropped() >= 1,
+    "the early datagram remains dropped (loss-tolerant); it is not replayed"
+  );
+}
+
+/// Test 2 — crash-stop before finality. `a2` sends an accepted 0-RTT flight (a
+/// push/pull JOIN stream WITH FIN, plus an application datagram), then `b`'s
+/// connection fails BEFORE it reaches establishment (a transport-level close, the
+/// crash-stop analogue). No membership/user effect is EVER committed, the
+/// connection and its quinn-held streams are reaped, `inbound_bridge_count` is
+/// unchanged, and no bridge is ever minted.
+#[test]
+fn zero_rtt_flight_then_crash_stop_commits_nothing() {
+  let (mut a2, mut b, a2_addr, b_addr, now) = setup_for_zero_rtt_resume(9330, None);
+  let a2_id = SmolStr::new("a2");
+
+  let _ = a2.start_push_pull(b_addr, PushPullKind::Join, now);
+  let _ = a2.queue_unreliable_datagram(b_addr, Bytes::from_static(b"\x01probe0rtt"), now);
+  let delivered = deliver_a2_first_flight_to_b(&mut a2, &mut b, a2_addr, b_addr, now);
+  assert!(delivered >= 1, "a2's 0-RTT first flight must reach b");
+
+  // Precondition: handshaking, nothing committed.
+  let ch = b
+    .conns
+    .handle_for(&a2_addr)
+    .expect("b holds the handshaking a2 connection");
+  assert!(b.conns.get(ch).unwrap().conn_ref().is_handshaking());
+  assert_eq!(b.endpoint_mut().num_members(), 2);
+  assert!(b.bridges.is_empty());
+  assert_eq!(b.inbound_bridge_count(), 0);
+  let dropped_before = b.pre_established_datagrams_dropped();
+  assert!(
+    dropped_before >= 1,
+    "the early datagram was dropped and counted"
+  );
+
+  // Crash-stop: fail b's connection to a2 BEFORE it ever establishes.
+  b.conns
+    .get_mut(ch)
+    .unwrap()
+    .conn_mut()
+    .close(now.into_std(), 0u32.into(), Bytes::new());
+  for _ in 0..8 {
+    b.handle_timeout(now);
+    while b.poll_event().is_some() {}
+  }
+
+  // No effect EVER; connection reaped; no bridge ever minted.
+  assert_eq!(
+    b.endpoint_mut().num_members(),
+    2,
+    "a crash-stop before finality must commit no membership effect"
+  );
+  assert_eq!(
+    b.endpoint_mut().member_liveness(&a2_id),
+    None,
+    "a2 must never become a known member from an abandoned 0-RTT handshake"
+  );
+  assert!(
+    b.bridges.is_empty(),
+    "no inbound bridge may survive an abandoned 0-RTT handshake"
+  );
+  assert_eq!(
+    b.inbound_bridge_count(),
+    0,
+    "inbound_bridge_count must be unchanged after a crash-stop"
+  );
+  assert_eq!(
+    b.pre_established_datagrams_dropped(),
+    dropped_before,
+    "the dropped early datagram is never revived by the connection teardown"
+  );
+}
+
+/// Test 3 — one-shot `Opened` re-drive. A 0-RTT stream whose ONLY
+/// `StreamEvent::Opened` fires while `b` is handshaking must still be accepted,
+/// minted, and pumped at the establishment transition — the coalesced signal
+/// never re-fires, so the transition drain (`|| established_transition`) is the
+/// only thing that can re-drive it. Proven by the JOIN completing with NO further
+/// peer application traffic after the first flight (only the handshake-completing
+/// packets are exchanged).
+///
+/// Mutation-anchor: drop `|| established_transition` from the accept-drain gate
+/// and the quarantined stream is never accepted — `num_members` stays 2 forever.
+#[test]
+fn zero_rtt_one_shot_opened_is_redriven_at_establishment() {
+  let (mut a2, mut b, a2_addr, b_addr, now) = setup_for_zero_rtt_resume(9340, None);
+  let a2_id = SmolStr::new("a2");
+
+  // Only a 0-RTT stream (no datagram): its single Opened fires while handshaking.
+  let _ = a2.start_push_pull(b_addr, PushPullKind::Join, now);
+  let delivered = deliver_a2_first_flight_to_b(&mut a2, &mut b, a2_addr, b_addr, now);
+  assert!(delivered >= 1);
+  assert_eq!(
+    b.endpoint_mut().num_members(),
+    2,
+    "the one-shot Opened fired while handshaking must NOT be accepted yet"
+  );
+  assert!(b.bridges.is_empty());
+
+  // Complete only the handshake (no re-sent stream frames): the re-drive accepts
+  // and pumps the quarantined stream at the establishment transition.
+  complete_a2_b_handshake(&mut a2, &mut b, a2_addr, b_addr, now);
+  assert_eq!(
+    b.endpoint_mut().num_members(),
+    3,
+    "the coalesced pre-establishment Opened must be re-driven at establishment so \
+       the quarantined stream is accepted and merged"
+  );
+  assert_eq!(b.endpoint_mut().member_liveness(&a2_id), Some(State::Alive),);
+}
+
+/// Test 6 — inbound-cap interaction. A 0-RTT stream quarantined in quinn while
+/// `b` handshakes counts against NOTHING (`inbound_bridge_count == 0`), so the
+/// `max_inbound_streams` headroom is preserved; the cap is applied at the
+/// establishment (transition) drain exactly as it would be at an inline drain —
+/// here the accept succeeds within a cap of 2 and the stream is counted only once
+/// accepted.
+#[test]
+fn zero_rtt_stream_counts_against_inbound_cap_only_once_accepted() {
+  let (mut a2, mut b, a2_addr, b_addr, now) = setup_for_zero_rtt_resume(9350, Some(2));
+
+  let _ = a2.start_push_pull(b_addr, PushPullKind::Join, now);
+  let delivered = deliver_a2_first_flight_to_b(&mut a2, &mut b, a2_addr, b_addr, now);
+  assert!(delivered >= 1);
+
+  // Quarantined while handshaking: counts against no budget.
+  assert_eq!(
+    b.inbound_bridge_count(),
+    0,
+    "a quarantined 0-RTT stream must not consume max_inbound_streams headroom"
+  );
+  assert_eq!(
+    b.metrics().inbound_streams_rejected,
+    0,
+    "no inbound stream may be rejected while it is merely quarantined"
+  );
+
+  // At establishment the cap gate runs in the transition drain and accepts (1 <= 2).
+  complete_a2_b_handshake(&mut a2, &mut b, a2_addr, b_addr, now);
+  assert_eq!(
+    b.endpoint_mut().num_members(),
+    3,
+    "within the inbound cap the re-driven stream is accepted and merged"
+  );
+  assert_eq!(
+    b.metrics().inbound_streams_rejected,
+    0,
+    "the accept at the transition drain stayed within the cap — no rejection"
+  );
+  assert!(
+    b.counters.max_inbound_bridges_live >= 1,
+    "the stream was counted as a live inbound bridge only once accepted at establishment"
+  );
+}


### PR DESCRIPTION
Closes #173 — caller-enabled QUIC 0-RTT could commit membership/user/probe effects before `Event::Connected`.

## The finding

When a caller enables QUIC 0-RTT / early data via the **raw `QuicOptions::new` escape hatch** (the checked-in `QuicConfigOptions::build` disables it), the coordinator processed accepted 0-RTT STREAM/DATAGRAM frames while still handshaking, committing membership merges, `UserPacket`s, and probe/gossip datagram effects **before the connection reached quinn's `Event::Connected`**, with no rollback if the handshake later failed. Under crash-stop (an accepted early flight, then the sender crashes before Finished) the acceptor commits effects from a connection that never existed at the finality boundary. 0-RTT early data is also replayable.

## The fix — readiness-gate the two inbound effect-committing sites

Gate the two inbound paths that commit un-rollback-able effects on the **existing** `ConnEntry::established_at_least_once` latch (which flips at the `!is_handshaking() && !is_closed()` transition quinn queues `Event::Connected` on — state-observation is equivalent-or-stronger than the event and immune to event-ordering; no new latch):

- **Inbound streams:** the accept-drain is factored into `accept_inbound_streams`, invoked only on an already-established connection or at the establishment-completion pass. While handshaking, nothing is accepted — **quinn itself holds the un-accepted bidi streams** (bounded by the connection's own stream credit, discarded with the connection on loss), so there is **zero new buffering**. The establishment-transition drive also re-processes the coalesced one-shot `Opened` (which, it turns out, is load-bearing for ordinary 1-RTT too, when a first stream arrives on the same pass the handshake completes).
- **Inbound datagrams:** the loop still pops quinn to empty (the zero-length-flood bound), but a pre-established datagram is **dropped and counted** (`pre_established_datagrams_dropped`) rather than released to `mem_ingress` — the unreliable plane is loss-tolerant, so a bounded quarantine buffer isn't worth its lifecycle.

Outbound sites stay ungated (they commit no un-rolled-back *local* effect; #190 already closed the canonical-capture leg; gating would only forfeit the 0-RTT latency win). Effect commitment is deferred to establishment while the caller keeps 0-RTT and its round-trip savings.

Plus: `QuicConfigOptions::build` **forces** early data off on the managed rustls path (`enable_early_data=false`, `max_early_data_size=0` — the analogue of the existing `IdleTimeoutZero` guard), and `QuicOptions::new` documents the **deferral** semantics (the coordinator defers effect commitment to establishment regardless of caller crypto config; no replay/transactional obligation transfers to delegates).
