### PR TITLE
fix(driver): size the QUIC recv buffer for QUIC packets, not just gossip MTU (#157 C5/R1)

### DIFF
--- a/memberlist-compio/src/quic/driver/mod.rs
+++ b/memberlist-compio/src/quic/driver/mod.rs
@@ -302,10 +302,15 @@ struct QuicDriverState<I, G = rand::rngs::StdRng> {
 ///   including the >= 1200-byte handshake Initial — would be truncated and the
 ///   handshake would never complete, silently breaking the transport.
 ///
-/// The result is capped at `GOSSIP_RECV_BUF_MAX`; the QUIC max (~1472) is far
-/// under that cap, so flooring at it never collides with the ceiling in
-/// practice. Mirrors the stream driver's `gossip_recv_buf_len` (which shares no
-/// socket with QUIC and so needs no QUIC floor).
+/// The `GOSSIP_RECV_BUF_MAX` cap applies ONLY to the gossip-derived size —
+/// applying it after taking the max with the QUIC size would wrongly truncate
+/// a custom `EndpointConfig` whose `max_udp_payload_size` sits above
+/// `GOSSIP_RECV_BUF_MAX` (quinn allows up to 65527, e.g. for IPv6 jumbograms,
+/// while `GOSSIP_RECV_BUF_MAX` is the IPv4 UDP payload ceiling of 65507). The
+/// QUIC size is already bounded to `1200..=65527` by quinn and is applied as a
+/// floor AFTER the gossip cap, so it is never clamped down and the result stays
+/// `<= 65527`. Mirrors the stream driver's `gossip_recv_buf_len` (which shares
+/// no socket with QUIC and so needs no QUIC floor).
 fn recv_buf_len<I, G>(endpoint: &QuicEndpoint<I, G>) -> usize
 where
   I: memberlist_proto::Id,
@@ -314,8 +319,8 @@ where
     .gossip_mtu()
     .saturating_add(ENCRYPTED_WRAPPER_OVERHEAD)
     .saturating_add(CHECKSUMED_WRAPPER_OVERHEAD)
-    .max(endpoint.max_recv_udp_payload_size())
     .min(GOSSIP_RECV_BUF_MAX)
+    .max(endpoint.max_recv_udp_payload_size())
 }
 
 /// Single-owner QUIC driver task.

--- a/memberlist-compio/src/quic/driver/mod.rs
+++ b/memberlist-compio/src/quic/driver/mod.rs
@@ -285,16 +285,28 @@ struct QuicDriverState<I, G = rand::rngs::StdRng> {
   pending_user_sends: Vec<PendingUserSend>,
 }
 
-/// Compute the per-recv UDP buffer size from the coordinator's
-/// configured `gossip_mtu`. A datagram on the wire is at most
-/// `gossip_mtu + ENCRYPTED_WRAPPER_OVERHEAD + CHECKSUMED_WRAPPER_OVERHEAD`
-/// bytes when checksum and encryption are enabled (the encryption wrapper
-/// carries the algorithm tag + nonce + AEAD auth tag, and the checksum
-/// wrapper its tag + digest); the driver sizes the recv buffer to that value so a
-/// configured `with_gossip_mtu` above the historical 16 KiB default is
-/// not silently truncated by the kernel. Mirrors the stream driver's
-/// `gossip_recv_buf_len`.
-fn gossip_recv_buf_len<I, G>(endpoint: &QuicEndpoint<I, G>) -> usize
+/// Compute the per-recv UDP buffer size for the QUIC driver's socket, which
+/// carries BOTH raw QUIC packets and memberlist gossip datagrams. The buffer
+/// must hold the larger of the two, or the kernel silently truncates whichever
+/// is bigger:
+///
+/// - A gossip datagram is at most
+///   `gossip_mtu + ENCRYPTED_WRAPPER_OVERHEAD + CHECKSUMED_WRAPPER_OVERHEAD`
+///   bytes when checksum and encryption are enabled (the encryption wrapper
+///   carries the algorithm tag + nonce + AEAD auth tag, and the checksum wrapper
+///   its tag + digest), so a `with_gossip_mtu` above the historical 16 KiB
+///   default is not truncated.
+/// - A QUIC packet is at most the endpoint's advertised
+///   [`QuicEndpoint::max_recv_udp_payload_size`]. A small `gossip_mtu` (validated
+///   floor 512) must NOT shrink the buffer below it: an inbound QUIC packet —
+///   including the >= 1200-byte handshake Initial — would be truncated and the
+///   handshake would never complete, silently breaking the transport.
+///
+/// The result is capped at `GOSSIP_RECV_BUF_MAX`; the QUIC max (~1472) is far
+/// under that cap, so flooring at it never collides with the ceiling in
+/// practice. Mirrors the stream driver's `gossip_recv_buf_len` (which shares no
+/// socket with QUIC and so needs no QUIC floor).
+fn recv_buf_len<I, G>(endpoint: &QuicEndpoint<I, G>) -> usize
 where
   I: memberlist_proto::Id,
 {
@@ -302,6 +314,7 @@ where
     .gossip_mtu()
     .saturating_add(ENCRYPTED_WRAPPER_OVERHEAD)
     .saturating_add(CHECKSUMED_WRAPPER_OVERHEAD)
+    .max(endpoint.max_recv_udp_payload_size())
     .min(GOSSIP_RECV_BUF_MAX)
 }
 
@@ -406,12 +419,12 @@ pub(crate) async fn quic_driver_loop<I, D, G>(
     pending_user_sends: Vec::new(),
   };
 
-  // Per-driver UDP recv buffer size derived once from the coordinator's
-  // configured `gossip_mtu` + encrypted-wrapper overhead, capped at the
-  // IP-layer UDP maximum. The coordinator's `gossip_mtu` is set at
-  // construction time and never reconfigured at runtime, so a single
-  // value computed up-front is correct.
-  let recv_buf_len = gossip_recv_buf_len::<I, G>(&state.endpoint);
+  // Per-driver UDP recv buffer size derived once: the larger of the gossip
+  // datagram ceiling (`gossip_mtu` + wrapper overheads) and the QUIC endpoint's
+  // advertised max recv UDP payload, capped at the IP-layer UDP maximum. Both
+  // the `gossip_mtu` and the QUIC config are set at construction time and never
+  // reconfigured at runtime, so a single value computed up-front is correct.
+  let recv_buf_len = recv_buf_len::<I, G>(&state.endpoint);
 
   // Arm the periodic probe / gossip / push-pull schedulers. Without this
   // the machine's `next_probe` / `next_gossip` / `next_pushpull` stay

--- a/memberlist-compio/src/quic/driver/tests.rs
+++ b/memberlist-compio/src/quic/driver/tests.rs
@@ -122,6 +122,56 @@ fn addr(port: u16) -> SocketAddr {
   ([127, 0, 0, 1], port).into()
 }
 
+/// Build a coordinator with an explicit gossip MTU, so the recv-buffer sizing
+/// can be exercised at the validated `gossip_mtu` floor and well above it.
+fn build_endpoint_with_gossip_mtu(
+  id: &str,
+  addr: SocketAddr,
+  now: Instant,
+  gossip_mtu: usize,
+) -> QuicEndpoint<smol_str::SmolStr> {
+  use memberlist_proto::{EndpointOptions, endpoint::Endpoint};
+  use rand::SeedableRng;
+
+  let cfg = EndpointOptions::new(smol_str::SmolStr::new(id), addr).with_gossip_mtu(gossip_mtu);
+  let rng = rand::rngs::StdRng::seed_from_u64(addr.port() as u64);
+  let mut ep: Endpoint<smol_str::SmolStr, SocketAddr, rand::rngs::StdRng> = Endpoint::new(cfg, rng);
+  ep.start_scheduling(now);
+
+  let mut seed = [0u8; 32];
+  seed[..2].copy_from_slice(&addr.port().to_le_bytes());
+  QuicEndpoint::<smol_str::SmolStr>::with_quinn_rng_seed(ep, test_quic_options(), Some(seed))
+}
+
+/// At the validated `gossip_mtu` floor (512) the gossip datagram ceiling is far
+/// below quinn's max recv UDP payload, so the recv buffer MUST floor at the QUIC
+/// max — otherwise inbound QUIC packets (the >= 1200-byte Initial included) are
+/// truncated and the handshake never completes. Reverting the `.max(...)` in
+/// `recv_buf_len` drops this below the QUIC max and fails the test.
+#[test]
+fn recv_buf_len_floors_at_quic_max_for_small_gossip_mtu() {
+  let ep = build_endpoint_with_gossip_mtu("n", addr(7710), Instant::now(), 512);
+  let quic_max = ep.max_recv_udp_payload_size();
+  assert!(quic_max >= 1200);
+  assert!(
+    super::recv_buf_len::<smol_str::SmolStr, rand::rngs::StdRng>(&ep) >= quic_max,
+    "recv buffer must accommodate the largest QUIC packet even at the gossip_mtu floor"
+  );
+}
+
+/// A large `gossip_mtu` keeps the gossip datagram ceiling as the binding size —
+/// the QUIC-max floor must not shrink it.
+#[test]
+fn recv_buf_len_gossip_wins_for_large_gossip_mtu() {
+  let ep = build_endpoint_with_gossip_mtu("n", addr(7711), Instant::now(), 60_000);
+  let got = super::recv_buf_len::<smol_str::SmolStr, rand::rngs::StdRng>(&ep);
+  assert!(got > ep.max_recv_udp_payload_size());
+  assert_eq!(
+    got,
+    60_000 + super::ENCRYPTED_WRAPPER_OVERHEAD + super::CHECKSUMED_WRAPPER_OVERHEAD
+  );
+}
+
 /// Build an empty (allow-all default) CIDR filter — admits every address.
 fn allow_all() -> super::CidrFilter {
   #[cfg(feature = "cidr")]

--- a/memberlist-compio/src/quic/driver/tests.rs
+++ b/memberlist-compio/src/quic/driver/tests.rs
@@ -67,7 +67,21 @@ fn build_endpoint_with_quic(
 fn test_quic_options() -> memberlist_proto::QuicOptions {
   use std::sync::Arc;
 
-  use quinn_proto::{ClientConfig, EndpointConfig, ServerConfig, TransportConfig};
+  use quinn_proto::EndpointConfig;
+
+  let hmac = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, &[0x5au8; 32]);
+  test_quic_options_with_endpoint_cfg(EndpointConfig::new(Arc::new(hmac)))
+}
+
+/// Like [`test_quic_options`] but with a caller-supplied `EndpointConfig`, so a
+/// test can raise `max_udp_payload_size` above quinn's 1472 default (up to its
+/// 65527 ceiling) to exercise `recv_buf_len`'s QUIC-size floor.
+fn test_quic_options_with_endpoint_cfg(
+  endpoint_cfg: quinn_proto::EndpointConfig,
+) -> memberlist_proto::QuicOptions {
+  use std::sync::Arc;
+
+  use quinn_proto::{ClientConfig, ServerConfig, TransportConfig};
   use rustls::RootCertStore;
   use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 
@@ -102,9 +116,6 @@ fn test_quic_options() -> memberlist_proto::QuicOptions {
   let qcc = quinn_proto::crypto::rustls::QuicClientConfig::try_from(Arc::new(rustls_client))
     .expect("QuicClientConfig");
   let client_cfg = ClientConfig::new(Arc::new(qcc));
-
-  let hmac = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, &[0x5au8; 32]);
-  let endpoint_cfg = EndpointConfig::new(Arc::new(hmac));
 
   let transport = TransportConfig::default();
 
@@ -169,6 +180,46 @@ fn recv_buf_len_gossip_wins_for_large_gossip_mtu() {
   assert_eq!(
     got,
     60_000 + super::ENCRYPTED_WRAPPER_OVERHEAD + super::CHECKSUMED_WRAPPER_OVERHEAD
+  );
+}
+
+/// A custom `EndpointConfig` can raise `max_udp_payload_size` up to quinn's
+/// 65527 ceiling (e.g. for IPv6 jumbograms), which sits ABOVE
+/// `GOSSIP_RECV_BUF_MAX` (65507, the IPv4 UDP payload limit). At the default
+/// gossip MTU the QUIC size is the binding term, and `recv_buf_len` must floor
+/// at it WITHOUT the `GOSSIP_RECV_BUF_MAX` cap clamping it back down — the cap
+/// applies only to the gossip-derived size. Applying `.min(GOSSIP_RECV_BUF_MAX)`
+/// after the `.max(quic)` (the old clamp order) would wrongly truncate this to
+/// 65507 and fail the assertion.
+#[test]
+fn recv_buf_len_floors_at_quic_max_above_gossip_cap() {
+  use std::sync::Arc;
+
+  use memberlist_proto::{EndpointOptions, endpoint::Endpoint};
+  use quinn_proto::EndpointConfig;
+  use rand::SeedableRng;
+
+  let hmac = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, &[0x5au8; 32]);
+  let mut endpoint_cfg = EndpointConfig::new(Arc::new(hmac));
+  endpoint_cfg
+    .max_udp_payload_size(65_527)
+    .expect("65527 is quinn's max_udp_payload_size ceiling");
+  let qc = test_quic_options_with_endpoint_cfg(endpoint_cfg);
+
+  let a = addr(7712);
+  let cfg = EndpointOptions::new(smol_str::SmolStr::new("n"), a);
+  let rng = rand::rngs::StdRng::seed_from_u64(a.port() as u64);
+  let mut ep: Endpoint<smol_str::SmolStr, SocketAddr, rand::rngs::StdRng> = Endpoint::new(cfg, rng);
+  ep.start_scheduling(Instant::now());
+  let mut seed = [0u8; 32];
+  seed[..2].copy_from_slice(&a.port().to_le_bytes());
+  let ep = QuicEndpoint::<smol_str::SmolStr>::with_quinn_rng_seed(ep, qc, Some(seed));
+
+  assert_eq!(ep.max_recv_udp_payload_size(), 65_527);
+  let got = super::recv_buf_len::<smol_str::SmolStr, rand::rngs::StdRng>(&ep);
+  assert!(
+    got >= 65_527,
+    "recv buffer must floor at the QUIC receive size even above GOSSIP_RECV_BUF_MAX, got {got}"
   );
 }
 

--- a/memberlist-proto/src/quic/mod.rs
+++ b/memberlist-proto/src/quic/mod.rs
@@ -1722,6 +1722,28 @@ impl<I, R> QuicEndpoint<I, R> {
     self.ep.gossip_mtu()
   }
 
+  /// The largest UDP datagram this QUIC endpoint can receive: quinn's advertised
+  /// `max_udp_payload_size` transport parameter, read from the bundled
+  /// [`quinn_proto::EndpointConfig`] via its `get_max_udp_payload_size`.
+  ///
+  /// A peer never sends this endpoint a QUIC packet larger than this value — it
+  /// is exactly the size quinn tells peers it accepts — so a driver that shares
+  /// one UDP socket for QUIC packets and gossip datagrams must size its receive
+  /// buffer to at least this many bytes. A smaller buffer silently truncates
+  /// inbound QUIC packets (including the >= 1200-byte handshake Initial), so the
+  /// handshake never completes and the QUIC transport is unusable.
+  ///
+  /// Defaults to quinn's 1472 (a 1500-byte Ethernet MTU minus IPv4/UDP
+  /// headers). A caller who raises `EndpointConfig::max_udp_payload_size` on the
+  /// raw [`QuicOptions::new`](crate::quic::QuicOptions::new) path — e.g. for a
+  /// jumbo-frame or loopback link — sees that larger value here, so the driver's
+  /// recv buffer tracks the configured value without any further wiring.
+  pub fn max_recv_udp_payload_size(&self) -> usize {
+    // Bounded to `1200..=65527` by quinn's setter, so the `u64 -> usize` cast is
+    // lossless on every supported target.
+    self.cfg.endpoint_ref().get_max_udp_payload_size() as usize
+  }
+
   /// Probe the protocol-layer credit for opening a remote-initiated
   /// unidirectional stream to `peer`. Returns `true` iff the open
   /// would have succeeded; on the (rare) success branch the probe

--- a/memberlist-proto/src/quic/tests.rs
+++ b/memberlist-proto/src/quic/tests.rs
@@ -172,6 +172,17 @@ fn quic_endpoint_type_is_constructible_signature() {
 }
 
 #[test]
+fn max_recv_udp_payload_size_is_quinn_default() {
+  // The bundled `EndpointConfig` leaves `max_udp_payload_size` at quinn's
+  // default (1472 = 1500-byte Ethernet MTU minus IPv4/UDP headers). The
+  // accessor surfaces exactly that so a driver can floor its recv buffer at it,
+  // and it must clear the 1200-byte QUIC Initial floor.
+  let ep = make_endpoint("n", "127.0.0.1:7590".parse().unwrap(), Instant::now());
+  assert_eq!(ep.max_recv_udp_payload_size(), 1472);
+  assert!(ep.max_recv_udp_payload_size() >= 1200);
+}
+
+#[test]
 fn with_label_empty_normalizes_to_none() {
   // An empty label collapses to the byte-identical no-label path, never a
   // `[12][0]` header.

--- a/memberlist-proto/src/quic/tests.rs
+++ b/memberlist-proto/src/quic/tests.rs
@@ -183,6 +183,34 @@ fn max_recv_udp_payload_size_is_quinn_default() {
 }
 
 #[test]
+fn max_recv_udp_payload_size_reaches_quinn_ceiling() {
+  // A custom `EndpointConfig` can raise `max_udp_payload_size` up to quinn's
+  // 65527 ceiling (e.g. for IPv6 jumbograms), which sits ABOVE
+  // `GOSSIP_RECV_BUF_MAX` (65507, the IPv4 UDP payload limit) that the QUIC
+  // drivers use to cap their gossip-derived recv-buffer term. The accessor
+  // must surface the full 65527 uncapped, so a driver's `recv_buf_len` can
+  // floor at it without truncating valid large QUIC datagrams.
+  let mut endpoint_cfg = crate::quic::crypto::tests::test_endpoint_config(&[0x5au8; 32]);
+  endpoint_cfg
+    .max_udp_payload_size(65_527)
+    .expect("65527 is quinn's max_udp_payload_size ceiling");
+  let qc = QuicOptions::new(
+    endpoint_cfg,
+    crate::quic::crypto::tests::test_server(),
+    crate::quic::crypto::tests::test_client(),
+    quinn_proto::TransportConfig::default(),
+    "localhost",
+    UnreliableTransport::Datagram,
+  );
+  let cfg = EndpointOptions::new(SmolStr::new("n"), "127.0.0.1:7591".parse().unwrap());
+  let mut ep: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg);
+  ep.start_scheduling(Instant::now());
+  let ep = QuicEndpoint::<SmolStr>::with_quinn_rng_seed(ep, qc, Some([0x11u8; 32]));
+
+  assert_eq!(ep.max_recv_udp_payload_size(), 65_527);
+}
+
+#[test]
 fn with_label_empty_normalizes_to_none() {
   // An empty label collapses to the byte-identical no-label path, never a
   // `[12][0]` header.

--- a/memberlist-reactor/src/driver/quic/mod.rs
+++ b/memberlist-reactor/src/driver/quic/mod.rs
@@ -95,16 +95,21 @@ const CHECKSUMED_WRAPPER_OVERHEAD: usize = 0;
 ///   including the >= 1200-byte handshake Initial — would be truncated and the
 ///   handshake would never complete, silently breaking the transport.
 ///
-/// The result is capped at `GOSSIP_RECV_BUF_MAX`; the QUIC max (~1472) is far
-/// under that cap, so flooring at it never collides with the ceiling in
-/// practice.
+/// The `GOSSIP_RECV_BUF_MAX` cap applies ONLY to the gossip-derived size —
+/// applying it after taking the max with the QUIC size would wrongly truncate
+/// a custom `EndpointConfig` whose `max_udp_payload_size` sits above
+/// `GOSSIP_RECV_BUF_MAX` (quinn allows up to 65527, e.g. for IPv6 jumbograms,
+/// while `GOSSIP_RECV_BUF_MAX` is the IPv4 UDP payload ceiling of 65507). The
+/// QUIC size is already bounded to `1200..=65527` by quinn and is applied as a
+/// floor AFTER the gossip cap, so it is never clamped down and the result stays
+/// `<= 65527`.
 fn recv_buf_len<I, G>(endpoint: &QuicEndpoint<I, G>) -> usize {
   endpoint
     .gossip_mtu()
     .saturating_add(ENCRYPTED_WRAPPER_OVERHEAD)
     .saturating_add(CHECKSUMED_WRAPPER_OVERHEAD)
-    .max(endpoint.max_recv_udp_payload_size())
     .min(GOSSIP_RECV_BUF_MAX)
+    .max(endpoint.max_recv_udp_payload_size())
 }
 
 /// Cap on the count of application-data events retained after a full observation

--- a/memberlist-reactor/src/driver/quic/mod.rs
+++ b/memberlist-reactor/src/driver/quic/mod.rs
@@ -80,6 +80,33 @@ const CHECKSUMED_WRAPPER_OVERHEAD: usize = memberlist_proto::CHECKSUMED_WRAPPER_
 #[cfg(not(checksum))]
 const CHECKSUMED_WRAPPER_OVERHEAD: usize = 0;
 
+/// Compute the per-recv UDP buffer size for the QUIC driver's socket, which
+/// carries BOTH raw QUIC packets and memberlist gossip datagrams. The buffer
+/// must hold the larger of the two, or the kernel silently truncates whichever
+/// is bigger:
+///
+/// - A gossip datagram is at most
+///   `gossip_mtu + ENCRYPTED_WRAPPER_OVERHEAD + CHECKSUMED_WRAPPER_OVERHEAD`
+///   bytes when checksum and encryption are enabled, so a `with_gossip_mtu`
+///   above the historical default is not truncated.
+/// - A QUIC packet is at most the endpoint's advertised
+///   [`QuicEndpoint::max_recv_udp_payload_size`]. A small `gossip_mtu` (validated
+///   floor 512) must NOT shrink the buffer below it: an inbound QUIC packet —
+///   including the >= 1200-byte handshake Initial — would be truncated and the
+///   handshake would never complete, silently breaking the transport.
+///
+/// The result is capped at `GOSSIP_RECV_BUF_MAX`; the QUIC max (~1472) is far
+/// under that cap, so flooring at it never collides with the ceiling in
+/// practice.
+fn recv_buf_len<I, G>(endpoint: &QuicEndpoint<I, G>) -> usize {
+  endpoint
+    .gossip_mtu()
+    .saturating_add(ENCRYPTED_WRAPPER_OVERHEAD)
+    .saturating_add(CHECKSUMED_WRAPPER_OVERHEAD)
+    .max(endpoint.max_recv_udp_payload_size())
+    .min(GOSSIP_RECV_BUF_MAX)
+}
+
 /// Cap on the count of application-data events retained after a full observation
 /// channel (the payload byte budget bounds their bytes; this bounds their count).
 const OBS_OVERFLOW_MAX: usize = 1024;
@@ -210,11 +237,7 @@ where
     label: Option<Bytes>,
     cidr_policy: CidrFilter,
   ) -> Self {
-    let buf_len = endpoint
-      .gossip_mtu()
-      .saturating_add(ENCRYPTED_WRAPPER_OVERHEAD)
-      .saturating_add(CHECKSUMED_WRAPPER_OVERHEAD)
-      .min(GOSSIP_RECV_BUF_MAX);
+    let buf_len = recv_buf_len(&endpoint);
     let last_snapshot_version = endpoint.endpoint_ref().snapshot_version();
     Self {
       endpoint,

--- a/memberlist-reactor/src/driver/quic/tests.rs
+++ b/memberlist-reactor/src/driver/quic/tests.rs
@@ -48,6 +48,14 @@ const ALPN: &[u8] = b"memberlist-quic-cov";
 /// driver tests never actually establish a connection, so a single self-trusted
 /// identity suffices.
 fn self_trusted_quic() -> QuicOptions {
+  let hmac = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, &[0x5au8; 32]);
+  self_trusted_quic_with_endpoint_cfg(EndpointConfig::new(Arc::new(hmac)))
+}
+
+/// Like [`self_trusted_quic`] but with a caller-supplied `EndpointConfig`, so a
+/// test can raise `max_udp_payload_size` above quinn's 1472 default (up to its
+/// 65527 ceiling) to exercise `recv_buf_len`'s QUIC-size floor.
+fn self_trusted_quic_with_endpoint_cfg(endpoint_cfg: EndpointConfig) -> QuicOptions {
   let ck = rcgen::generate_simple_self_signed(vec!["localhost".into()]).expect("rcgen");
   let cert = CertificateDer::from(ck.cert.der().to_vec());
   let key = PrivateKeyDer::Pkcs8(ck.signing_key.serialize_der().into());
@@ -76,8 +84,6 @@ fn self_trusted_quic() -> QuicOptions {
     .expect("QuicClientConfig");
   let client_cfg = ClientConfig::new(Arc::new(qcc));
 
-  let hmac = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, &[0x5au8; 32]);
-  let endpoint_cfg = EndpointConfig::new(Arc::new(hmac));
   let transport = TransportConfig::default();
   QuicOptions::new(
     endpoint_cfg,
@@ -226,6 +232,42 @@ fn recv_buf_len_gossip_wins_for_large_gossip_mtu() {
   assert_eq!(
     got,
     60_000 + ENCRYPTED_WRAPPER_OVERHEAD + CHECKSUMED_WRAPPER_OVERHEAD
+  );
+}
+
+/// A custom `EndpointConfig` can raise `max_udp_payload_size` up to quinn's
+/// 65527 ceiling (e.g. for IPv6 jumbograms), which sits ABOVE
+/// `GOSSIP_RECV_BUF_MAX` (65507, the IPv4 UDP payload limit). At the default
+/// gossip MTU the QUIC size is the binding term, and `recv_buf_len` must floor
+/// at it WITHOUT the `GOSSIP_RECV_BUF_MAX` cap clamping it back down — the cap
+/// applies only to the gossip-derived size. Applying `.min(GOSSIP_RECV_BUF_MAX)`
+/// after the `.max(quic)` (the old clamp order) would wrongly truncate this to
+/// 65507 and fail the assertion.
+#[test]
+fn recv_buf_len_floors_at_quic_max_above_gossip_cap() {
+  let mut endpoint_cfg = EndpointConfig::new(Arc::new(ring::hmac::Key::new(
+    ring::hmac::HMAC_SHA256,
+    &[0x5au8; 32],
+  )));
+  endpoint_cfg
+    .max_udp_payload_size(65_527)
+    .expect("65527 is quinn's max_udp_payload_size ceiling");
+  let quic = self_trusted_quic_with_endpoint_cfg(endpoint_cfg);
+
+  let ep = Endpoint::new(
+    EndpointOptions::new(
+      SmolStr::new("qdrv"),
+      "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+    ),
+    crate::gossip_rng().expect("test: OS entropy"),
+  );
+  let ep = QuicEndpoint::new(ep, quic);
+
+  assert_eq!(ep.max_recv_udp_payload_size(), 65_527);
+  let got = recv_buf_len(&ep);
+  assert!(
+    got >= 65_527,
+    "recv buffer must floor at the QUIC receive size even above GOSSIP_RECV_BUF_MAX, got {got}"
   );
 }
 

--- a/memberlist-reactor/src/driver/quic/tests.rs
+++ b/memberlist-reactor/src/driver/quic/tests.rs
@@ -185,6 +185,50 @@ async fn build_driver_with_quic(
   (driver, obs_rx, shared, obs_payload_bytes)
 }
 
+/// Build a standalone coordinator with an explicit gossip MTU (no socket), so
+/// the recv-buffer sizing can be exercised at the validated `gossip_mtu` floor
+/// and well above it.
+fn endpoint_with_gossip_mtu(gossip_mtu: usize) -> QuicEndpoint<SmolStr, impl rand::Rng> {
+  let ep = Endpoint::new(
+    EndpointOptions::new(
+      SmolStr::new("qdrv"),
+      "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+    )
+    .with_gossip_mtu(gossip_mtu),
+    crate::gossip_rng().expect("test: OS entropy"),
+  );
+  QuicEndpoint::new(ep, self_trusted_quic())
+}
+
+/// At the validated `gossip_mtu` floor (512) the gossip datagram ceiling is far
+/// below quinn's max recv UDP payload, so the recv buffer MUST floor at the QUIC
+/// max — otherwise inbound QUIC packets (the >= 1200-byte Initial included) are
+/// truncated and the handshake never completes. Reverting the `.max(...)` in
+/// `recv_buf_len` drops this below the QUIC max and fails the test.
+#[test]
+fn recv_buf_len_floors_at_quic_max_for_small_gossip_mtu() {
+  let ep = endpoint_with_gossip_mtu(512);
+  let quic_max = ep.max_recv_udp_payload_size();
+  assert!(quic_max >= 1200);
+  assert!(
+    recv_buf_len(&ep) >= quic_max,
+    "recv buffer must accommodate the largest QUIC packet even at the gossip_mtu floor"
+  );
+}
+
+/// A large `gossip_mtu` keeps the gossip datagram ceiling as the binding size —
+/// the QUIC-max floor must not shrink it.
+#[test]
+fn recv_buf_len_gossip_wins_for_large_gossip_mtu() {
+  let ep = endpoint_with_gossip_mtu(60_000);
+  let got = recv_buf_len(&ep);
+  assert!(got > ep.max_recv_udp_payload_size());
+  assert_eq!(
+    got,
+    60_000 + ENCRYPTED_WRAPPER_OVERHEAD + CHECKSUMED_WRAPPER_OVERHEAD
+  );
+}
+
 /// Drives one `Future::poll` with a harmless waker.
 fn poll_once(driver: &mut QuicDriver<SmolStr, TokioRuntime>) -> Poll<()> {
   let waker = flag_waker();


### PR DESCRIPTION
Addresses #157 findings **C5** (compio) and **R1** (reactor) — the QUIC drivers' shared UDP recv buffer was sized only for gossip.

## The bug (transport-breaking, honest-config)

Both QUIC drivers sized their shared UDP receive buffer from `gossip_mtu` + wrapper overheads (capped at `GOSSIP_RECV_BUF_MAX` = 65507). The same socket carries QUIC packets, and quinn advertises a receive limit (`EndpointConfig::max_udp_payload_size`, default **1472**) independent of the gossip MTU. So a supported small `gossip_mtu` (validated floor 512) sized the buffer to ~512 bytes → inbound QUIC Initials (≥1200) and steady-state packets (up to 1472) were **truncated**, and the QUIC handshake silently never completed. Confirmed still-open in the #157 re-validation (both are the same defect in the two drivers).

## The fix

- **proto** (`QuicEndpoint::max_recv_udp_payload_size()`): a small additive accessor returning quinn's *receive-advertised* value via its public `EndpointConfig::get_max_udp_payload_size()` getter — quinn documents that getter as existing precisely so higher layers can size a receive buffer. It tracks a caller's custom `EndpointConfig` automatically (no pinning, no caveat), and quinn bounds it to `1200..=65527` (the `u64→usize` cast is lossless on every supported target).
- **both drivers** (`recv_buf_len` helper in each): `gossip_derived_size.min(GOSSIP_RECV_BUF_MAX).max(endpoint.max_recv_udp_payload_size())` — the gossip cap applies only to the gossip-derived term, and the QUIC receive size (≤ 65527) sets an independent floor that is never clamped below it. So the buffer always covers a valid QUIC datagram at any supported `gossip_mtu`, up to quinn's 65527 ceiling. The stream (TCP/TLS) drivers share no QUIC socket and are untouched.
