### PR TITLE
fix(proto): treat a bare transport FIN as TLS truncation, not a clean close (#168)

### DIFF
--- a/memberlist-proto/src/streams/bridge.rs
+++ b/memberlist-proto/src/streams/bridge.rs
@@ -442,6 +442,20 @@ where
         }
       };
 
+      // The inner record stream authenticated-closed before the composed
+      // handshake / label could settle (e.g. TLS complete + `close_notify`
+      // before the peer's label): the record layer will read no further, so the
+      // handshake can never complete — fail now rather than holding a zombie
+      // bridge until the accept deadline. Automatically TCP-safe:
+      // `Passthrough::peer_has_closed()` is permanently `false`, so this never
+      // fires for plain TCP (whose pre-`Stream` EOF is the empty-slice
+      // `is_handshaking => fail` above). No retire here — during `Handshaking`
+      // there is no `Stream` and no queue to clear.
+      if self.records.is_handshaking() && self.records.peer_has_closed() {
+        self.fail(BridgeFailure::ConnectionLost);
+        return Err(());
+      }
+
       // The handshake / label step just settled inside this feed: any trailing
       // request is already surfaced as inbound plaintext inside the record
       // layer (drained by `replay_pending` post-promotion), unless the record
@@ -1069,6 +1083,17 @@ where
           self.fail(BridgeFailure::ConnectionLost);
           return Err(());
         }
+        if R::requires_authenticated_close() && !self.records.peer_has_closed() {
+          // Settled handshake, a complete unit already buffered, then a bare
+          // FIN with no authenticated in-band close (TLS `close_notify`): a
+          // truncation. Fail EARLY, before minting a `Stream`, rather than
+          // latching `pending_eof` and replaying into the post-promotion clean
+          // path (the post-promotion gate in `pump_in_established` would also
+          // catch it via `replay_pending`, but this avoids minting a doomed
+          // `Stream` for an exchange that is already truncated).
+          self.fail(BridgeFailure::ConnectionLost);
+          return Err(());
+        }
         self.pending_eof = true;
       }
       return self.intake_handshaking(data, now);
@@ -1195,7 +1220,8 @@ where
     // premature-vs-clean EOF decision. A premature EOF
     // (`StreamError::PeerClosed`) is the truncation path → decode failure; a
     // clean EOF (`Ok`) retires the recv half below via `observe_recv_fin`.
-    let fin_seen = eof || self.records.peer_has_closed();
+    let peer_closed = self.records.peer_has_closed();
+    let fin_seen = eof || peer_closed;
     if fin_seen && !decode_failed && !self.recv_accum.is_empty() {
       // A trailing partial reliable unit at EOF is a truncated transmission —
       // the peer closed mid-unit. Treat it as a decode failure (the same
@@ -1222,6 +1248,22 @@ where
       // `Stream::is_failed()`; `drain_then_reap`'s `StreamErrored` notice uses
       // the `BridgeFailure::Decode` high-level reason.
       self.fail_with_retire(BridgeFailure::Decode);
+      return Err(());
+    }
+
+    // Authenticated-close gate. Reaching here with `fin_seen` means the FSM
+    // accepted the close anchor as a CLEAN completion (a premature EOF routed
+    // through the decode-fail path above). But a secure transport's clean
+    // receive-close is its authenticated in-band close — so a bare transport FIN
+    // (`eof && !peer_closed`) on such a transport is a truncation at a
+    // complete-unit boundary, not a clean completion, even though the FSM's
+    // exchange happens to be complete. Fail it `ConnectionLost` rather than
+    // committing the buffered payload as cleanly closed. Plain TCP's
+    // `peer_has_closed()` is permanently `false` AND `requires_authenticated_close()`
+    // is `false`, so this never fires there — a plain-TCP FIN at a unit boundary
+    // stays the legitimate clean close.
+    if fin_seen && !decode_failed && eof && !peer_closed && R::requires_authenticated_close() {
+      self.fail_with_retire(BridgeFailure::ConnectionLost);
       return Err(());
     }
 

--- a/memberlist-proto/src/streams/bridge.rs
+++ b/memberlist-proto/src/streams/bridge.rs
@@ -957,8 +957,11 @@ where
   }
 
   /// Test-only: expose the pre-promote out-of-band FIN latch (asserted by the
-  /// plain-TCP bridge tests, whose FIN is the only close anchor).
-  #[cfg(all(test, feature = "tcp"))]
+  /// plain-TCP bridge tests, whose FIN is the only close anchor, and by the TLS
+  /// bridge tests exercising the retained-ciphertext deferral of the
+  /// authenticated-close classification). Gated on either transport feature so a
+  /// TLS-only build (no `tcp`) still resolves it.
+  #[cfg(all(test, any(feature = "tcp", feature = "tls")))]
   #[allow(dead_code)]
   pub(crate) fn pending_eof(&self) -> bool {
     self.pending_eof

--- a/memberlist-proto/src/streams/bridge.rs
+++ b/memberlist-proto/src/streams/bridge.rs
@@ -1083,14 +1083,30 @@ where
           self.fail(BridgeFailure::ConnectionLost);
           return Err(());
         }
