### PR TITLE
fix(proto): cancel the armed reliable-ping fallback when its probe succeeds (#178)

### DIFF
--- a/memberlist-proto/src/endpoint/mod.rs
+++ b/memberlist-proto/src/endpoint/mod.rs
@@ -2119,6 +2119,22 @@ where
     let Some(probe) = self.probes.remove(&seq) else {
       return;
     };
+    // Symmetric with `probe_terminate_failure`: a probe rescued by a late Ack must
+    // also cancel its concurrently-armed reliable-ping fallback. The peer is proven
+    // alive, so the fallback has no remaining purpose; leaving its pending intent
+    // parked would let a rescued probe's fallback linger to its deadline and, across
+    // probe rounds under sustained UDP degradation, accumulate. If the fallback dial
+    // is already live the intent is gone and this is a no-op; a late reliable-ping
+    // event then lands on an absent probe and returns harmlessly.
+    if let ProbePhase::AwaitingIndirect(AwaitingIndirect {
+      reliable_stream_id: Some(rid),
+      ..
+    }) = &probe.phase
+    {
+      // Copy the id out before the `&mut self` call to release the `&probe.phase` borrow.
+      let rid = *rid;
+      self.remove_intent(&rid);
+    }
     // Drop the original direct-ping AckRegistry entry registered at
     // `start_probe`. The direct/indirect-relayed paths reach here via
     // `handle_ack`, which already removed it; the reliable-fallback
@@ -2647,6 +2663,11 @@ where
   /// initiated, `false` if no eligible target exists (cluster has only the
   /// local node, all peers are dead/leaving, etc.). The periodic scheduler
   /// calls this every `probe_interval` (scaled by Awareness).
+  ///
+  /// Detection single-flight — at most one live Detection probe per peer, which is
+  /// what bounds a peer's concurrently-armed reliable-ping fallbacks to one — is
+  /// enforced by that periodic scheduler's target selection, NOT by this method. A
+  /// direct caller that starts a probe out of band bypasses that guard.
   pub fn start_probe(&mut self, now: Instant) -> bool {
     // A leaving/left node starts no failure-detection probe (no direct Ping I/O).
     if !self.is_running() {

--- a/memberlist-proto/src/endpoint/tests.rs
+++ b/memberlist-proto/src/endpoint/tests.rs
@@ -2045,6 +2045,93 @@ fn detection_late_direct_ack_in_awaiting_indirect_emits_ping_completed() {
   assert_eq!(completed.payload_ref().as_ref(), b"pong");
 }
 
+/// A Detection probe that escalated (direct timeout → `AwaitingIndirect`) arms a
+/// concurrent reliable-ping fallback: an inserted pending stream intent plus its
+/// mirrored deadline-index key. If a LATE direct Ack then rescues the probe, that
+/// armed fallback must be cancelled — the peer is proven alive, so the fallback has
+/// no purpose, and a parked intent left behind would linger to its deadline and,
+/// across probe rounds under sustained UDP degradation, accumulate.
+///
+/// Mutation anchor: without `complete_probe_success`'s cancellation the intent (and
+/// its deadline key) survive the rescued probe, so both post-Ack `is_none` /
+/// `!contains` assertions fail.
+#[test]
+fn detection_late_direct_ack_cancels_armed_reliable_ping_fallback() {
+  let pt = Duration::from_millis(50);
+  // 4-node cluster so the direct-timeout escalation has real indirect peers to fan
+  // out to and the probe genuinely enters `AwaitingIndirect`. Reliable ping is
+  // enabled by default, so the escalation also arms the concurrent fallback.
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg().with_probe_timeout(pt));
+  process_alive_auto(&mut e, alive("bob", 7001, 1), false, Instant::now());
+  process_alive_auto(&mut e, alive("carol", 7002, 1), false, Instant::now());
+  process_alive_auto(&mut e, alive("dave", 7003, 1), false, Instant::now());
+  while e.poll_event().is_some() {}
+  while e.poll_transmit().is_some() {}
+
+  let t0 = Instant::now();
+  e.start_probe(t0);
+  let (seq, target_addr) = match e.poll_transmit().expect("direct Ping") {
+    Transmit::Packet(p) => {
+      let (to, message) = p.into_parts();
+      if let Message::Ping(ping) = message {
+        (ping.sequence_number(), to)
+      } else {
+        panic!("Ping message expected")
+      }
+    }
+    _ => panic!("Ping expected"),
+  };
+  while e.poll_transmit().is_some() {}
+  while e.poll_event().is_some() {}
+
+  // Direct sub-timeout (t0+50ms) elapses at t0+60ms → escalate to AwaitingIndirect,
+  // fan out IndirectPings, and arm the reliable-ping fallback.
+  e.handle_timeout(t0 + Duration::from_millis(60));
+
+  // Capture the armed fallback's stream id from the escalated phase.
+  let rid = match &e.probes.get(&seq).expect("probe still in flight").phase {
+    ProbePhase::AwaitingIndirect(AwaitingIndirect {
+      reliable_stream_id, ..
+    }) => reliable_stream_id.expect("escalation armed the reliable-ping fallback"),
+    other => panic!("expected AwaitingIndirect, got {other:?}"),
+  };
+  // The fallback is genuinely armed: its pending intent and mirrored deadline key
+  // both resident before the rescue.
+  assert!(
+    e.pending_stream_intents.contains_key(&rid),
+    "escalation must insert the fallback's pending stream intent",
+  );
+  assert!(
+    e.intent_deadlines.contains(&rid),
+    "the fallback intent must mirror into the intent deadline index",
+  );
+  while e.poll_transmit().is_some() {}
+  while e.poll_event().is_some() {}
+
+  // The target answers LATE with a DIRECT Ack (its own source address) at t0+70ms,
+  // still inside the cumulative window → the probe is rescued.
+  e.handle_ack(
+    target_addr,
+    Ack::new(seq).with_payload(Bytes::from_static(b"pong")),
+    t0 + Duration::from_millis(70),
+  );
+
+  assert!(
+    !e.probes.contains_key(&seq),
+    "the late direct Ack completes the probe",
+  );
+  // The rescued probe cancelled its armed fallback: both the pending intent and its
+  // deadline-index key are gone.
+  assert!(
+    !e.pending_stream_intents.contains_key(&rid),
+    "a rescued probe must cancel its armed reliable-ping fallback intent",
+  );
+  assert!(
+    !e.intent_deadlines.contains(&rid),
+    "the cancelled fallback's intent deadline key must be cleared",
+  );
+}
+
 #[test]
 fn handle_ack_for_unknown_seq_is_noop() {
   let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());

--- a/memberlist-proto/src/quic/crypto/mod.rs
+++ b/memberlist-proto/src/quic/crypto/mod.rs
@@ -153,8 +153,7 @@ pub struct QuicOptions {
   dial_service_margin: Duration,
   /// Maximum liveness-critical reliable-ping fallback dials the coordinator attempts
   /// PAST a per-pass dial-attempt budget, per peer bucket per pass. See
-  /// [`Self::max_reliable_ping_exempt_pops_per_pass`] for the default and the safety
-  /// floor.
+  /// [`Self::max_reliable_ping_exempt_pops_per_pass`] for the default and the floor.
   max_reliable_ping_exempt_pops_per_pass: usize,
 }
 
@@ -287,10 +286,11 @@ pub const DEFAULT_DIAL_SERVICE_MARGIN: Duration = super::DIAL_SERVICE_MARGIN;
 /// liveness-critical reliable-ping fallback at the front of a peer's parked bucket is
 /// attempted even when a pass's shared dial-attempt budget is spent, so it is never
 /// deferred to its cumulative probe deadline (a false-positive Dead) behind a
-/// user-message flood. `8` equals the membership `awareness_max_multiplier` default —
-/// the bound on how many same-peer reliable-ping fallbacks can stack at once — so an
-/// honest fallback is never deferred at the default configuration. See
-/// [`QuicOptions::max_reliable_ping_exempt_pops_per_pass`] for the safety floor.
+/// user-message flood. A cap of `1` already suffices: every probe-terminal path
+/// cancels the armed fallback, and Detection single-flight plus "application pings
+/// never escalate" bound the live same-peer fallbacks to exactly one. `8` is a
+/// conservative default that keeps ample headroom for transient stale entries. See
+/// [`QuicOptions::max_reliable_ping_exempt_pops_per_pass`] for the floor.
 pub const DEFAULT_MAX_RELIABLE_PING_EXEMPT_POPS_PER_PASS: usize = 8;
 
 // A zero exempt-pop cap would defer EVERY reliable-ping fallback that arrives on a
@@ -624,10 +624,10 @@ impl QuicOptions {
   }
 
   /// Override the per-pass reliable-ping exempt-pop cap. A value of `0` disables the
-  /// exemption and is rejected by [`Self::validate`]. It MUST stay `>=` the
-  /// membership `awareness_max_multiplier` or honest reliable-ping fallbacks defer to
-  /// a false Suspect — see [`Self::max_reliable_ping_exempt_pops_per_pass`]. Defaults
-  /// to [`DEFAULT_MAX_RELIABLE_PING_EXEMPT_POPS_PER_PASS`].
+  /// exemption and is rejected by [`Self::validate`]; any value `>= 1` is accepted,
+  /// and `1` suffices because live same-peer fallbacks are bounded to one — see
+  /// [`Self::max_reliable_ping_exempt_pops_per_pass`]. Defaults to
+  /// [`DEFAULT_MAX_RELIABLE_PING_EXEMPT_POPS_PER_PASS`].
   #[must_use]
   #[inline(always)]
   pub const fn with_max_reliable_ping_exempt_pops_per_pass(mut self, max: usize) -> Self {
@@ -753,13 +753,14 @@ impl QuicOptions {
   /// an honest fallback from stranding behind a user-message flood. Defaults to
   /// [`DEFAULT_MAX_RELIABLE_PING_EXEMPT_POPS_PER_PASS`].
   ///
-  /// SAFETY FLOOR: keep this `>=` the membership `awareness_max_multiplier` (config
-  /// default 8), which bounds how many same-peer reliable-ping fallbacks can stack at
-  /// once. A smaller cap would defer honest fallbacks past the budget and risk a
-  /// false Suspect. The coordinator cannot cheaply read the membership awareness
-  /// bound at runtime (the composed endpoint exposes no accessor for it), so
-  /// [`Self::validate`] only rejects a zero cap; the default matches the awareness
-  /// default so the floor holds unless an operator lowers one without the other.
+  /// FLOOR: `1` is sufficient. Every probe-terminal path (success, failure, expiry,
+  /// dial-failure, leave) cancels the armed reliable-ping fallback, so a
+  /// `ReliablePing` pending intent exists only while its owning Detection probe is
+  /// live; Detection single-flight plus "application pings never escalate" then bound
+  /// the live same-peer fallbacks to exactly one. A stale entry left by a
+  /// since-succeeded probe retires at the coordinator without a dial and without
+  /// charging this budget, so it cannot crowd out the live ping. [`Self::validate`]
+  /// therefore only rejects a zero cap; the default keeps generous headroom.
   #[inline(always)]
   pub const fn max_reliable_ping_exempt_pops_per_pass(&self) -> usize {
     self.max_reliable_ping_exempt_pops_per_pass
@@ -859,7 +860,7 @@ pub enum QuicOptionsError {
   DialServiceMarginExceedsTwiceCatchupInterval,
   /// `max_reliable_ping_exempt_pops_per_pass` was set to `0`, which would defer every
   /// over-budget reliable-ping fallback to its cumulative deadline (a false Suspect).
-  /// Set it to `>= 1` (and `>=` the membership awareness max).
+  /// Set it to `>= 1`.
   #[error("max_reliable_ping_exempt_pops_per_pass must be >= 1")]
   MaxReliablePingExemptPopsPerPassZero,
 }

--- a/memberlist-proto/src/quic/mod.rs
+++ b/memberlist-proto/src/quic/mod.rs
@@ -168,6 +168,18 @@ const MAX_BRIDGE_PUMPS_PER_PASS: usize = 64;
 /// a handshake-blocked bucket still stops at the first re-park.
 const MAX_DIAL_ATTEMPTS_PER_PASS: usize = 64;
 
+/// Hard per-drain cap on machine-cancelled reliable-ping entries retired through the
+/// zero-budget exempt lane of [`QuicEndpoint::service_peer_bucket`]. Those retires open
+/// no stream and are deliberately NOT charged against the exempt-pop budget (a transient
+/// stale entry must never consume the single live-ping pop), so absent this cap a long
+/// prefix of stale entries would be walked in full in one pass. Honest operation leaves at
+/// most ~2 stale entries per peer (Detection single-flight plus the tick's unbudgeted dial
+/// drain), so this 4x-margin cap never fires under the scheduler; it bounds the lane
+/// unconditionally against an out-of-band [`Endpoint::start_probe`](crate::Endpoint) caller
+/// that stacks same-peer fallbacks, with the residue riding the ready-dial ledger to the
+/// next drain.
+const MAX_CANCELLED_RETIRES_PER_EXEMPT_DRAIN: usize = 8;
+
 /// Maximum peers the budgeted catch-up ready-dial drain in
 /// [`QuicEndpoint::catchup_service`] POPS from [`QuicEndpoint::ready_dial_peers`] in
 /// ONE [`CATCHUP_INTERVAL`], independent of the ledger's size — the visit-count twin
@@ -3432,14 +3444,24 @@ where
     // attempted PAST an exhausted pass budget — the pass-budget twin of the
     // reliable-ping outbound-cap exemption — up to this cap, so an honest FSM ping is
     // never deferred to its cumulative probe deadline (a false Suspect) behind a
-    // user-message flood. A cap of 1 suffices: every probe-terminal path (success,
-    // failure, expiry, dial-failure, leave) cancels the armed fallback, and
-    // Detection single-flight plus "application pings never escalate" bound the live
-    // same-peer fallbacks to exactly one — a stale entry from a since-succeeded probe
-    // retires here without a dial and without charging this budget. See
+    // user-message flood. An exempt cap of 1 suffices FOR THE LIVE POP, and stale
+    // entries reach the live ping the same pass, CONDITIONAL on scheduler single-flight:
+    // every probe-terminal path (success, failure, expiry, dial-failure, leave) cancels
+    // the armed fallback, and Detection single-flight plus "application pings never
+    // escalate" bound the live same-peer fallbacks to exactly one — a stale entry from a
+    // since-succeeded probe retires here without a dial and without charging this budget.
+    // Per-pass BOUNDEDNESS of this lane does NOT rely on that scheduler property: the
+    // uncharged stale retires are independently capped by
+    // [`MAX_CANCELLED_RETIRES_PER_EXEMPT_DRAIN`], so even an out-of-band `start_probe`
+    // caller that stacks same-peer fallbacks cannot make one pass O(stale prefix). See
     // [`QuicOptions::max_reliable_ping_exempt_pops_per_pass`].
     let exempt_cap = self.cfg.max_reliable_ping_exempt_pops_per_pass();
     let mut exempt_pops = 0usize;
+    // Machine-cancelled reliable-ping entries retire here without opening a stream and
+    // WITHOUT charging `exempt_pops` (see the `RetiredCancelled` arm), so a separate
+    // counter caps that uncharged cleanup at
+    // [`MAX_CANCELLED_RETIRES_PER_EXEMPT_DRAIN`] per drain.
+    let mut cancelled_retires = 0usize;
     loop {
       if *dial_budget == 0 {
         // Budget exhausted (or zero on arrival). Only a FRONT reliable-ping is popped
@@ -3475,11 +3497,21 @@ where
           // The intent was already cancelled by its succeeding probe, so this retire
           // never attempted a dial — do NOT charge the exempt budget, or a burst of
           // transient stale entries under a small cap could exhaust it before the
-          // live fallback ping is reached. The parked-ping population is FSM/probe-
-          // bounded (never datagram-mintable) and, once its probe succeeds, these
-          // stale entries drain within about one tick, so this uncounted retire loop
-          // is bounded and CST-safe. Keep popping to reach the live ping behind them.
-          DialAttempt::RetiredCancelled => {}
+          // live fallback ping is reached. It is instead counted against a SEPARATE
+          // per-drain cap: honest operation leaves at most ~2 such stale entries per
+          // peer (Detection single-flight plus the tick's unbudgeted dial drain), so
+          // the cap never fires under the scheduler, but it bounds this uncharged loop
+          // UNCONDITIONALLY — including against an out-of-band `start_probe` caller that
+          // stacks same-peer fallbacks — instead of walking an arbitrarily long stale
+          // prefix in one pass. On the cap the loop breaks with the residue resident;
+          // the deposit below then rides it on the ready-dial ledger to the next drain.
+          // Below the cap, keep popping to reach the live ping behind them.
+          DialAttempt::RetiredCancelled => {
+            cancelled_retires += 1;
+            if cancelled_retires >= MAX_CANCELLED_RETIRES_PER_EXEMPT_DRAIN {
+              break;
+            }
+          }
           // Re-parked to the FRONT (a ping always front-parks): stop before re-popping
           // it. Leaving `attempted_any` / `last_was_reparked` untouched preserves the
           // zero-budget deposit for the tail below.
@@ -3505,8 +3537,9 @@ where
         // A `MAX_STREAMS` raise may grant more than one bidi credit, and a
         // retire consumes none, so a later entry in the bucket may still find
         // an opening — keep draining (up to the budget). A cancelled-intent
-        // retire opened nothing either and is treated the same here; its only
-        // distinction is uncounted exempt pops in the zero-budget lane above.
+        // retire opened nothing either and is treated the same here, charging a
+        // dial unit like any pop; it only differs in the zero-budget lane above,
+        // where it is uncharged against `exempt_pops` but capped per drain.
         DialAttempt::Minted | DialAttempt::Retired | DialAttempt::RetiredCancelled => {
           last_was_reparked = false
         }

--- a/memberlist-proto/src/quic/mod.rs
+++ b/memberlist-proto/src/quic/mod.rs
@@ -403,6 +403,13 @@ enum DialAttempt {
   /// `dial_succeeded` invalidated it. No bidi credit was consumed, so a later
   /// entry may still open.
   Retired,
+  /// A `ReliablePing` entry was retired because its machine intent was already
+  /// cancelled (the owning Detection probe succeeded, which drops the armed
+  /// fallback). Like `Retired` it opened no stream and consumed no bidi credit,
+  /// but the scoped drain's exempt lane does NOT charge it against the exempt-pop
+  /// budget: it never attempted a dial, so a burst of these stale entries must not
+  /// exhaust the budget before the peer's live fallback ping is reached.
+  RetiredCancelled,
   /// The intent re-parked into [`QuicEndpoint::dial_parked`] because the pooled
   /// connection is still handshaking or its bidi credit is exhausted. Every later
   /// entry in the same bucket shares that connection and would re-park
@@ -3425,8 +3432,11 @@ where
     // attempted PAST an exhausted pass budget — the pass-budget twin of the
     // reliable-ping outbound-cap exemption — up to this cap, so an honest FSM ping is
     // never deferred to its cumulative probe deadline (a false Suspect) behind a
-    // user-message flood. The cap MUST be >= the membership awareness max (which
-    // bounds how many same-peer fallbacks stack); see
+    // user-message flood. A cap of 1 suffices: every probe-terminal path (success,
+    // failure, expiry, dial-failure, leave) cancels the armed fallback, and
+    // Detection single-flight plus "application pings never escalate" bound the live
+    // same-peer fallbacks to exactly one — a stale entry from a since-succeeded probe
+    // retires here without a dial and without charging this budget. See
     // [`QuicOptions::max_reliable_ping_exempt_pops_per_pass`].
     let exempt_cap = self.cfg.max_reliable_ping_exempt_pops_per_pass();
     let mut exempt_pops = 0usize;
@@ -3457,11 +3467,19 @@ where
         let Some(entry) = popped else {
           break;
         };
-        exempt_pops += 1;
         match self.process_dial_entry(entry, now, &mut minted, &mut touched) {
-          // Minted/Retired consumed the ping terminally; a later front entry may be
-          // another stacked exempt ping — keep popping up to the cap.
-          DialAttempt::Minted | DialAttempt::Retired => {}
+          // Minted/Retired consumed the ping terminally after attempting a dial; a
+          // later front entry may be another stacked exempt ping — charge the exempt
+          // budget and keep popping up to the cap.
+          DialAttempt::Minted | DialAttempt::Retired => exempt_pops += 1,
+          // The intent was already cancelled by its succeeding probe, so this retire
+          // never attempted a dial — do NOT charge the exempt budget, or a burst of
+          // transient stale entries under a small cap could exhaust it before the
+          // live fallback ping is reached. The parked-ping population is FSM/probe-
+          // bounded (never datagram-mintable) and, once its probe succeeds, these
+          // stale entries drain within about one tick, so this uncounted retire loop
+          // is bounded and CST-safe. Keep popping to reach the live ping behind them.
+          DialAttempt::RetiredCancelled => {}
           // Re-parked to the FRONT (a ping always front-parks): stop before re-popping
           // it. Leaving `attempted_any` / `last_was_reparked` untouched preserves the
           // zero-budget deposit for the tail below.
@@ -3486,8 +3504,12 @@ where
       match self.process_dial_entry(entry, now, &mut minted, &mut touched) {
         // A `MAX_STREAMS` raise may grant more than one bidi credit, and a
         // retire consumes none, so a later entry in the bucket may still find
-        // an opening — keep draining (up to the budget).
-        DialAttempt::Minted | DialAttempt::Retired => last_was_reparked = false,
+        // an opening — keep draining (up to the budget). A cancelled-intent
+        // retire opened nothing either and is treated the same here; its only
+        // distinction is uncounted exempt pops in the zero-budget lane above.
+        DialAttempt::Minted | DialAttempt::Retired | DialAttempt::RetiredCancelled => {
+          last_was_reparked = false
+        }
         // The first re-park proves the shared pooled connection is still
         // handshaking or its restored bidi credit is already spent. Every later
         // entry in this bucket targets that SAME connection and would re-park
@@ -3762,6 +3784,24 @@ where
         now,
       );
       return DialAttempt::Retired;
+    }
+    // Retire a `ReliablePing` entry whose machine intent has already been
+    // cancelled, WITHOUT opening a stream. The Detection probe that armed this
+    // fallback succeeded (a late Ack rescued it), which drops the pending intent;
+    // the coordinator's parked entry is now stale. Opening `open(Dir::Bi)` for it
+    // would burn a peer bidi-stream credit only for `dial_succeeded` to invalidate
+    // the resulting stream (its intent is gone), so route it through the same
+    // pre-open retire the deadline pre-check uses. `intent_kind` reads the machine
+    // intent map: `None` means the intent was cancelled or consumed. Only a
+    // `ReliablePing` fallback can be cancelled out from under a still-parked entry
+    // this way; other kinds retire on their own deadline / dial outcome.
+    if matches!(kind, ExchangeKind::ReliablePing) && self.ep.intent_kind(id).is_none() {
+      self.retire_failed_dial(
+        id,
+        StreamError::DialFailed("quic reliable-ping fallback cancelled".into()),
+        now,
+      );
+      return DialAttempt::RetiredCancelled;
     }
     // The membership address `peer` IS the wire `SocketAddr` (the
     // coordinator pins `A = SocketAddr` internally); the TLS verification

--- a/memberlist-proto/src/quic/tests.rs
+++ b/memberlist-proto/src/quic/tests.rs
@@ -6705,20 +6705,11 @@ fn drained_slot_freed_before_dials_opens_a_cap_blocked_reliable_dial_same_tick()
 
   // A reliable ping to a live peer Y parked at the cap (deadline far). A
   // reapable connection (X) exists, so at the cap it re-parks rather than
-  // retiring — the intent survives to the reap tick.
+  // retiring — the intent survives to the reap tick. Arm a real machine
+  // fallback intent so the parked entry is a live (not machine-cancelled) dial.
   let y: SocketAddr = "127.0.0.9:5000".parse().unwrap();
   let deadline = now + Duration::from_secs(30);
-  a.dial_parked
-    .entry(y)
-    .or_default()
-    .push_back(super::PendingDial {
-      id: StreamId::from_raw(300_000),
-      peer: y,
-      deadline,
-      wake: deadline,
-      attempted: true,
-      kind: super::ExchangeKind::ReliablePing,
-    });
+  arm_parked_reliable_ping(&mut a, "y", y, 300, deadline, now);
   assert_eq!(a.live_connections_to(y), 0, "Y is not yet dialed");
 
   // One global tick: it reaps the drained X BEFORE dial servicing, so the parked
@@ -6806,20 +6797,11 @@ fn flush_path_reaps_drained_slot_before_dials_so_a_cap_blocked_reliable_dial_ope
 
   // A ready reliable ping to peer Y deposited into the ready-dial ledger so the
   // FLUSH path's ledger drain services its parked bucket (the flush owns no
-  // `service_dials`).
+  // `service_dials`). Arm a real machine fallback intent so the parked entry is a
+  // live (not machine-cancelled) dial.
   let y: SocketAddr = "127.0.0.9:5000".parse().unwrap();
   let deadline = now + Duration::from_secs(30);
-  a.dial_parked
-    .entry(y)
-    .or_default()
-    .push_back(super::PendingDial {
-      id: StreamId::from_raw(310_000),
-      peer: y,
-      deadline,
-      wake: deadline,
-      attempted: true,
-      kind: super::ExchangeKind::ReliablePing,
-    });
+  arm_parked_reliable_ping(&mut a, "y", y, 310, deadline, now);
   a.ready_dial_peers.insert(y);
   assert_eq!(a.live_connections_to(y), 0, "Y is not yet dialed");
 
@@ -12185,6 +12167,361 @@ fn reliable_ping_front_mints_past_zero_budget() {
     a.bridges.contains_key(&ping_id),
     "the front reliable-ping mints even at zero budget (mechanism (b)); removing the \
        exempt-pop parks it to a false Suspect"
+  );
+}
+
+/// Arm one machine-internal reliable-ping fallback to `target`/`peer` and park it at
+/// the BACK of the peer's bucket (front-to-back arrival order across calls), leaving
+/// its pending stream intent live. Returns the fallback's [`StreamId`].
+fn arm_parked_reliable_ping(
+  n: &mut QuicEndpoint<SmolStr>,
+  target: &str,
+  peer: SocketAddr,
+  seq: u32,
+  deadline: Instant,
+  now: Instant,
+) -> StreamId {
+  let id = n
+    .endpoint_mut()
+    .start_reliable_ping(SmolStr::new(target), peer, seq, deadline);
+  n.sieve_dial_events();
+  let mut pd = n
+    .dial_pending
+    .pop_front()
+    .expect("the reliable ping sieved into dial_pending");
+  n.unattempted_dial_count = 0;
+  assert!(
+    matches!(pd.kind, super::ExchangeKind::ReliablePing),
+    "the sieved intent is stamped ReliablePing"
+  );
+  pd.attempted = true;
+  pd.wake = n.dial_wake(pd.deadline, now);
+  let wake = pd.wake;
+  n.dial_parked.entry(peer).or_default().push_back(pd);
+  n.deadline_index.set(super::TimerKey::Dial(id), Some(wake));
+  while n.poll_event().is_some() {}
+  id
+}
+
+/// Count the `ReliablePing` entries currently parked for `peer`.
+fn parked_reliable_ping_count(n: &QuicEndpoint<SmolStr>, peer: SocketAddr) -> usize {
+  n.dial_parked
+    .get(&peer)
+    .map(|bk| {
+      bk.iter()
+        .filter(|e| matches!(e.kind, super::ExchangeKind::ReliablePing))
+        .count()
+    })
+    .unwrap_or(0)
+}
+
+/// Under sustained UDP degradation the probe FSM starts a fresh Detection fallback
+/// each interval while a late Ack rescues the previous round's probe (cancelling its
+/// armed fallback). With every probe-terminal path — success included — cancelling
+/// the fallback, the coordinator's parked bucket holds at most ONE live reliable-ping
+/// entry per peer: the stale entry from a since-succeeded probe retires without
+/// opening before the next one is armed, so fallbacks never accumulate to starve the
+/// exempt budget. Once credit is restored the surviving live fallback mints before
+/// its deadline.
+///
+/// Without the success-path cancellation (and the coordinator's stale-entry retire)
+/// the parked bucket would grow one entry per rescued round.
+#[test]
+fn reliable_ping_fallback_never_accumulates_across_rescued_probes() {
+  let n_addr: SocketAddr = "127.0.0.1:8460".parse().unwrap();
+  let b_addr: SocketAddr = "127.0.0.1:8461".parse().unwrap();
+  let now = Instant::now();
+  let mut n = make_endpoint_full(
+    EndpointOptions::new(SmolStr::new("n"), n_addr),
+    test_config_bidi_limit(1),
+    n_addr,
+    now,
+  );
+  let mut b = make_endpoint_full(
+    EndpointOptions::new(SmolStr::new("b"), b_addr),
+    test_config_bidi_limit(1),
+    b_addr,
+    now,
+  );
+  establish(&mut n, &mut b, n_addr, b_addr, now);
+  while n.poll_transmit().is_some() {}
+  while b.poll_transmit().is_some() {}
+
+  // Consume the single bidi credit with a held push/pull bridge, so every
+  // reliable-ping fallback re-parks (credit exhausted) rather than minting.
+  let _hold = n.start_push_pull(b_addr, PushPullKind::Join, now);
+  assert_eq!(
+    n.live_bridge_count(),
+    1,
+    "the held push/pull consumes the one bidi credit"
+  );
+
+  let deadline = now + Duration::from_secs(5);
+  let mut prev: Option<StreamId> = None;
+  for seq in 0..6u32 {
+    if let Some(prev_id) = prev.take() {
+      // The previous round's probe was rescued by a late Ack — cancel its armed
+      // fallback intent, exactly as `complete_probe_success` does in the machine.
+      n.endpoint_mut().dial_failed(
+        prev_id,
+        crate::error::StreamError::DialFailed("probe rescued by a late ack".into()),
+        now,
+      );
+    }
+    // Service first: the now-stale previous entry retires without opening.
+    let mut budget = super::MAX_DIAL_ATTEMPTS_PER_PASS;
+    let _ = n.service_peer_bucket(b_addr, now, &mut budget);
+    // Arm this round's fresh fallback and let it re-park (credit exhausted).
+    let id = arm_parked_reliable_ping(&mut n, "b", b_addr, seq, deadline, now);
+    let mut budget = super::MAX_DIAL_ATTEMPTS_PER_PASS;
+    let _ = n.service_peer_bucket(b_addr, now, &mut budget);
+    assert!(
+      parked_reliable_ping_count(&n, b_addr) <= 1,
+      "at most one live reliable-ping fallback may be parked per peer across rescued \
+         probe rounds; round {seq} left {}",
+      parked_reliable_ping_count(&n, b_addr)
+    );
+    prev = Some(id);
+  }
+
+  // The final round's fallback is live and parked, credit-blocked.
+  let live = prev.expect("a final live fallback remains parked");
+  assert!(
+    !n.bridges.contains_key(&live),
+    "the surviving fallback is credit-blocked, not yet open"
+  );
+
+  // Restore credit by ferrying the held push/pull to completion: B reaps its inbound
+  // bridge and raises MAX_STREAMS, whose Available arm services the parked fallback.
+  let mut minted = false;
+  let mut t = now;
+  'ferry: for _ in 0..400 {
+    t += Duration::from_millis(10);
+    let mut n_out: Vec<Vec<u8>> = Vec::new();
+    while let Some((to, bytes)) = n.poll_transmit() {
+      if to == b_addr {
+        n_out.push(bytes.to_vec());
+      }
+    }
+    for dg in n_out {
+      b.handle_udp(n_addr, &dg, t);
+    }
+    let mut b_out: Vec<Vec<u8>> = Vec::new();
+    while let Some((to, bytes)) = b.poll_transmit() {
+      if to == n_addr {
+        b_out.push(bytes.to_vec());
+      }
+    }
+    for dg in b_out {
+      n.handle_udp(b_addr, &dg, t);
+      if n.bridges.contains_key(&live) {
+        minted = true;
+        break 'ferry;
+      }
+    }
+    b.handle_timeout(t);
+  }
+  assert!(
+    minted,
+    "once credit is restored the surviving live reliable-ping fallback mints before \
+       its deadline"
+  );
+}
+
+/// A prefix of stale `ReliablePing` entries (their machine intents cancelled by a
+/// since-succeeded probe) at the front of a peer's bucket must retire WITHOUT opening
+/// a stream — no bidi credit spent, no bridge minted — and WITHOUT charging the
+/// exempt-pop budget, so the live fallback behind them is still serviced. The cap is
+/// pinned to the stale count: if a stale retire consumed an exempt pop, the live ping
+/// would be starved and never mint.
+#[test]
+fn stale_reliable_ping_entries_retire_without_opening_or_consuming_exempt_pops() {
+  const STALE: usize = 3;
+  let a_addr: SocketAddr = "127.0.0.1:8464".parse().unwrap();
+  let y_addr: SocketAddr = "127.0.0.1:8465".parse().unwrap();
+  let now = Instant::now();
+  let a_cfg = EndpointOptions::new(SmolStr::new("a"), a_addr)
+    .with_probe_interval(Duration::ZERO)
+    .with_gossip_interval(Duration::ZERO)
+    .with_push_pull_interval(Duration::ZERO);
+  let mut a = make_endpoint_full(
+    a_cfg,
+    test_config().with_max_reliable_ping_exempt_pops_per_pass(STALE),
+    a_addr,
+    now,
+  );
+  let mut y = make_endpoint_full(
+    EndpointOptions::new(SmolStr::new("y"), y_addr),
+    test_config(),
+    y_addr,
+    now,
+  );
+  establish(&mut a, &mut y, a_addr, y_addr, now);
+  quiesce(&mut a, now);
+  let bridges_before = a.live_bridge_count();
+
+  let deadline = now + Duration::from_secs(5);
+  // Arm STALE fallbacks, then cancel each machine intent (as a succeeding probe does).
+  let mut stale_ids = Vec::new();
+  for seq in 0..STALE as u32 {
+    let id = arm_parked_reliable_ping(&mut a, "y", y_addr, seq, deadline, now);
+    a.endpoint_mut().dial_failed(
+      id,
+      crate::error::StreamError::DialFailed("probe rescued".into()),
+      now,
+    );
+    stale_ids.push(id);
+  }
+  // One LIVE fallback behind the stale prefix (its intent remains).
+  let live = arm_parked_reliable_ping(&mut a, "y", y_addr, STALE as u32, deadline, now);
+
+  for id in &stale_ids {
+    assert!(
+      a.endpoint_mut().intent_kind(*id).is_none(),
+      "the stale fallback's machine intent is cancelled"
+    );
+  }
+  assert!(
+    a.endpoint_mut().intent_kind(live).is_some(),
+    "the live fallback's machine intent is resident"
+  );
+
+  // Zero budget → only the exempt lane runs.
+  let mut budget = 0usize;
+  let _ = a.service_peer_bucket(y_addr, now, &mut budget);
+  while a.poll_transmit().is_some() {}
+
+  for id in &stale_ids {
+    assert!(
+      !a.bridges.contains_key(id),
+      "a stale fallback must retire without opening a stream"
+    );
+  }
+  assert!(
+    a.bridges.contains_key(&live),
+    "the live fallback behind the stale prefix is serviced (stale retires never charge \
+       the exempt budget)"
+  );
+  assert_eq!(
+    a.live_bridge_count(),
+    bridges_before + 1,
+    "exactly one stream opened (the live ping); each stale retire opens none"
+  );
+  assert_eq!(
+    parked_reliable_ping_count(&a, y_addr),
+    0,
+    "the stale prefix retired and the live ping minted, draining the bucket"
+  );
+}
+
+/// Zero-budget regression: a front live reliable-ping still mints past a spent budget,
+/// and a non-ping creditable tail is deposited to the ready-dial ledger for a
+/// pre-deadline catch-up wake (existing behavior preserved alongside the stale-entry
+/// retire).
+#[test]
+fn zero_budget_services_front_live_ping_and_deposits_nonping_tail() {
+  let a_addr: SocketAddr = "127.0.0.1:8468".parse().unwrap();
+  let y_addr: SocketAddr = "127.0.0.1:8469".parse().unwrap();
+  let now = Instant::now();
+  let a_cfg = EndpointOptions::new(SmolStr::new("a"), a_addr)
+    .with_probe_interval(Duration::ZERO)
+    .with_gossip_interval(Duration::ZERO)
+    .with_push_pull_interval(Duration::ZERO);
+  let mut a = make_endpoint_full(a_cfg, test_config(), a_addr, now);
+  let mut y = make_endpoint_full(
+    EndpointOptions::new(SmolStr::new("y"), y_addr),
+    test_config(),
+    y_addr,
+    now,
+  );
+  establish(&mut a, &mut y, a_addr, y_addr, now);
+  quiesce(&mut a, now);
+
+  let deadline = now + Duration::from_secs(5);
+  // A live reliable-ping at the FRONT, then a non-ping (user-message) tail behind it.
+  let live = arm_parked_reliable_ping(&mut a, "y", y_addr, 1, deadline, now);
+  a.dial_parked
+    .entry(y_addr)
+    .or_default()
+    .push_back(super::PendingDial {
+      id: StreamId::from_raw(160_000),
+      peer: y_addr,
+      deadline,
+      wake: deadline,
+      attempted: true,
+      kind: super::ExchangeKind::UserMessage,
+    });
+
+  let mut budget = 0usize;
+  let _ = a.service_peer_bucket(y_addr, now, &mut budget);
+  while a.poll_transmit().is_some() {}
+
+  assert!(
+    a.bridges.contains_key(&live),
+    "the front live reliable-ping mints even at zero budget"
+  );
+  assert!(
+    a.ready_dial_peers.seen.contains(&y_addr),
+    "the creditable non-ping tail deposits the peer into the ready-dial ledger"
+  );
+  assert_eq!(
+    a.dial_parked.get(&y_addr).map(|bk| bk.len()).unwrap_or(0),
+    1,
+    "the user-message tail remains parked for the catch-up wake"
+  );
+}
+
+/// Cap = 1 crux: with the exempt budget pinned to one and a zero pass budget, a live
+/// reliable-ping behind a prefix of stale (intent-cancelled) entries is STILL attempted
+/// this pass, because a stale retire never charges the single exempt pop.
+///
+/// Mutation anchor: charge the intent-gone retire against `exempt_pops` (revert B2's
+/// uncounted retire) — the first stale entry then consumes the one pop, the loop breaks
+/// before the live ping, and it defers unopened.
+#[test]
+fn cap_one_live_ping_attempted_past_stale_prefix() {
+  const STALE: usize = 2;
+  let a_addr: SocketAddr = "127.0.0.1:8472".parse().unwrap();
+  let y_addr: SocketAddr = "127.0.0.1:8473".parse().unwrap();
+  let now = Instant::now();
+  let a_cfg = EndpointOptions::new(SmolStr::new("a"), a_addr)
+    .with_probe_interval(Duration::ZERO)
+    .with_gossip_interval(Duration::ZERO)
+    .with_push_pull_interval(Duration::ZERO);
+  let mut a = make_endpoint_full(
+    a_cfg,
+    test_config().with_max_reliable_ping_exempt_pops_per_pass(1),
+    a_addr,
+    now,
+  );
+  let mut y = make_endpoint_full(
+    EndpointOptions::new(SmolStr::new("y"), y_addr),
+    test_config(),
+    y_addr,
+    now,
+  );
+  establish(&mut a, &mut y, a_addr, y_addr, now);
+  quiesce(&mut a, now);
+
+  let deadline = now + Duration::from_secs(5);
+  for seq in 0..STALE as u32 {
+    let id = arm_parked_reliable_ping(&mut a, "y", y_addr, seq, deadline, now);
+    a.endpoint_mut().dial_failed(
+      id,
+      crate::error::StreamError::DialFailed("probe rescued".into()),
+      now,
+    );
+  }
+  let live = arm_parked_reliable_ping(&mut a, "y", y_addr, STALE as u32, deadline, now);
+
+  let mut budget = 0usize;
+  let _ = a.service_peer_bucket(y_addr, now, &mut budget);
+  while a.poll_transmit().is_some() {}
+
+  assert!(
+    a.bridges.contains_key(&live),
+    "under cap = 1 the live reliable-ping still mints past a stale prefix; charging the \
+       intent-gone retire against the single exempt pop would defer it"
   );
 }
 

--- a/memberlist-proto/src/quic/tests.rs
+++ b/memberlist-proto/src/quic/tests.rs
@@ -12525,6 +12525,332 @@ fn cap_one_live_ping_attempted_past_stale_prefix() {
   );
 }
 
+/// The zero-budget exempt lane retires machine-cancelled `ReliablePing` entries (their
+/// intents dropped by a since-succeeded probe) WITHOUT charging the exempt-pop budget, so
+/// a burst of stale entries cannot starve the single live-fallback pop. That uncharged
+/// retire is bounded per drain by `MAX_CANCELLED_RETIRES_PER_EXEMPT_DRAIN`: a pass that
+/// hits the cap stops with the residue resident, deposits the peer into the ready-dial
+/// ledger, and rides the catch-up anchor — so the lane is bounded per pass even against an
+/// out-of-band `start_probe` caller that stacks same-peer fallbacks.
+///
+/// Mutation anchor: remove the cap `break` — the pass then walks the WHOLE stale prefix
+/// (and mints the live ping) in one call, so the serviced delta exceeds the cap and the
+/// bucket empties, failing every assertion below.
+#[test]
+fn exempt_lane_cancelled_retire_cleanup_is_capped_per_drain() {
+  const CAP: usize = super::MAX_CANCELLED_RETIRES_PER_EXEMPT_DRAIN;
+  const STALE: usize = CAP + 4;
+  let a_addr: SocketAddr = "127.0.0.1:8476".parse().unwrap();
+  let y_addr: SocketAddr = "127.0.0.1:8477".parse().unwrap();
+  let now = Instant::now();
+  let a_cfg = EndpointOptions::new(SmolStr::new("a"), a_addr)
+    .with_probe_interval(Duration::ZERO)
+    .with_gossip_interval(Duration::ZERO)
+    .with_push_pull_interval(Duration::ZERO);
+  let mut a = make_endpoint_full(
+    a_cfg,
+    test_config().with_max_reliable_ping_exempt_pops_per_pass(1),
+    a_addr,
+    now,
+  );
+  let mut y = make_endpoint_full(
+    EndpointOptions::new(SmolStr::new("y"), y_addr),
+    test_config(),
+    y_addr,
+    now,
+  );
+  establish(&mut a, &mut y, a_addr, y_addr, now);
+  quiesce(&mut a, now);
+
+  let deadline = now + Duration::from_secs(5);
+  // A prefix of machine-cancelled stale fallbacks, then one live fallback behind them.
+  for seq in 0..STALE as u32 {
+    let id = arm_parked_reliable_ping(&mut a, "y", y_addr, seq, deadline, now);
+    a.endpoint_mut().dial_failed(
+      id,
+      crate::error::StreamError::DialFailed("probe rescued".into()),
+      now,
+    );
+  }
+  let _live = arm_parked_reliable_ping(&mut a, "y", y_addr, STALE as u32, deadline, now);
+  assert_eq!(
+    parked_reliable_ping_count(&a, y_addr),
+    STALE + 1,
+    "all stale fallbacks plus the live one are parked before the drain"
+  );
+
+  let before = a.counters.dial_entries_serviced;
+  let mut budget = 0usize;
+  let _ = a.service_peer_bucket(y_addr, now, &mut budget);
+  let serviced = a.counters.dial_entries_serviced - before;
+  while a.poll_transmit().is_some() {}
+
+  assert_eq!(
+    serviced, CAP as u64,
+    "the exempt drain retires exactly MAX_CANCELLED_RETIRES_PER_EXEMPT_DRAIN={CAP} stale \
+       entries then breaks; without the cap it would drain all {STALE} and mint the live \
+       ping ({serviced} serviced)"
+  );
+  assert_eq!(
+    parked_reliable_ping_count(&a, y_addr),
+    STALE + 1 - CAP,
+    "the un-retired stale remainder and the live ping stay resident for the next drain"
+  );
+  assert!(
+    a.ready_dial_peers.seen.contains(&y_addr),
+    "the resident residue deposits the peer into the ready-dial ledger"
+  );
+  // The connection-event / catch-up pass that owns this drain arms the sticky anchor;
+  // mirror that reconcile and assert the deferred residue is anchored.
+  a.reconcile_catchup_anchor(now);
+  assert!(
+    a.next_catchup_at.is_some(),
+    "the capped-drain residue leaves the catch-up anchor armed"
+  );
+}
+
+/// After the exempt lane caps its cancelled-retire cleanup and defers the residue, that
+/// residue drains over successive bounded zero-budget passes: each pass retires at most
+/// the cap (plus the single live mint on the final pass), the stale prefix shrinks
+/// monotonically, and once it is exhausted the live fallback mints — before its dial
+/// deadline, nothing stranded.
+#[test]
+fn capped_cancelled_retire_residue_drains_to_the_live_ping_over_bounded_passes() {
+  const CAP: usize = super::MAX_CANCELLED_RETIRES_PER_EXEMPT_DRAIN;
+  const STALE: usize = CAP * 2 + 3;
+  let a_addr: SocketAddr = "127.0.0.1:8480".parse().unwrap();
+  let y_addr: SocketAddr = "127.0.0.1:8481".parse().unwrap();
+  let now = Instant::now();
+  let a_cfg = EndpointOptions::new(SmolStr::new("a"), a_addr)
+    .with_probe_interval(Duration::ZERO)
+    .with_gossip_interval(Duration::ZERO)
+    .with_push_pull_interval(Duration::ZERO);
+  let mut a = make_endpoint_full(
+    a_cfg,
+    test_config().with_max_reliable_ping_exempt_pops_per_pass(1),
+    a_addr,
+    now,
+  );
+  let mut y = make_endpoint_full(
+    EndpointOptions::new(SmolStr::new("y"), y_addr),
+    test_config(),
+    y_addr,
+    now,
+  );
+  establish(&mut a, &mut y, a_addr, y_addr, now);
+  quiesce(&mut a, now);
+
+  let deadline = now + Duration::from_secs(5);
+  for seq in 0..STALE as u32 {
+    let id = arm_parked_reliable_ping(&mut a, "y", y_addr, seq, deadline, now);
+    a.endpoint_mut().dial_failed(
+      id,
+      crate::error::StreamError::DialFailed("probe rescued".into()),
+      now,
+    );
+  }
+  let live = arm_parked_reliable_ping(&mut a, "y", y_addr, STALE as u32, deadline, now);
+
+  let mut t = now;
+  let mut passes = 0usize;
+  loop {
+    let before_count = parked_reliable_ping_count(&a, y_addr);
+    let before_serviced = a.counters.dial_entries_serviced;
+    let mut budget = 0usize;
+    let _ = a.service_peer_bucket(y_addr, t, &mut budget);
+    while a.poll_transmit().is_some() {}
+    let serviced = a.counters.dial_entries_serviced - before_serviced;
+    let after_count = parked_reliable_ping_count(&a, y_addr);
+
+    assert!(
+      serviced <= CAP as u64 + 1,
+      "each bounded pass retires at most the cap plus the single live mint; pass \
+         serviced {serviced}"
+    );
+    assert!(
+      after_count < before_count,
+      "the stale prefix shrinks monotonically each pass ({before_count} -> {after_count})"
+    );
+    passes += 1;
+    if a.bridges.contains_key(&live) {
+      break;
+    }
+    assert!(
+      passes < 100,
+      "the residue must drain in a bounded number of passes"
+    );
+    t += Duration::from_millis(1);
+    assert!(
+      t < deadline,
+      "the live fallback still has budget before its dial deadline"
+    );
+  }
+  assert!(
+    a.bridges.contains_key(&live),
+    "once the capped stale prefix drains the live fallback mints before its deadline"
+  );
+  assert_eq!(
+    parked_reliable_ping_count(&a, y_addr),
+    0,
+    "no residue strands: the whole bucket drained"
+  );
+}
+
+/// The gate's exact shape: a bucket holding MORE than a full dial budget's worth of
+/// machine-cancelled fallbacks plus one live entry, serviced by ONE pass that starts with
+/// the shared `MAX_DIAL_ATTEMPTS_PER_PASS` dial budget — as a handshake / `MAX_STREAMS`
+/// connection-event servicing pass hands to `service_peer_bucket`. The budgeted lane
+/// charges a dial unit per pop until the budget is spent, then the zero-budget exempt lane
+/// caps its cancelled cleanup, so the whole pass retires at most
+/// `MAX_DIAL_ATTEMPTS_PER_PASS + MAX_CANCELLED_RETIRES_PER_EXEMPT_DRAIN` entries, with the
+/// remainder deposited into the ready-dial ledger and anchored.
+#[test]
+fn budgeted_then_exempt_cancelled_drain_is_bounded_by_dial_budget_plus_cap() {
+  const CAP: usize = super::MAX_CANCELLED_RETIRES_PER_EXEMPT_DRAIN;
+  const BUDGET: usize = super::MAX_DIAL_ATTEMPTS_PER_PASS;
+  const STALE: usize = BUDGET + CAP * 2;
+  let a_addr: SocketAddr = "127.0.0.1:8484".parse().unwrap();
+  let y_addr: SocketAddr = "127.0.0.1:8485".parse().unwrap();
+  let now = Instant::now();
+  let a_cfg = EndpointOptions::new(SmolStr::new("a"), a_addr)
+    .with_probe_interval(Duration::ZERO)
+    .with_gossip_interval(Duration::ZERO)
+    .with_push_pull_interval(Duration::ZERO);
+  let mut a = make_endpoint_full(
+    a_cfg,
+    test_config().with_max_reliable_ping_exempt_pops_per_pass(1),
+    a_addr,
+    now,
+  );
+  let mut y = make_endpoint_full(
+    EndpointOptions::new(SmolStr::new("y"), y_addr),
+    test_config(),
+    y_addr,
+    now,
+  );
+  establish(&mut a, &mut y, a_addr, y_addr, now);
+  quiesce(&mut a, now);
+
+  let deadline = now + Duration::from_secs(5);
+  for seq in 0..STALE as u32 {
+    let id = arm_parked_reliable_ping(&mut a, "y", y_addr, seq, deadline, now);
+    a.endpoint_mut().dial_failed(
+      id,
+      crate::error::StreamError::DialFailed("probe rescued".into()),
+      now,
+    );
+  }
+  let _live = arm_parked_reliable_ping(&mut a, "y", y_addr, STALE as u32, deadline, now);
+
+  let before = a.counters.dial_entries_serviced;
+  let mut budget = BUDGET;
+  let _ = a.service_peer_bucket(y_addr, now, &mut budget);
+  let serviced = a.counters.dial_entries_serviced - before;
+  while a.poll_transmit().is_some() {}
+
+  assert!(
+    serviced <= (BUDGET + CAP) as u64,
+    "one pass retires at most MAX_DIAL_ATTEMPTS_PER_PASS + \
+       MAX_CANCELLED_RETIRES_PER_EXEMPT_DRAIN = {} entries; serviced {serviced}",
+    BUDGET + CAP
+  );
+  assert_eq!(
+    serviced,
+    (BUDGET + CAP) as u64,
+    "the budgeted lane spends the whole dial budget over the stale prefix, then the exempt \
+       lane retires exactly the cap before deferring the remainder"
+  );
+  assert_eq!(
+    budget, 0,
+    "the budgeted lane spent the whole shared dial budget"
+  );
+  assert_eq!(
+    parked_reliable_ping_count(&a, y_addr),
+    STALE + 1 - (BUDGET + CAP),
+    "the un-serviced remainder and the live ping stay resident"
+  );
+  assert!(
+    a.ready_dial_peers.seen.contains(&y_addr),
+    "the residue deposits the peer into the ready-dial ledger"
+  );
+  a.reconcile_catchup_anchor(now);
+  assert!(
+    a.next_catchup_at.is_some(),
+    "the deferred residue leaves the catch-up anchor armed"
+  );
+}
+
+/// Honest population leaves the cap uninvoked: a single stale cancelled fallback ahead of
+/// one live ping retires uncounted and the live ping mints the SAME zero-budget pass, so
+/// the cap never fires under the scheduler-bounded stale prefix. Pins the `b93ab8a`
+/// exempt-lane behavior unchanged by the per-drain cap.
+#[test]
+fn honest_single_stale_cancelled_retire_leaves_the_cap_uninvoked() {
+  let a_addr: SocketAddr = "127.0.0.1:8488".parse().unwrap();
+  let y_addr: SocketAddr = "127.0.0.1:8489".parse().unwrap();
+  let now = Instant::now();
+  let a_cfg = EndpointOptions::new(SmolStr::new("a"), a_addr)
+    .with_probe_interval(Duration::ZERO)
+    .with_gossip_interval(Duration::ZERO)
+    .with_push_pull_interval(Duration::ZERO);
+  let mut a = make_endpoint_full(
+    a_cfg,
+    test_config().with_max_reliable_ping_exempt_pops_per_pass(1),
+    a_addr,
+    now,
+  );
+  let mut y = make_endpoint_full(
+    EndpointOptions::new(SmolStr::new("y"), y_addr),
+    test_config(),
+    y_addr,
+    now,
+  );
+  establish(&mut a, &mut y, a_addr, y_addr, now);
+  quiesce(&mut a, now);
+  let bridges_before = a.live_bridge_count();
+
+  let deadline = now + Duration::from_secs(5);
+  let stale = arm_parked_reliable_ping(&mut a, "y", y_addr, 0, deadline, now);
+  a.endpoint_mut().dial_failed(
+    stale,
+    crate::error::StreamError::DialFailed("probe rescued".into()),
+    now,
+  );
+  let live = arm_parked_reliable_ping(&mut a, "y", y_addr, 1, deadline, now);
+
+  let before = a.counters.dial_entries_serviced;
+  let mut budget = 0usize;
+  let _ = a.service_peer_bucket(y_addr, now, &mut budget);
+  let serviced = a.counters.dial_entries_serviced - before;
+  while a.poll_transmit().is_some() {}
+
+  assert_eq!(
+    serviced,
+    2,
+    "the honest pass retires the one stale entry and mints the live ping — the cap of {} \
+       is never reached",
+    super::MAX_CANCELLED_RETIRES_PER_EXEMPT_DRAIN
+  );
+  assert!(
+    !a.bridges.contains_key(&stale),
+    "the stale cancelled fallback retires without opening a stream"
+  );
+  assert!(
+    a.bridges.contains_key(&live),
+    "the live fallback mints the same pass — the uncounted stale retire never deferred it"
+  );
+  assert_eq!(
+    a.live_bridge_count(),
+    bridges_before + 1,
+    "exactly the live ping opened; the stale retire opened nothing"
+  );
+  assert_eq!(
+    parked_reliable_ping_count(&a, y_addr),
+    0,
+    "the stale prefix retired and the live ping minted, draining the bucket"
+  );
+}
+
 /// T4 (mechanism (c): urgent front-deposit ordering). A budget-deferred peer whose front
 /// dial is within two catch-up intervals of its DEADLINE is deposited at the FRONT of
 /// the ready-dial ledger, ahead of a pre-existing non-urgent peer, so the next catch-up


### PR DESCRIPTION
Closes #178.