-        if R::requires_authenticated_close() && !self.records.peer_has_closed() {
-          // Settled handshake, a complete unit already buffered, then a bare
-          // FIN with no authenticated in-band close (TLS `close_notify`): a
-          // truncation. Fail EARLY, before minting a `Stream`, rather than
-          // latching `pending_eof` and replaying into the post-promotion clean
-          // path (the post-promotion gate in `pump_in_established` would also
-          // catch it via `replay_pending`, but this avoids minting a doomed
-          // `Stream` for an exchange that is already truncated).
+        if R::requires_authenticated_close()
+          && !self.records.peer_has_closed()
+          && self.pending_inbound.is_empty()
+        {
+          // Settled handshake, every received byte already processed (no
+          // retained inbound ciphertext), then a bare FIN with no authenticated
+          // in-band close (TLS `close_notify`): a truncation. Fail EARLY, before
+          // minting a `Stream`, rather than latching `pending_eof` and replaying
+          // into the post-promotion clean path.
+          //
+          // The `pending_inbound.is_empty()` guard is load-bearing. A coalesced
+          // `[handshake final][reliable unit > 16 KiB][close_notify]` trips the
+          // record layer's received-plaintext backpressure, so the
+          // `close_notify`'s ciphertext stays in the retained tail
+          // (`pending_inbound`) BEHIND the large unit and `peer_has_closed()` is
+          // still `false` here — the authenticated close IS present, just not
+          // processed yet. Eager-failing then would drop a CLEAN exchange. When
+          // the tail is non-empty we instead fall through to latch `pending_eof`
+          // and defer the authenticated-close classification to the
+          // post-promotion gate, which runs AFTER `replay_pending` drains the
+          // tail (processing the `close_notify`, so `peer_has_closed()` is then
+          // `true` and the exchange stays clean). This is only an optimization —
+          // avoiding a minted `Stream` for a genuinely-truncated pre-mint
+          // exchange — so deferring when unsure costs at most one `Stream` mint.
           self.fail(BridgeFailure::ConnectionLost);
           return Err(());
         }

--- a/memberlist-proto/src/streams/bridge.rs
+++ b/memberlist-proto/src/streams/bridge.rs
@@ -1079,40 +1079,23 @@ where
         // peer half-closed before establishing the exchange — that handshake can
         // never complete, so fail now (ConnectionLost) rather than holding a
         // zombie bridge (and its record-layer buffers) until the accept
-        // deadline. If it HAS settled (the mint is merely deferred to the tick),
-        // this is the benign coalesced-close case: latch the FIN for
-        // post-promotion replay.
+        // deadline.
         if self.records.is_handshaking() {
           self.fail(BridgeFailure::ConnectionLost);
           return Err(());
         }
-        if R::requires_authenticated_close()
-          && !self.records.peer_has_closed()
-          && self.pending_inbound.is_empty()
-        {
-          // Settled handshake, every received byte already processed (no
-          // retained inbound ciphertext), then a bare FIN with no authenticated
-          // in-band close (TLS `close_notify`): a truncation. Fail EARLY, before
-          // minting a `Stream`, rather than latching `pending_eof` and replaying
-          // into the post-promotion clean path.
-          //
-          // The `pending_inbound.is_empty()` guard is load-bearing. A coalesced
-          // `[handshake final][reliable unit > 16 KiB][close_notify]` trips the
-          // record layer's received-plaintext backpressure, so the
-          // `close_notify`'s ciphertext stays in the retained tail
-          // (`pending_inbound`) BEHIND the large unit and `peer_has_closed()` is
-          // still `false` here — the authenticated close IS present, just not
-          // processed yet. Eager-failing then would drop a CLEAN exchange. When
-          // the tail is non-empty we instead fall through to latch `pending_eof`
-          // and defer the authenticated-close classification to the
-          // post-promotion gate, which runs AFTER `replay_pending` drains the
-          // tail (processing the `close_notify`, so `peer_has_closed()` is then
-          // `true` and the exchange stays clean). This is only an optimization —
-          // avoiding a minted `Stream` for a genuinely-truncated pre-mint
-          // exchange — so deferring when unsure costs at most one `Stream` mint.
-          self.fail(BridgeFailure::ConnectionLost);
-          return Err(());
-        }
+        // Settled pre-mint EOF (the mint is merely deferred to the tick): latch
+        // the FIN and defer ALL close classification to the post-promotion gate.
+        // That gate runs AFTER `replay_pending` drains the retained ciphertext
+        // tail and surfaces any buffered plaintext, so it sees the true post-
+        // decode state: a `close_notify` buffered behind a large reliable unit is
+        // honored (clean), a bare FIN at a complete-unit boundary becomes
+        // `ConnectionLost`, and a buffered partial reliable unit becomes
+        // `Decode`. Classifying here instead would have to proxy "nothing
+        // buffered" through `pending_inbound` (retained ciphertext only), which
+        // misses a decrypted partial unit the record layer holds as plaintext —
+        // misclassifying a mid-unit truncation. Deferring costs at most one
+        // `Stream` mint for a genuinely-truncated pre-mint exchange.
         self.pending_eof = true;
       }
       return self.intake_handshaking(data, now);

--- a/memberlist-proto/src/streams/labeled/mod.rs
+++ b/memberlist-proto/src/streams/labeled/mod.rs
@@ -552,6 +552,10 @@ where
   fn is_secure() -> bool {
     R::is_secure()
   }
+
+  fn requires_authenticated_close() -> bool {
+    R::requires_authenticated_close()
+  }
 }
 
 #[cfg(test)]

--- a/memberlist-proto/src/streams/mod.rs
+++ b/memberlist-proto/src/streams/mod.rs
@@ -1065,8 +1065,10 @@ where
   /// drive a scenario the public `start_*` wrappers cannot reach — e.g.
   /// invoking `Endpoint::start_reliable_ping` WITHOUT the in-band
   /// `service_dials` + `flush_outbound` the coordinator wrapper runs, or
-  /// retiring a dial intent directly with `Endpoint::dial_failed`.
-  #[cfg(all(test, feature = "tcp"))]
+  /// retiring a dial intent directly with `Endpoint::dial_failed`. Used by both
+  /// the plain-TCP and TLS stream tests, so it is gated on either transport
+  /// feature (a TLS-only build has no `tcp` but still runs the TLS dial tests).
+  #[cfg(all(test, any(feature = "tcp", feature = "tls")))]
   pub(crate) fn endpoint_mut(&mut self) -> &mut Endpoint<I, A, G> {
     &mut self.ep
   }

--- a/memberlist-proto/src/streams/transport.rs
+++ b/memberlist-proto/src/streams/transport.rs
@@ -158,4 +158,17 @@ pub trait StreamTransport: Sized {
   ///
   /// Mirrors the legacy `memberlist-net::StreamLayer::is_secure`.
   fn is_secure() -> bool;
+
+  /// Whether a clean receive-close on this transport REQUIRES an authenticated
+  /// in-band close (so a bare transport FIN is truncation, not a clean close).
+  /// `true` for TLS (a `close_notify` alert); `false` for a plaintext transport
+  /// whose only close signal is the transport FIN itself.
+  ///
+  /// Type-level capability — no `&self`. The bridge uses this to distinguish a
+  /// transport whose out-of-band FIN is its legitimate clean close (plain TCP)
+  /// from one whose only authenticated clean close is in band (TLS): for the
+  /// latter, a bare FIN without [`Self::peer_has_closed`] is a truncation.
+  fn requires_authenticated_close() -> bool {
+    false
+  }
 }

--- a/memberlist-proto/src/tcp/bridge.rs
+++ b/memberlist-proto/src/tcp/bridge.rs
@@ -1560,3 +1560,77 @@ fn pump_out_on_fsm_failed_bridge_uses_fsm_reason() {
     phase_label(server.phase_ref())
   );
 }
+
+/// F1-4 (positive control, guards plain TCP): a promoted plain-TCP server
+/// receives one COMPLETE reliable unit and then a bare transport FIN. Unlike
+/// TLS, a plain-TCP FIN at a complete-unit boundary IS the legitimate clean
+/// close (`Passthrough::requires_authenticated_close() == false`), so the
+/// truncation gate must NOT fire: the exchange stays clean and commits its
+/// payload. Proves the F1 gate leaves `Passthrough` behavior unchanged.
+#[test]
+fn established_tcp_complete_unit_then_fin_stays_clean() {
+  let now = Instant::now();
+  let (mut client, mut server) = handshaking_pair("cluster-x", now + Duration::from_secs(10));
+  complete_label_exchange(&mut client, &mut server, now);
+
+  let mut ep_c: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("cli"), addr(7820)));
+  let payload = Bytes::from_static(b"plain-tcp-clean-unit");
+  let sid = ep_c
+    .start_user_message(addr(7000), payload.clone(), now)
+    .expect("issued while running");
+  let c_stream = ep_c.dial_succeeded(sid, now).expect("dial mints");
+  client.promote(c_stream);
+
+  let mut ep_s: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("srv"), addr(7000)));
+  let s_stream = ep_s
+    .accept_stream(addr(7820), now)
+    .expect("node is running");
+  server.promote(s_stream);
+  while ep_s.poll_event().is_some() {}
+
+  client
+    .pump_out(now)
+    .expect("client writes the reliable unit");
+  let mut c_out = Vec::new();
+  client.poll_transport_transmit(&mut c_out);
+  assert!(
+    !c_out.is_empty(),
+    "the plain-TCP unit is on the wire (no in-band close record exists)"
+  );
+  server
+    .handle_transport_data(&c_out, now)
+    .expect("the complete unit decodes");
+  server.drain_payload_only(&mut ep_s, now);
+
+  // The bare TCP FIN at a complete-unit boundary is a clean close for plain TCP.
+  let res = server.handle_transport_data(&[], now);
+  assert!(
+    res.is_ok(),
+    "a plain-TCP FIN at a unit boundary is a clean close, not a truncation"
+  );
+  assert!(
+    !matches!(
+      server.phase_ref(),
+      BridgePhase::Established(LinkState::Failed(_))
+    ),
+    "the truncation gate must NOT fire for plain TCP, got {:?}",
+    phase_label(server.phase_ref())
+  );
+
+  server.drain_payload_only(&mut ep_s, now);
+  server.drain_then_reap(&mut ep_s, now);
+  let mut committed = None;
+  while let Some(ev) = ep_s.poll_event() {
+    if let Event::UserPacket(p) = ev {
+      let (_, data, _) = p.into_parts();
+      committed = Some(data);
+    }
+  }
+  assert_eq!(
+    committed.as_deref(),
+    Some(payload.as_ref()),
+    "the plain-TCP exchange commits its payload cleanly"
+  );
+}

--- a/memberlist-proto/src/tls/bridge.rs
+++ b/memberlist-proto/src/tls/bridge.rs
@@ -21,11 +21,18 @@ use crate::{
   error::StreamError,
   event::Event,
   streams::{
+    LabelOptions, Labeled,
     bridge::StreamBridge,
     phase::BridgePhase,
-    test_support::{addr, handshaking_pair as shared_handshaking_pair, phase_label},
+    test_support::{
+      TEST_RELIABLE_MAX, addr, handshaking_pair as shared_handshaking_pair, phase_label,
+    },
+    transport::StreamTransport,
   },
-  tls::options::tests::{test_client, test_server},
+  tls::{
+    TlsOptions,
+    options::tests::{test_client, test_server},
+  },
 };
 
 /// Build a `Handshaking` client/server bridge pair sharing the accept-any
@@ -1002,5 +1009,595 @@ fn tls_bridge_reliable_skips_encryption_when_is_secure() {
   assert!(
     !bridge.encryption_for_test().is_enabled(),
     "a TLS bridge zeroes the EncryptionOptions regardless of caller intent"
+  );
+}
+
+// ── F1: a bare transport FIN is NOT a clean TLS close ───────────────────────
+
+/// Walk the outer TLS record framing of `ciphertext` and return
+/// `(all_but_last_record, last_record)`. Each TLS record is a 5-byte header
+/// (`[type][version_hi][version_lo][len_hi][len_lo]`) followed by `len`
+/// application bytes; the outer length is cleartext even in TLS 1.3 (only the
+/// content type is hidden by the record protection). The last record a
+/// post-handshake dialer transmits is its `close_notify` alert, so dropping it
+/// simulates an on-path truncation that delivers the complete application
+/// record(s) without the authenticated in-band close.
+fn split_trailing_tls_record(ciphertext: &[u8]) -> (&[u8], &[u8]) {
+  let mut last_start = 0usize;
+  let mut offset = 0usize;
+  while offset + 5 <= ciphertext.len() {
+    let len = u16::from_be_bytes([ciphertext[offset + 3], ciphertext[offset + 4]]) as usize;
+    let end = offset + 5 + len;
+    assert!(
+      end <= ciphertext.len(),
+      "a TLS record header must not declare a length past the buffer"
+    );
+    last_start = offset;
+    offset = end;
+  }
+  assert_eq!(
+    offset,
+    ciphertext.len(),
+    "the captured ciphertext is a whole number of TLS records"
+  );
+  ciphertext.split_at(last_start)
+}
+
+/// F1-1: a promoted TLS server bridge receives one COMPLETE reliable unit and
+/// then a bare transport FIN with NO `close_notify`. The bare FIN is a
+/// truncation, not a clean completion: the bridge must fail
+/// `Failed(ConnectionLost)` and commit NO payload event. Before the fix the
+/// bridge computed `fin_seen = eof || peer_has_closed()` and accepted the bare
+/// FIN as a clean close, committing the buffered `UserData`.
+///
+/// Mutation anchor: reverting the post-promotion gate in `pump_in_established`
+/// lets this exchange reach `RecvClosed` and commit `Event::UserPacket`, so the
+/// "NO payload committed" assertion below fails.
+#[test]
+fn established_tls_complete_unit_then_bare_fin_is_truncation() {
+  let now = Instant::now();
+  let (mut client, mut server) = handshaking_pair(now + Duration::from_secs(10));
+  complete_handshake(&mut client, &mut server, now);
+
+  // Client: a one-way user message. `pump_out` writes the reliable unit AND
+  // (one-way half-close) queues a `close_notify`, so the transmit is
+  // `[app record][close_notify record]`.
+  let mut ep_c: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("cli"), addr(7300)));
+  let payload = Bytes::from_static(b"truncated-tls-unit");
+  let sid = ep_c
+    .start_user_message(addr(7000), payload.clone(), now)
+    .expect("issued while running");
+  let c_stream = ep_c
+    .dial_succeeded(sid, now)
+    .expect("dial_succeeded mints the outbound stream");
+  client.promote(c_stream);
+  client
+    .pump_out(now)
+    .expect("client pumps its request + close_notify");
+
+  // Server: accept + promote, then drain the pre-existing endpoint events so the
+  // post-truncation assertion observes only what the truncated exchange emits.
+  let mut ep_s: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("srv"), addr(7000)));
+  let s_stream = ep_s
+    .accept_stream(addr(7300), now)
+    .expect("node is running");
+  server.promote(s_stream);
+  while ep_s.poll_event().is_some() {}
+
+  // On-path truncation: deliver the application record(s) but DROP the trailing
+  // `close_notify` record.
+  let mut c_out = Vec::new();
+  client.poll_transport_transmit(&mut c_out);
+  let (app, close_notify) = split_trailing_tls_record(&c_out);
+  assert_eq!(
+    close_notify.len(),
+    24,
+    "the withheld trailing record is the 24-byte TLS 1.3 close_notify"
+  );
+  server
+    .handle_transport_data(app, now)
+    .expect("the complete reliable unit decodes");
+
+  // Nothing commits yet — the payload event stays queued pending close proof.
+  server.drain_payload_only(&mut ep_s, now);
+  assert!(
+    ep_s.poll_event().is_none(),
+    "no payload commits before the close anchor"
+  );
+
+  // The bare transport FIN, with no `close_notify` observed.
+  let res = server.handle_transport_data(&[], now);
+  assert!(
+    res.is_err(),
+    "a bare FIN on a TLS exchange with no close_notify is a truncation"
+  );
+  assert!(
+    matches!(
+      server.phase_ref(),
+      BridgePhase::Established(LinkState::Failed(BridgeFailure::ConnectionLost))
+    ),
+    "the truncated TLS exchange fails ConnectionLost, got {:?}",
+    phase_label(server.phase_ref())
+  );
+
+  // The reap routes a `StreamErrored` notice (no public Event); crucially, the
+  // buffered payload is NEVER committed.
+  server.drain_payload_only(&mut ep_s, now);
+  server.drain_then_reap(&mut ep_s, now);
+  let mut committed = None;
+  while let Some(ev) = ep_s.poll_event() {
+    if let Event::UserPacket(p) = ev {
+      let (_, data, _) = p.into_parts();
+      committed = Some(data);
+    }
+  }
+  assert!(
+    committed.is_none(),
+    "a truncated TLS exchange commits NO payload event, got {committed:?}"
+  );
+  assert!(
+    server.is_terminal(),
+    "the bridge is terminal after the truncation reap"
+  );
+}
+
+/// F1-2: the same truncation with the complete unit buffered PRE-promotion. A
+/// bare FIN arriving before the `Stream` is minted must fail EARLY
+/// (`ConnectionLost`) through the settled-empty-slice gate — NOT latch
+/// `pending_eof` and mint a doomed `Stream` that later replays into the
+/// post-promotion clean path.
+///
+/// Mutation anchor: reverting the pre-promotion gate lets the empty-slice arm
+/// latch `pending_eof` and return `Ok`, leaving the bridge live (not
+/// terminal), so the `Failed(ConnectionLost)` assertion fails.
+#[test]
+fn pre_promotion_tls_complete_unit_then_bare_fin_fails_without_minting() {
+  let now = Instant::now();
+  let (mut client, mut server) = handshaking_pair(now + Duration::from_secs(10));
+
+  // Drive the handshake until the CLIENT is done but the SERVER has NOT yet
+  // consumed the client's final flight (still Handshaking, no Stream).
+  for _ in 0..64 {
+    if !client.is_handshaking() {
+      break;
+    }
+    let mut c_out = Vec::new();
+    client.poll_transport_transmit(&mut c_out);
+    if !c_out.is_empty() {
+      server.handle_transport_data(&c_out, now).unwrap();
+    }
+    let mut s_out = Vec::new();
+    server.poll_transport_transmit(&mut s_out);
+    if !s_out.is_empty() {
+      client.handle_transport_data(&s_out, now).unwrap();
+    }
+    if c_out.is_empty() && s_out.is_empty() {
+      break;
+    }
+  }
+  assert!(!client.is_handshaking(), "client completed its handshake");
+  assert!(
+    server.is_handshaking(),
+    "server has not consumed the client's final flight"
+  );
+
+  // Client: a one-way user message; coalesce `[Finished][app unit][close_notify]`.
+  let mut ep_c: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("cli"), addr(7350)));
+  let payload = Bytes::from_static(b"pre-promote-truncation");
+  let sid = ep_c
+    .start_user_message(addr(7000), payload, now)
+    .expect("issued while running");
+  let c_stream = ep_c
+    .dial_succeeded(sid, now)
+    .expect("dial_succeeded mints the outbound stream");
+  client.promote(c_stream);
+  client.pump_out(now).expect("client pumps its request");
+  let mut coalesced = Vec::new();
+  for _ in 0..64 {
+    let before = coalesced.len();
+    client.poll_transport_transmit(&mut coalesced);
+    if coalesced.len() == before {
+      break;
+    }
+  }
+
+  // Truncation: drop the trailing `close_notify` record. Feed the
+  // `[Finished][app unit]` prefix to the still-Handshaking server: the handshake
+  // completes and the unit buffers inside rustls, but `peer_has_closed()` stays
+  // false.
+  let (finished_and_app, close_notify) = split_trailing_tls_record(&coalesced);
+  assert_eq!(
+    close_notify.len(),
+    24,
+    "the withheld trailing record is the 24-byte TLS 1.3 close_notify"
+  );
+  server
+    .handle_transport_data(finished_and_app, now)
+    .expect("the handshake completes and the unit buffers");
+  assert!(
+    !server.is_handshaking(),
+    "the server handshake settled inside the feed"
+  );
+
+  // The bare FIN arrives pre-promotion (no Stream yet): the settled-empty-slice
+  // gate fails it early instead of latching `pending_eof`.
+  let res = server.handle_transport_data(&[], now);
+  assert!(
+    res.is_err(),
+    "a pre-promotion bare FIN on TLS is a truncation"
+  );
+  assert!(
+    matches!(
+      server.phase_ref(),
+      BridgePhase::Established(LinkState::Failed(BridgeFailure::ConnectionLost))
+    ),
+    "the pre-promotion truncation fails ConnectionLost, got {:?}",
+    phase_label(server.phase_ref())
+  );
+  assert!(
+    server.stream_is_none(),
+    "NO Stream is minted for a truncated pre-promotion exchange"
+  );
+  assert!(server.is_terminal(), "the bridge is terminal");
+}
+
+/// F1-3 (positive control): a complete reliable unit followed by an authentic
+/// `close_notify` (and a later TCP EOF) stays CLEAN — the payload commits and
+/// the bridge is NOT failed. Proves the truncation gate only fires on a bare
+/// FIN, never on an authenticated in-band close.
+#[test]
+fn established_tls_complete_unit_with_close_notify_stays_clean() {
+  let now = Instant::now();
+  let (mut client, mut server) = handshaking_pair(now + Duration::from_secs(10));
+  complete_handshake(&mut client, &mut server, now);
+
+  let mut ep_c: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("cli"), addr(7400)));
+  let payload = Bytes::from_static(b"clean-tls-unit");
+  let sid = ep_c
+    .start_user_message(addr(7000), payload.clone(), now)
+    .expect("issued while running");
+  let c_stream = ep_c
+    .dial_succeeded(sid, now)
+    .expect("dial_succeeded mints the outbound stream");
+  client.promote(c_stream);
+  client
+    .pump_out(now)
+    .expect("client pumps its request + close_notify");
+
+  let mut ep_s: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("srv"), addr(7000)));
+  let s_stream = ep_s
+    .accept_stream(addr(7400), now)
+    .expect("node is running");
+  server.promote(s_stream);
+  while ep_s.poll_event().is_some() {}
+
+  // Deliver the WHOLE transmit — application record(s) AND the `close_notify`.
+  let mut c_out = Vec::new();
+  client.poll_transport_transmit(&mut c_out);
+  server
+    .handle_transport_data(&c_out, now)
+    .expect("the unit + close_notify are accepted");
+  // The authenticated close drove `RecvClosed`; the payload commits.
+  server.drain_payload_only(&mut ep_s, now);
+  // A later bare TCP EOF is benign here (close_notify already latched).
+  server
+    .handle_transport_data(&[], now)
+    .expect("a redundant EOF after close_notify is benign");
+  assert!(
+    !matches!(
+      server.phase_ref(),
+      BridgePhase::Established(LinkState::Failed(_))
+    ),
+    "an authenticated close_notify keeps the exchange clean, got {:?}",
+    phase_label(server.phase_ref())
+  );
+
+  server.drain_then_reap(&mut ep_s, now);
+  let mut committed = None;
+  while let Some(ev) = ep_s.poll_event() {
+    if let Event::UserPacket(p) = ev {
+      let (_, data, _) = p.into_parts();
+      committed = Some(data);
+    }
+  }
+  assert_eq!(
+    committed.as_deref(),
+    Some(payload.as_ref()),
+    "the cleanly-closed TLS exchange commits its payload"
+  );
+}
+
+// ── F2: an in-band close before the composed handshake settles is terminal ──
+
+/// Build a `Labeled<TlsRecords>` acceptor bridge that requires `cluster` as its
+/// inbound label. Compression + encryption start disabled; the bridge zeroes
+/// the reliable-plane encryption anyway because `TlsRecords::is_secure()`.
+fn labeled_acceptor_bridge(
+  cluster: &str,
+  deadline: Instant,
+) -> StreamBridge<SmolStr, SocketAddr, Labeled<TlsRecords>> {
+  let opts = LabelOptions::new_in(
+    Some(cluster.as_bytes().to_vec()),
+    TlsOptions::new(test_server(), test_client()),
+  );
+  let records =
+    Labeled::<TlsRecords>::acceptor(&opts).expect("acceptor construction is infallible");
+  StreamBridge::new(
+    records,
+    deadline,
+    crate::CompressionOptions::new(),
+    crate::EncryptionOptions::new(),
+    TEST_RELIABLE_MAX,
+  )
+}
+
+/// Complete the raw TLS handshake between a bare `TlsRecords` dialer (which
+/// emits NO cluster label) and a `Labeled<TlsRecords>` acceptor bridge. After
+/// this the dialer's TLS is established, but the acceptor's label gate is still
+/// validating, so the acceptor bridge remains `Handshaking`.
+fn handshake_raw_dialer_into_labeled_acceptor(
+  dialer: &mut TlsRecords,
+  acceptor: &mut StreamBridge<SmolStr, SocketAddr, Labeled<TlsRecords>>,
+  now: Instant,
+) {
+  for _ in 0..64 {
+    let mut d_out = Vec::new();
+    dialer.poll_transport_transmit(&mut d_out);
+    if !d_out.is_empty() {
+      acceptor
+        .handle_transport_data(&d_out, now)
+        .expect("handshake ciphertext is accepted");
+    }
+    let mut a_out = Vec::new();
+    acceptor.poll_transport_transmit(&mut a_out);
+    if !a_out.is_empty() {
+      // Ignoring Intake: the raw dialer only needs to advance its own
+      // handshake. (The inherent `TlsRecords::handle_transport_data` takes no
+      // `now`.)
+      let _ = dialer.handle_transport_data(&a_out);
+    }
+    if d_out.is_empty() && a_out.is_empty() {
+      break;
+    }
+  }
+}
+
+/// F2-1: a `Labeled<TlsRecords>` acceptor completes TLS, then the peer sends an
+/// authenticated `close_notify` before ever sending its cluster label (TCP held
+/// open). rustls will read no further, so the composed handshake can never
+/// settle. The bridge must fail immediately (`ConnectionLost`) with NO `Stream`
+/// minted and NO outbound label / ciphertext emitted — not linger as a zombie
+/// until the accept deadline.
+///
+/// Mutation anchor: reverting the `intake_handshaking` gate lets the empty-slice
+/// intake return `Ok` while the acceptor stays `Handshaking`, so it survives to
+/// its deadline and the `Failed(ConnectionLost)` / `is_terminal` assertions fail.
+#[test]
+fn labeled_tls_close_notify_before_label_is_terminal() {
+  let now = Instant::now();
+  let mut acceptor = labeled_acceptor_bridge("cluster-x", now + Duration::from_secs(10));
+  let mut dialer = TlsRecords::client(
+    Arc::new(test_client()),
+    ServerName::try_from("localhost").unwrap(),
+  )
+  .unwrap();
+
+  handshake_raw_dialer_into_labeled_acceptor(&mut dialer, &mut acceptor, now);
+  assert!(!dialer.is_handshaking(), "the dialer's TLS is established");
+  assert!(
+    acceptor.is_handshaking(),
+    "the acceptor still awaits the peer's cluster label"
+  );
+
+  // The peer authenticated-closes before sending any label.
+  dialer.send_close_notify();
+  let mut cn = Vec::new();
+  dialer.poll_transport_transmit(&mut cn);
+  assert!(!cn.is_empty(), "the dialer produced a close_notify record");
+
+  let res = acceptor.handle_transport_data(&cn, now);
+  assert!(
+    res.is_err(),
+    "a close_notify before the label settles is terminal"
+  );
+  assert!(
+    matches!(
+      acceptor.phase_ref(),
+      BridgePhase::Established(LinkState::Failed(BridgeFailure::ConnectionLost))
+    ),
+    "the acceptor fails ConnectionLost, got {:?}",
+    phase_label(acceptor.phase_ref())
+  );
+  assert!(
+    acceptor.stream_is_none(),
+    "NO Stream is minted for a pre-label close"
+  );
+  assert!(acceptor.is_terminal(), "the bridge is terminal");
+
+  // No local label / ciphertext leaks on the failure path.
+  let mut leaked = Vec::new();
+  let n = acceptor.poll_transport_transmit(&mut leaked);
+  assert_eq!(n, 0, "a failed pre-label acceptor emits no outbound bytes");
+  assert!(leaked.is_empty(), "no local label or ciphertext leaked");
+}
+
+/// F2-2: the same close-before-label, but after the peer has sent a PARTIAL
+/// (fragmented) label. The label gate is mid-buffer when the `close_notify`
+/// lands; the bridge must still fail immediately rather than wait for the rest
+/// of a label that can never arrive.
+#[test]
+fn labeled_tls_close_notify_after_partial_label_is_terminal() {
+  let now = Instant::now();
+  let mut acceptor = labeled_acceptor_bridge("cluster-x", now + Duration::from_secs(10));
+  let mut dialer = TlsRecords::client(
+    Arc::new(test_client()),
+    ServerName::try_from("localhost").unwrap(),
+  )
+  .unwrap();
+
+  handshake_raw_dialer_into_labeled_acceptor(&mut dialer, &mut acceptor, now);
+  assert!(acceptor.is_handshaking(), "the acceptor awaits its label");
+
+  // A partial label frame: the `[LABELED_TAG=12][len=9]` header plus only two of
+  // the nine promised label bytes. The gate buffers it and stays validating.
+  dialer.write_plaintext(&[12u8, 9, b'c', b'l']);
+  let mut partial = Vec::new();
+  dialer.poll_transport_transmit(&mut partial);
+  acceptor
+    .handle_transport_data(&partial, now)
+    .expect("a partial label is buffered, not yet terminal");
+  assert!(
+    acceptor.is_handshaking(),
+    "a partial label leaves the acceptor validating"
+  );
+
+  // The peer authenticated-closes mid-label.
+  dialer.send_close_notify();
+  let mut cn = Vec::new();
+  dialer.poll_transport_transmit(&mut cn);
+  let res = acceptor.handle_transport_data(&cn, now);
+  assert!(res.is_err(), "a close_notify mid-label is terminal");
+  assert!(
+    matches!(
+      acceptor.phase_ref(),
+      BridgePhase::Established(LinkState::Failed(BridgeFailure::ConnectionLost))
+    ),
+    "the acceptor fails ConnectionLost, got {:?}",
+    phase_label(acceptor.phase_ref())
+  );
+  assert!(acceptor.stream_is_none(), "NO Stream is minted");
+  assert!(acceptor.is_terminal(), "the bridge is terminal");
+}
+
+/// F2-3 (positive control): a matching label, a reliable unit, and a
+/// `close_notify` all coalesced into ONE feed to a still-`Handshaking`
+/// `Labeled<TlsRecords>` acceptor. The label settles the composed handshake in
+/// the SAME feed, so the F2 gate (which only fires while still handshaking) does
+/// NOT trip: the acceptor promotes, drains the unit, and closes cleanly.
+#[test]
+fn labeled_tls_coalesced_label_unit_close_notify_promotes_clean() {
+  let now = Instant::now();
+  let deadline = now + Duration::from_secs(10);
+  let (mut client, mut server) = shared_handshaking_pair(
+    deadline,
+    || {
+      let opts = LabelOptions::new_in(
+        Some(b"cluster-x".to_vec()),
+        TlsOptions::new(test_server(), test_client()),
+      );
+      let ctx = <Labeled<TlsRecords> as StreamTransport>::dial_context(&addr(0), Some("localhost"))
+        .expect("dial context");
+      Labeled::<TlsRecords>::dialer(&opts, ctx).expect("dialer construction")
+    },
+    || {
+      let opts = LabelOptions::new_in(
+        Some(b"cluster-x".to_vec()),
+        TlsOptions::new(test_server(), test_client()),
+      );
+      Labeled::<TlsRecords>::acceptor(&opts).expect("acceptor construction")
+    },
+  );
+
+  // Drive the handshake until the CLIENT is done but the SERVER has not yet
+  // consumed the final flight (still Handshaking, awaiting the label too).
+  for _ in 0..64 {
+    if !client.is_handshaking() {
+      break;
+    }
+    let mut c_out = Vec::new();
+    client.poll_transport_transmit(&mut c_out);
+    if !c_out.is_empty() {
+      server.handle_transport_data(&c_out, now).unwrap();
+    }
+    let mut s_out = Vec::new();
+    server.poll_transport_transmit(&mut s_out);
+    if !s_out.is_empty() {
+      client.handle_transport_data(&s_out, now).unwrap();
+    }
+    if c_out.is_empty() && s_out.is_empty() {
+      break;
+    }
+  }
+  assert!(!client.is_handshaking(), "client completed its handshake");
+  assert!(
+    server.is_handshaking(),
+    "server still awaits label + final flight"
+  );
+
+  // Client: a one-way user message; drain everything the client has to send —
+  // the coalesced `[Finished][label][unit][close_notify]`.
+  let mut ep_c: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("cli"), addr(7500)));
+  let payload = Bytes::from_static(b"labeled-coalesced-unit");
+  let sid = ep_c
+    .start_user_message(addr(7000), payload.clone(), now)
+    .expect("issued while running");
+  let c_stream = ep_c
+    .dial_succeeded(sid, now)
+    .expect("dial_succeeded mints the outbound stream");
+  client.promote(c_stream);
+  client.pump_out(now).expect("client pumps its request");
+  let mut coalesced = Vec::new();
+  for _ in 0..64 {
+    let before = coalesced.len();
+    client.poll_transport_transmit(&mut coalesced);
+    if coalesced.len() == before {
+      break;
+    }
+  }
+
+  // Deliver the WHOLE coalesced buffer in one feed. The label validates and the
+  // handshake settles in the SAME call — so `is_handshaking()` is already false
+  // when `peer_has_closed()` becomes true, and the F2 gate does not fire.
+  server
+    .handle_transport_data(&coalesced, now)
+    .expect("the coalesced label + unit + close_notify is accepted");
+  assert!(
+    !server.is_handshaking(),
+    "the label validated and the handshake settled in the coalesced feed"
+  );
+  assert!(
+    !server.is_terminal(),
+    "the F2 gate did not fire — the handshake settled before the close was seen"
+  );
+
+  // Promote + replay: the buffered unit drains and the close anchor fires clean.
+  let mut ep_s: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("srv"), addr(7000)));
+  let s_stream = ep_s
+    .accept_stream(addr(7500), now)
+    .expect("node is running");
+  server.promote(s_stream);
+  while ep_s.poll_event().is_some() {}
+  server
+    .replay_pending(now)
+    .expect("post-promote replay drains the unit and honors the close anchor");
+  server.drain_payload_only(&mut ep_s, now);
+  assert!(
+    !matches!(
+      server.phase_ref(),
+      BridgePhase::Established(LinkState::Failed(_))
+    ),
+    "the coalesced clean exchange is not failed, got {:?}",
+    phase_label(server.phase_ref())
+  );
+
+  server.drain_then_reap(&mut ep_s, now);
+  let mut committed = None;
+  while let Some(ev) = ep_s.poll_event() {
+    if let Event::UserPacket(p) = ev {
+      let (_, data, _) = p.into_parts();
+      committed = Some(data);
+    }
+  }
+  assert_eq!(
+    committed.as_deref(),
+    Some(payload.as_ref()),
+    "the coalesced labeled exchange commits its payload cleanly"
   );
 }

--- a/memberlist-proto/src/tls/bridge.rs
+++ b/memberlist-proto/src/tls/bridge.rs
@@ -1312,6 +1312,157 @@ fn established_tls_complete_unit_with_close_notify_stays_clean() {
   );
 }
 
+/// F1 (retained-tail ordering, positive control): a coalesced
+/// `[handshake final][reliable unit > 16 KiB][close_notify]` delivered to a
+/// still-`Handshaking` server trips the record layer's received-plaintext
+/// backpressure, so the authenticated `close_notify` stays BEHIND the large
+/// unit in the retained ciphertext tail and `peer_has_closed()` is still false
+/// when a pre-promotion bare EOF arrives. The pre-promotion truncation gate
+/// must NOT eager-fail here (the close IS present, just unprocessed): it latches
+/// `pending_eof` and defers to the post-promotion gate, which — after
+/// `replay_pending` drains the tail and processes the `close_notify` — sees the
+/// authenticated close and keeps the exchange CLEAN.
+///
+/// Mutation anchor: dropping the `pending_inbound.is_empty()` guard on the
+/// pre-promotion gate makes this exchange eager-fail `ConnectionLost` before the
+/// retained close_notify is ever processed, so the "committed / not failed"
+/// assertions below fail.
+#[test]
+fn pre_promotion_large_unit_with_retained_close_notify_stays_clean() {
+  let now = Instant::now();
+  let (mut client, mut server) = handshaking_pair(now + Duration::from_secs(10));
+
+  // Drive the handshake until the CLIENT is done but the SERVER has NOT yet
+  // consumed the client's final flight (still Handshaking, no Stream).
+  for _ in 0..64 {
+    if !client.is_handshaking() {
+      break;
+    }
+    let mut c_out = Vec::new();
+    client.poll_transport_transmit(&mut c_out);
+    if !c_out.is_empty() {
+      server.handle_transport_data(&c_out, now).unwrap();
+    }
+    let mut s_out = Vec::new();
+    server.poll_transport_transmit(&mut s_out);
+    if !s_out.is_empty() {
+      client.handle_transport_data(&s_out, now).unwrap();
+    }
+    if c_out.is_empty() && s_out.is_empty() {
+      break;
+    }
+  }
+  assert!(!client.is_handshaking(), "client completed its handshake");
+  assert!(
+    server.is_handshaking(),
+    "server has not consumed the client's final flight"
+  );
+
+  // Client: a one-way LARGE (> 16 KiB) user message. `pump_out` writes the
+  // reliable unit AND (one-way half-close) queues a `close_notify`, so the
+  // coalesced transmit is `[Finished][> 16 KiB unit][close_notify]`.
+  let mut ep_c: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("cli"), addr(7450)));
+  let payload = Bytes::from((0..48 * 1024).map(|i| (i % 251) as u8).collect::<Vec<u8>>());
+  let sid = ep_c
+    .start_user_message(addr(7000), payload.clone(), now)
+    .expect("issued while running");
+  let c_stream = ep_c
+    .dial_succeeded(sid, now)
+    .expect("dial_succeeded mints the outbound stream");
+  client.promote(c_stream);
+  client
+    .pump_out(now)
+    .expect("client pumps its request + close_notify");
+  let mut coalesced = Vec::new();
+  for _ in 0..64 {
+    let before = coalesced.len();
+    client.poll_transport_transmit(&mut coalesced);
+    if coalesced.len() == before {
+      break;
+    }
+  }
+  assert!(
+    coalesced.len() > 16 * 1024,
+    "the coalesced [Finished][large unit][close_notify] exceeds the received-plaintext limit, got {}",
+    coalesced.len()
+  );
+
+  // Deliver the WHOLE coalesced buffer to the still-Handshaking server. The
+  // handshake settles; the > 16 KiB unit trips backpressure, so the record layer
+  // retains the tail (rest of the unit + the close_notify) in `pending_inbound`
+  // and `peer_has_closed()` is still false.
+  server
+    .handle_transport_data(&coalesced, now)
+    .expect("the coalesced final flight + large unit + close_notify is accepted");
+  assert!(
+    !server.is_handshaking(),
+    "the server handshake settled inside the coalesced feed"
+  );
+  assert!(
+    !server.pending_inbound_is_empty(),
+    "the > 16 KiB unit tripped backpressure — the close_notify is retained behind it"
+  );
+
+  // A bare EOF arrives pre-promotion. Because retained ciphertext (carrying the
+  // close_notify) is still to be processed, the truncation gate must DEFER —
+  // latch `pending_eof`, not eager-fail.
+  server
+    .handle_transport_data(&[], now)
+    .expect("a pre-promotion EOF with retained ciphertext defers, it does not fail");
+  assert!(
+    !server.is_terminal(),
+    "the bridge is NOT failed — the retained close_notify is a clean close, got {:?}",
+    phase_label(server.phase_ref())
+  );
+  assert!(
+    server.pending_eof(),
+    "the pre-promotion EOF was latched, not failed"
+  );
+
+  // Promote + replay: the retained tail (unit + close_notify) drains, the
+  // authenticated close is processed (peer_has_closed becomes true), and the
+  // latched EOF is applied AFTER — so the post-promotion gate stays clean.
+  let mut ep_s: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("srv"), addr(7000)));
+  let s_stream = ep_s
+    .accept_stream(addr(7450), now)
+    .expect("node is running");
+  server.promote(s_stream);
+  while ep_s.poll_event().is_some() {}
+  server
+    .replay_pending(now)
+    .expect("post-promote replay drains the large unit + close_notify cleanly");
+  assert!(
+    !matches!(
+      server.phase_ref(),
+      BridgePhase::Established(LinkState::Failed(_))
+    ),
+    "a large unit with a retained close_notify closes clean, got {:?}",
+    phase_label(server.phase_ref())
+  );
+
+  server.drain_payload_only(&mut ep_s, now);
+  server.drain_then_reap(&mut ep_s, now);
+  let mut committed = Vec::new();
+  while let Some(ev) = ep_s.poll_event() {
+    if let Event::UserPacket(p) = ev {
+      let (_, data, _) = p.into_parts();
+      committed.push(data);
+    }
+  }
+  assert_eq!(
+    committed.len(),
+    1,
+    "the large payload commits exactly once (not zero, not duplicated)"
+  );
+  assert_eq!(
+    committed[0].as_ref(),
+    payload.as_ref(),
+    "the reassembled large payload is intact"
+  );
+}
+
 // ── F2: an in-band close before the composed handshake settles is terminal ──
 
 /// Build a `Labeled<TlsRecords>` acceptor bridge that requires `cluster` as its

--- a/memberlist-proto/src/tls/bridge.rs
+++ b/memberlist-proto/src/tls/bridge.rs
@@ -1043,6 +1043,31 @@ fn split_trailing_tls_record(ciphertext: &[u8]) -> (&[u8], &[u8]) {
   ciphertext.split_at(last_start)
 }
 
+/// Split `ciphertext` into its individual TLS records (each a 5-byte header plus
+/// its declared application bytes), returned in wire order. Lets a test deliver
+/// a handshake flight one record at a time and stop after the FIRST application
+/// record — surfacing only the leading chunk of a multi-record reliable unit.
+fn split_tls_records(ciphertext: &[u8]) -> Vec<&[u8]> {
+  let mut records = Vec::new();
+  let mut offset = 0usize;
+  while offset + 5 <= ciphertext.len() {
+    let len = u16::from_be_bytes([ciphertext[offset + 3], ciphertext[offset + 4]]) as usize;
+    let end = offset + 5 + len;
+    assert!(
+      end <= ciphertext.len(),
+      "a TLS record header must not declare a length past the buffer"
+    );
+    records.push(&ciphertext[offset..end]);
+    offset = end;
+  }
+  assert_eq!(
+    offset,
+    ciphertext.len(),
+    "the captured ciphertext is a whole number of TLS records"
+  );
+  records
+}
+
 /// F1-1: a promoted TLS server bridge receives one COMPLETE reliable unit and
 /// then a bare transport FIN with NO `close_notify`. The bare FIN is a
 /// truncation, not a clean completion: the bridge must fail
@@ -1144,16 +1169,16 @@ fn established_tls_complete_unit_then_bare_fin_is_truncation() {
 }
 
 /// F1-2: the same truncation with the complete unit buffered PRE-promotion. A
-/// bare FIN arriving before the `Stream` is minted must fail EARLY
-/// (`ConnectionLost`) through the settled-empty-slice gate — NOT latch
-/// `pending_eof` and mint a doomed `Stream` that later replays into the
-/// post-promotion clean path.
-///
-/// Mutation anchor: reverting the pre-promotion gate lets the empty-slice arm
-/// latch `pending_eof` and return `Ok`, leaving the bridge live (not
-/// terminal), so the `Failed(ConnectionLost)` assertion fails.
+/// bare FIN arriving before the `Stream` is minted latches `pending_eof` and
+/// defers classification to the post-promotion gate. After promote + replay the
+/// complete unit surfaces, the bare FIN at the complete-unit boundary is a
+/// truncation with no authenticated in-band close, so the exchange fails
+/// `ConnectionLost` and commits NO payload. The `Stream` is minted then
+/// immediately retired — the terminal outcome and the security property (a
+/// truncated TLS exchange never commits clean) are what matter, not whether a
+/// `Stream` is transiently minted.
 #[test]
-fn pre_promotion_tls_complete_unit_then_bare_fin_fails_without_minting() {
+fn pre_promotion_tls_complete_unit_then_bare_fin_is_connection_lost() {
   let now = Instant::now();
   let (mut client, mut server) = handshaking_pair(now + Duration::from_secs(10));
 
@@ -1223,11 +1248,34 @@ fn pre_promotion_tls_complete_unit_then_bare_fin_fails_without_minting() {
   );
 
   // The bare FIN arrives pre-promotion (no Stream yet): the settled-empty-slice
-  // gate fails it early instead of latching `pending_eof`.
-  let res = server.handle_transport_data(&[], now);
+  // gate latches `pending_eof` and defers, it does not eager-fail.
+  server
+    .handle_transport_data(&[], now)
+    .expect("a pre-promotion bare FIN latches, it does not fail");
+  assert!(
+    !server.is_terminal(),
+    "the pre-promotion EOF was latched, not classified early, got {:?}",
+    phase_label(server.phase_ref())
+  );
+  assert!(
+    server.pending_eof(),
+    "the pre-promotion EOF was latched for post-promotion replay"
+  );
+
+  // Promote + replay: the complete unit surfaces, then the latched bare FIN at
+  // the complete-unit boundary (no close_notify processed) is classified by the
+  // post-promotion gate as a truncation → ConnectionLost.
+  let mut ep_s: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("srv"), addr(7000)));
+  let s_stream = ep_s
+    .accept_stream(addr(7350), now)
+    .expect("node is running");
+  server.promote(s_stream);
+  while ep_s.poll_event().is_some() {}
+  let res = server.replay_pending(now);
   assert!(
     res.is_err(),
-    "a pre-promotion bare FIN on TLS is a truncation"
+    "the replayed complete unit + bare FIN is a truncation"
   );
   assert!(
     matches!(
@@ -1237,9 +1285,179 @@ fn pre_promotion_tls_complete_unit_then_bare_fin_fails_without_minting() {
     "the pre-promotion truncation fails ConnectionLost, got {:?}",
     phase_label(server.phase_ref())
   );
+
+  // The buffered payload is NEVER committed and the bridge ends terminal.
+  server.drain_payload_only(&mut ep_s, now);
+  server.drain_then_reap(&mut ep_s, now);
+  let mut committed = None;
+  while let Some(ev) = ep_s.poll_event() {
+    if let Event::UserPacket(p) = ev {
+      let (_, data, _) = p.into_parts();
+      committed = Some(data);
+    }
+  }
   assert!(
-    server.stream_is_none(),
-    "NO Stream is minted for a truncated pre-promotion exchange"
+    committed.is_none(),
+    "a truncated TLS exchange commits NO payload event, got {committed:?}"
+  );
+  assert!(server.is_terminal(), "the bridge is terminal");
+}
+
+/// F1-2b: a PARTIAL reliable unit buffered PRE-promotion, then a bare FIN, is a
+/// mid-unit truncation and must fail `Decode` (NOT `ConnectionLost`). The peer
+/// coalesces `[Finished][first application record of a > 16 KiB reliable unit]`
+/// — one complete TLS record carrying only the leading ~16 KiB of a unit whose
+/// varint length declares far more — then bare-FINs with no `close_notify`.
+/// rustls consumes all of that ciphertext (no retained tail: `pending_inbound`
+/// is empty) while holding the leading chunk as decrypted plaintext, so the
+/// buffered reliable unit is genuinely partial. The pre-promotion EOF latches
+/// and defers; after promote + replay the partial unit surfaces into
+/// `recv_accum` and the FSM classifies the mid-unit close as a decode failure.
+///
+/// Mutation anchor: restoring the deleted pre-promotion eager-fail (which gated
+/// on `pending_inbound.is_empty()`) would classify this exact input
+/// `ConnectionLost` before promotion — the wrong class for a partial unit,
+/// because `pending_inbound` tests retained ciphertext only and cannot see the
+/// decrypted partial unit rustls holds as plaintext.
+#[test]
+fn pre_promotion_tls_partial_unit_then_bare_fin_is_decode() {
+  let now = Instant::now();
+  let (mut client, mut server) = handshaking_pair(now + Duration::from_secs(10));
+
+  // Drive the handshake until the CLIENT is done but the SERVER has NOT yet
+  // consumed the client's final flight (still Handshaking, no Stream).
+  for _ in 0..64 {
+    if !client.is_handshaking() {
+      break;
+    }
+    let mut c_out = Vec::new();
+    client.poll_transport_transmit(&mut c_out);
+    if !c_out.is_empty() {
+      server.handle_transport_data(&c_out, now).unwrap();
+    }
+    let mut s_out = Vec::new();
+    server.poll_transport_transmit(&mut s_out);
+    if !s_out.is_empty() {
+      client.handle_transport_data(&s_out, now).unwrap();
+    }
+    if c_out.is_empty() && s_out.is_empty() {
+      break;
+    }
+  }
+  assert!(!client.is_handshaking(), "client completed its handshake");
+  assert!(
+    server.is_handshaking(),
+    "server has not consumed the client's final flight"
+  );
+
+  // Client: a one-way LARGE (> 16 KiB) user message; coalesce
+  // `[Finished][> 16 KiB unit as multiple app records][close_notify]`.
+  let mut ep_c: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("cli"), addr(7375)));
+  let payload = Bytes::from((0..48 * 1024).map(|i| (i % 251) as u8).collect::<Vec<u8>>());
+  let sid = ep_c
+    .start_user_message(addr(7000), payload, now)
+    .expect("issued while running");
+  let c_stream = ep_c
+    .dial_succeeded(sid, now)
+    .expect("dial_succeeded mints the outbound stream");
+  client.promote(c_stream);
+  client
+    .pump_out(now)
+    .expect("client pumps its request + close_notify");
+  let mut coalesced = Vec::new();
+  for _ in 0..64 {
+    let before = coalesced.len();
+    client.poll_transport_transmit(&mut coalesced);
+    if coalesced.len() == before {
+      break;
+    }
+  }
+  assert!(
+    coalesced.len() > 16 * 1024,
+    "the coalesced [Finished][large unit][close_notify] spans multiple records, got {}",
+    coalesced.len()
+  );
+
+  // Deliver records one at a time until the handshake settles (the Finished
+  // flight is a pure handshake record — it surfaces no application plaintext),
+  // then deliver exactly ONE more record: the first application record, carrying
+  // only the leading ~16 KiB of the 48 KiB unit. Everything after it (the rest
+  // of the unit and the close_notify) is dropped — an on-path truncation.
+  let records = split_tls_records(&coalesced);
+  let mut idx = 0;
+  while idx < records.len() && server.is_handshaking() {
+    server.handle_transport_data(records[idx], now).unwrap();
+    idx += 1;
+  }
+  assert!(
+    !server.is_handshaking(),
+    "the server handshake settled inside the record-by-record feed"
+  );
+  assert!(
+    idx < records.len(),
+    "an application record follows the settling handshake flight"
+  );
+  server
+    .handle_transport_data(records[idx], now)
+    .expect("the first application record decodes into buffered plaintext");
+  assert!(
+    server.pending_inbound_is_empty(),
+    "the single ~16 KiB application record is fully consumed — no retained ciphertext"
+  );
+
+  // The bare FIN arrives pre-promotion: latch `pending_eof` and defer, do not
+  // eager-fail. (The deleted eager-fail, gating on the empty `pending_inbound`,
+  // would misclassify this buffered PARTIAL unit as `ConnectionLost` here.)
+  server
+    .handle_transport_data(&[], now)
+    .expect("a pre-promotion bare FIN latches, it does not fail");
+  assert!(
+    !server.is_terminal(),
+    "the pre-promotion EOF was latched, not classified early, got {:?}",
+    phase_label(server.phase_ref())
+  );
+  assert!(
+    server.pending_eof(),
+    "the pre-promotion EOF was latched for post-promotion replay"
+  );
+
+  // Promote + replay: the partial unit surfaces into `recv_accum`, and the bare
+  // FIN mid-unit is classified `Decode` — a truncated transmission.
+  let mut ep_s: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(EndpointOptions::new(SmolStr::new("srv"), addr(7000)));
+  let s_stream = ep_s
+    .accept_stream(addr(7375), now)
+    .expect("node is running");
+  server.promote(s_stream);
+  while ep_s.poll_event().is_some() {}
+  let res = server.replay_pending(now);
+  assert!(
+    res.is_err(),
+    "a partial reliable unit resident at FIN is a decode failure"
+  );
+  assert!(
+    matches!(
+      server.phase_ref(),
+      BridgePhase::Established(LinkState::Failed(BridgeFailure::Decode))
+    ),
+    "a mid-unit truncation fails Decode, not ConnectionLost, got {:?}",
+    phase_label(server.phase_ref())
+  );
+
+  // No payload commits, and the bridge ends terminal.
+  server.drain_payload_only(&mut ep_s, now);
+  server.drain_then_reap(&mut ep_s, now);
+  let mut committed = None;
+  while let Some(ev) = ep_s.poll_event() {
+    if let Event::UserPacket(p) = ev {
+      let (_, data, _) = p.into_parts();
+      committed = Some(data);
+    }
+  }
+  assert!(
+    committed.is_none(),
+    "a truncated partial unit commits NO payload event, got {committed:?}"
   );
   assert!(server.is_terminal(), "the bridge is terminal");
 }

--- a/memberlist-proto/src/tls/mod.rs
+++ b/memberlist-proto/src/tls/mod.rs
@@ -127,6 +127,12 @@ impl StreamTransport for TlsRecords {
   fn is_secure() -> bool {
     true
   }
+
+  fn requires_authenticated_close() -> bool {
+    // TLS's clean receive-close is its authenticated `close_notify` alert; a
+    // bare transport FIN — even at a complete-unit boundary — is a truncation.
+    true
+  }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #168 — the shared TCP/TLS stream bridge conflated an unauthenticated transport FIN with an authenticated TLS `close_notify`.