### PR TITLE
fix(proto): advance stored incarnation on higher failure evidence to block stale-Alive resurrection (#157 P3)

### DIFF
--- a/memberlist-proto/src/endpoint/mod.rs
+++ b/memberlist-proto/src/endpoint/mod.rs
@@ -1669,8 +1669,10 @@ where
   /// Apply an incoming Suspect to local state. Branches:
   /// 1. Unknown id: ignore.
   /// 2. Older incarnation: ignore.
-  /// 3. Existing suspicion timer: forward to `confirm`. Re-broadcast on new info.
-  /// 4. Non-Alive node: ignore.
+  /// 3. Existing suspicion timer: forward to `confirm`. Re-broadcast on new info,
+  ///    and record a newer incarnation for the resurrection gate.
+  /// 4. Non-Alive node: record a newer incarnation for the resurrection gate,
+  ///    then ignore.
   /// 5. Self → refute, return.
   /// 6. Otherwise: install a fresh Suspicion, transition to Suspect,
   ///    enqueue broadcast.
@@ -1729,13 +1731,37 @@ where
       if confirmed.is_accepted() {
         self.broadcast_message(
           target.cheap_clone(),
-          Message::Suspect(Suspect::new(inc, target, from)),
+          Message::Suspect(Suspect::new(inc, target.cheap_clone(), from)),
         );
+      }
+      // Record higher-incarnation evidence carried by a confirming Suspect,
+      // independent of the confirmation dedup above: the stored incarnation
+      // feeds the Alive resurrection gate, and a suspicion that later expires
+      // synthesizes its Dead at this incarnation. Monotone (strict `>` so a
+      // gossip duplicate does not churn the snapshot); no state change, event,
+      // or broadcast beyond the confirm's own.
+      if inc > local_inc {
+        if let Some(m) = self.members.get_mut(&target) {
+          m.state_mut().set_incarnation(inc);
+          self.bump_snapshot_version();
+        }
       }
       return;
     }
 
     if current_state != State::Alive {
+      // The member is Dead or Left. Record higher-incarnation failure evidence
+      // without changing state: `merge_state` funnels remote Dead and Suspect
+      // push/pull entries through here, so this is the anti-entropy path that
+      // advances a dead member's stored incarnation, and the Alive resurrection
+      // gate then rejects a stale lower-incarnation Alive. Monotone (strict `>`);
+      // no state change, event, or broadcast.
+      if inc > local_inc {
+        if let Some(m) = self.members.get_mut(&target) {
+          m.state_mut().set_incarnation(inc);
+          self.bump_snapshot_version();
+        }
+      }
       return;
     }
 
@@ -1775,7 +1801,8 @@ where
   /// Apply an incoming Dead to local state. Branches:
   /// 1. Unknown id: ignore.
   /// 2. Older incarnation: ignore.
-  /// 3. Already Dead/Left: ignore.
+  /// 3. Already Dead/Left: record a newer incarnation for the resurrection gate,
+  ///    then ignore.
   /// 4. Self + not leaving: refute, return.
   /// 5. Self + leaving: mark Left.
   /// 6. Otherwise: mark Dead.
@@ -1805,6 +1832,20 @@ where
       return;
     }
     if matches!(current_state, State::Dead | State::Left) {
+      // Record higher-incarnation failure evidence for an already-dead member
+      // without changing state: the Alive resurrection gate compares against the
+      // stored incarnation, so advancing it here stops a later stale, lower-
+      // incarnation Alive from resurrecting a node that higher evidence killed.
+      // Monotone (strict `>` so a gossip duplicate does not churn the snapshot);
+      // no state change, event, or broadcast. Guarded on Running so a
+      // leaving/left node makes no remote membership change during its drain.
+      // (HashiCorp's `deadNode` drops this evidence; the port closes the hole.)
+      if inc > local_inc && self.lifecycle.is_running() {
+        if let Some(m) = self.members.get_mut(&target) {
+          m.state_mut().set_incarnation(inc);
+          self.bump_snapshot_version();
+        }
+      }
       return;
     }
 
@@ -3995,6 +4036,16 @@ where
     let local_protocol = member.state_ref().server_ref().protocol_version();
     let local_delegate = member.state_ref().server_ref().delegate_version();
 
+    // The stored incarnation is monotone: it records the highest incarnation
+    // carried by any admitted evidence (Alive/Suspect/Dead, from gossip, probe
+    // escalation, suspicion expiry, or push/pull merge) for the member's current
+    // instance, EVEN when that evidence caused no state transition (see the
+    // incarnation-advance in `process_dead` / `process_suspect`). Because this
+    // gate compares against that maximum, a stale lower-incarnation Alive cannot
+    // resurrect a member that higher failure evidence has killed; a genuine
+    // rejoin still passes by learning the recorded maximum via anti-entropy and
+    // refuting past it. (Address-change reclaim below is a separate path — a new
+    // instance with a fresh generation — and is deliberately exempt.)
     if !is_new && !updates_address && !is_local && alive_incarnation <= local_incarnation {
       return;
     }

--- a/memberlist-proto/src/endpoint/swim_parity_tests.rs
+++ b/memberlist-proto/src/endpoint/swim_parity_tests.rs
@@ -591,11 +591,17 @@ fn dead_on_dead_records_incarnation_and_blocks_stale_resurrection() {
   let queued_before = e.broadcast_queue_len();
 
   // Dead@10 on the already-Dead peer: record the incarnation, nothing else.
+  let version_before = e.snapshot_version();
   e.process_dead(dead_of(test.id_ref(), e.local_id_ref(), 10), Instant::now());
   assert_eq!(
     e.node_incarnation(test.id_ref()),
     Some(10),
     "the higher Dead advances the stored incarnation"
+  );
+  assert!(
+    e.snapshot_version() > version_before,
+    "recording a strictly higher incarnation must bump snapshot_version so the \
+     push/pull cache rebuilds"
   );
   assert_eq!(
     e.member_liveness(test.id_ref()),
@@ -673,11 +679,17 @@ fn suspect_confirm_records_incarnation_and_blocks_stale_refutation() {
   assert_eq!(e.member_liveness(test.id_ref()), Some(State::Suspect));
 
   // A distinct-source Suspect at a higher incarnation confirms and records 10.
+  let version_before = e.snapshot_version();
   e.process_suspect(suspect_of(test.id_ref(), &src_b, 10), t0);
   assert_eq!(
     e.node_incarnation(test.id_ref()),
     Some(10),
     "a confirming higher-incarnation Suspect advances the stored incarnation"
+  );
+  assert!(
+    e.snapshot_version() > version_before,
+    "recording a strictly higher incarnation on the confirm branch must bump \
+     snapshot_version so the push/pull cache rebuilds"
   );
 
   // The suspicion timer is armed; capture its deadline.
@@ -746,12 +758,18 @@ fn suspect_on_dead_records_incarnation() {
   while e.poll_event().is_some() {}
 
   // A remote push/pull batch reports the node Dead at incarnation 10.
+  let version_before = e.snapshot_version();
   let remote = [pns_of(&test, 10, State::Dead)];
   e.merge_state(&remote, t0);
   assert_eq!(
     e.node_incarnation(test.id_ref()),
     Some(10),
     "a remote Dead advances the stored incarnation through anti-entropy"
+  );
+  assert!(
+    e.snapshot_version() > version_before,
+    "recording a strictly higher incarnation on the non-Alive branch must bump \
+     snapshot_version so the push/pull cache rebuilds"
   );
   assert_eq!(
     e.member_liveness(test.id_ref()),
@@ -815,6 +833,132 @@ fn equal_incarnation_duplicates_do_not_bump_snapshot_version() {
     e.snapshot_version(),
     version_before,
     "an equal-incarnation duplicate must not bump the snapshot version"
+  );
+}
+
+/// Decode a `SendPushPullResponse` command's frame and return the incarnation
+/// it advertises for `id`, if the response carries an entry for it.
+fn pushpull_reply_incarnation(
+  cmd: StreamCommand<SmolStr, SocketAddr>,
+  id: &SmolStr,
+) -> Option<u32> {
+  match cmd {
+    StreamCommand::SendPushPullResponse(resp) => {
+      let bytes = resp.into_encoded();
+      let (_, msg) = crate::wire::decode_message::<SmolStr, SocketAddr>(&bytes)
+        .expect("cached push/pull response must decode");
+      match msg {
+        Message::PushPull(pp) => pp
+          .states_slice()
+          .iter()
+          .find(|s| s.id_ref() == id)
+          .map(|s| s.incarnation()),
+        other => panic!("expected a PushPull response frame, got {other:?}"),
+      }
+    }
+    StreamCommand::Close => panic!("an admitted push/pull request must not close the stream"),
+  }
+}
+
+/// Feed an empty-state `PushPullRequestReceived` (a bare refresh probe) at
+/// `now` and return the response command, so the cached push/pull response can
+/// be inspected without perturbing membership.
+fn probe_pushpull_response(
+  e: &mut Endpoint<SmolStr, SocketAddr>,
+  requester: SocketAddr,
+  stream_id: u64,
+  now: Instant,
+) -> StreamCommand<SmolStr, SocketAddr> {
+  let req = EndpointEvent::PushPullRequestReceived(PushPullRequestReceived::new_with_stream_id(
+    requester,
+    Vec::new(),
+    Bytes::new(),
+    PushPullKind::Refresh,
+    StreamId::from_raw(stream_id),
+  ));
+  e.handle_stream_event(req, now)
+    .expect("an admitted push/pull request must yield a response command")
+}
+
+/// The `process_dead` already-Dead branch's `snapshot_version` bump is load-
+/// bearing for propagation: the push/pull response cache rebuilds only when
+/// `snapshot_version` moves (see `refresh_pushpull_response_cache`), so a
+/// corrected higher incarnation must actually reach the wire, not just the
+/// in-memory member table.
+#[test]
+fn dead_on_dead_incarnation_advance_propagates_through_pushpull_cache() {
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  let test = node("test", 8000);
+  let requester = node("requester", 9000);
+
+  let t0 = Instant::now();
+  e.process_alive(alive_of(&test, 1), false, t0);
+  e.age_member(test.id_ref(), Duration::from_secs(3600));
+  e.process_dead(dead_of(test.id_ref(), e.local_id_ref(), 1), t0);
+  while e.poll_event().is_some() {}
+
+  // Publish the Dead@1 view into the response cache via the schedule-fired
+  // tick, then confirm a fresh requester is served incarnation 1.
+  e.handle_timeout(t0);
+  let cmd_before = probe_pushpull_response(&mut e, *requester.addr_ref(), 1, t0);
+  assert_eq!(
+    pushpull_reply_incarnation(cmd_before, test.id_ref()),
+    Some(1),
+    "the cache must reflect Dead@1 before the higher evidence arrives"
+  );
+
+  // Higher failure evidence on the already-Dead peer.
+  e.process_dead(dead_of(test.id_ref(), e.local_id_ref(), 10), Instant::now());
+  assert_eq!(e.node_incarnation(test.id_ref()), Some(10));
+
+  // The next tick rebuilds the cache; a fresh requester now sees incarnation
+  // 10, not the stale 1.
+  e.handle_timeout(Instant::now());
+  let cmd_after = probe_pushpull_response(&mut e, *requester.addr_ref(), 2, Instant::now());
+  assert_eq!(
+    pushpull_reply_incarnation(cmd_after, test.id_ref()),
+    Some(10),
+    "the rebuilt push/pull response must advertise the corrected incarnation"
+  );
+}
+
+/// Same propagation contract as
+/// `dead_on_dead_incarnation_advance_propagates_through_pushpull_cache`, but
+/// for the anti-entropy path: a remote `Dead@10` folded through `merge_state`
+/// (which funnels into `process_suspect`'s non-Alive branch) must also reach
+/// the rebuilt push/pull cache.
+#[test]
+fn merge_state_incarnation_advance_propagates_through_pushpull_cache() {
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  let test = node("test", 8000);
+  let requester = node("requester", 9000);
+
+  let t0 = Instant::now();
+  e.process_alive(alive_of(&test, 1), false, t0);
+  e.age_member(test.id_ref(), Duration::from_secs(3600));
+  e.process_dead(dead_of(test.id_ref(), e.local_id_ref(), 1), t0);
+  while e.poll_event().is_some() {}
+
+  e.handle_timeout(t0);
+  let cmd_before = probe_pushpull_response(&mut e, *requester.addr_ref(), 1, t0);
+  assert_eq!(
+    pushpull_reply_incarnation(cmd_before, test.id_ref()),
+    Some(1),
+    "the cache must reflect Dead@1 before the anti-entropy evidence arrives"
+  );
+
+  // A remote push/pull batch reports the node Dead at incarnation 10.
+  let remote = [pns_of(&test, 10, State::Dead)];
+  e.merge_state(&remote, Instant::now());
+  assert_eq!(e.node_incarnation(test.id_ref()), Some(10));
+
+  e.handle_timeout(Instant::now());
+  let cmd_after = probe_pushpull_response(&mut e, *requester.addr_ref(), 2, Instant::now());
+  assert_eq!(
+    pushpull_reply_incarnation(cmd_after, test.id_ref()),
+    Some(10),
+    "the rebuilt push/pull response must advertise the anti-entropy-corrected \
+     incarnation"
   );
 }
 

--- a/memberlist-proto/src/endpoint/swim_parity_tests.rs
+++ b/memberlist-proto/src/endpoint/swim_parity_tests.rs
@@ -525,9 +525,9 @@ fn dead_node() {
   );
 }
 
-/// A second `Dead` for an already-`Dead` peer is a no-op: even at a higher
-/// incarnation it leaves the state, incarnation, and stamp untouched, emits no
-/// event, and enqueues no broadcast.
+/// A second `Dead` for an already-`Dead` peer at a strictly higher incarnation
+/// records the higher incarnation (so the resurrection gate compares against it)
+/// but leaves the state, state-change stamp, events, and broadcasts untouched.
 #[test]
 fn dead_node_double() {
   let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
@@ -538,14 +538,14 @@ fn dead_node_double() {
   e.age_member(test.id_ref(), Duration::from_secs(3600));
   e.process_dead(dead_of(test.id_ref(), e.local_id_ref(), 1), t0);
   while e.poll_event().is_some() {}
-  let inc_before = e.node_incarnation(test.id_ref());
   let change_before = e.node_state_change(test.id_ref());
 
   // Drain so the queue-length delta isolates the second Dead's effect.
   e.drain_broadcasts();
   let queued_before = e.broadcast_queue_len();
 
-  // A second Dead at a strictly higher incarnation must do nothing.
+  // A second Dead at a strictly higher incarnation records that incarnation but
+  // is otherwise silent.
   e.process_dead(dead_of(test.id_ref(), e.local_id_ref(), 2), Instant::now());
 
   assert_eq!(
@@ -555,8 +555,8 @@ fn dead_node_double() {
   );
   assert_eq!(
     e.node_incarnation(test.id_ref()),
-    inc_before,
-    "a double Dead must not advance the incarnation"
+    Some(2),
+    "higher-incarnation failure evidence advances the stored incarnation"
   );
   assert_eq!(
     e.node_state_change(test.id_ref()),
@@ -568,6 +568,253 @@ fn dead_node_double() {
     e.broadcast_queue_len(),
     queued_before,
     "a double Dead must not enqueue a broadcast"
+  );
+}
+
+/// Higher-incarnation failure evidence on an already-Dead peer advances the
+/// stored incarnation without any state change, so the Alive resurrection gate
+/// later rejects a stale lower-incarnation Alive and admits only a genuinely
+/// newer one. Without the advance, `Alive@1 → Dead@1 → Dead@10 → Alive@2` would
+/// resurrect a node higher evidence had killed.
+#[test]
+fn dead_on_dead_records_incarnation_and_blocks_stale_resurrection() {
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  let test = node("test", 8000);
+
+  let t0 = Instant::now();
+  e.process_alive(alive_of(&test, 1), false, t0);
+  e.age_member(test.id_ref(), Duration::from_secs(3600));
+  e.process_dead(dead_of(test.id_ref(), e.local_id_ref(), 1), t0);
+  while e.poll_event().is_some() {}
+  let change_after_dead = e.node_state_change(test.id_ref());
+  e.drain_broadcasts();
+  let queued_before = e.broadcast_queue_len();
+
+  // Dead@10 on the already-Dead peer: record the incarnation, nothing else.
+  e.process_dead(dead_of(test.id_ref(), e.local_id_ref(), 10), Instant::now());
+  assert_eq!(
+    e.node_incarnation(test.id_ref()),
+    Some(10),
+    "the higher Dead advances the stored incarnation"
+  );
+  assert_eq!(
+    e.member_liveness(test.id_ref()),
+    Some(State::Dead),
+    "the node stays Dead"
+  );
+  assert_eq!(
+    e.node_state_change(test.id_ref()),
+    change_after_dead,
+    "recording an incarnation must not restamp the state-change"
+  );
+  assert!(
+    e.poll_event().is_none(),
+    "recording an incarnation emits no event"
+  );
+  assert_eq!(
+    e.broadcast_queue_len(),
+    queued_before,
+    "recording an incarnation enqueues no broadcast"
+  );
+
+  // A stale Alive@2 (< 10) can no longer resurrect the killed node.
+  e.process_alive(alive_of(&test, 2), false, Instant::now());
+  assert_eq!(
+    e.member_liveness(test.id_ref()),
+    Some(State::Dead),
+    "a stale lower-incarnation Alive must not resurrect a killed node"
+  );
+  assert!(
+    e.poll_event().is_none(),
+    "the rejected Alive emits no NodeJoined"
+  );
+
+  // A genuinely newer Alive@11 (> 10) resurrects the node the standard way.
+  e.process_alive(alive_of(&test, 11), false, Instant::now());
+  assert_eq!(
+    e.member_liveness(test.id_ref()),
+    Some(State::Alive),
+    "an Alive past the recorded maximum resurrects the node"
+  );
+  let ev = e.poll_event().expect("expected NodeJoined");
+  match ev {
+    Event::NodeJoined(n) => assert_eq!(n.id_ref(), test.id_ref()),
+    other => panic!("expected NodeJoined, got {other:?}"),
+  }
+}
+
+/// A confirming `Suspect` at a higher incarnation records that incarnation on an
+/// already-suspected peer (independent of the confirmation dedup), so a stale
+/// lower-incarnation Alive can no longer refute the suspicion, while the
+/// suspicion timer keeps running and, on expiry, synthesizes its `Dead` at the
+/// recorded incarnation.
+#[test]
+fn suspect_confirm_records_incarnation_and_blocks_stale_refutation() {
+  let scfg = || {
+    cfg()
+      .with_probe_interval(Duration::ZERO)
+      .with_push_pull_interval(Duration::ZERO)
+      .with_gossip_interval(Duration::ZERO)
+      .with_suspicion_mult(1)
+      .with_suspicion_max_timeout_mult(1)
+  };
+  let src_b = SmolStr::new("srcB");
+
+  // Main flow: confirm up to 10, then verify the resurrection/refute gate.
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(scfg());
+  let test = node("test", 8000);
+
+  let t0 = Instant::now();
+  e.process_alive(alive_of(&test, 1), false, t0);
+  e.age_member(test.id_ref(), Duration::from_secs(3600));
+  while e.poll_event().is_some() {}
+
+  e.process_suspect(suspect_of(test.id_ref(), e.local_id_ref(), 1), t0);
+  assert_eq!(e.member_liveness(test.id_ref()), Some(State::Suspect));
+
+  // A distinct-source Suspect at a higher incarnation confirms and records 10.
+  e.process_suspect(suspect_of(test.id_ref(), &src_b, 10), t0);
+  assert_eq!(
+    e.node_incarnation(test.id_ref()),
+    Some(10),
+    "a confirming higher-incarnation Suspect advances the stored incarnation"
+  );
+
+  // The suspicion timer is armed; capture its deadline.
+  let armed_deadline = e
+    .poll_timeout()
+    .expect("an armed suspicion exposes a deadline");
+
+  // Alive@2 (< 10) cannot refute: the node stays Suspect and the timer is intact.
+  e.process_alive(alive_of(&test, 2), false, Instant::now());
+  assert_eq!(
+    e.member_liveness(test.id_ref()),
+    Some(State::Suspect),
+    "a stale lower-incarnation Alive must not clear the suspicion"
+  );
+  assert_eq!(
+    e.poll_timeout(),
+    Some(armed_deadline),
+    "a rejected Alive must leave the suspicion timer unchanged"
+  );
+
+  // Alive@11 (> 10) refutes past the recorded maximum and clears the suspicion.
+  e.process_alive(alive_of(&test, 11), false, Instant::now());
+  assert_eq!(
+    e.member_liveness(test.id_ref()),
+    Some(State::Alive),
+    "an Alive past the recorded maximum clears the suspicion"
+  );
+
+  // Expiry variant: the recorded incarnation flows into the synthesized Dead.
+  let mut e2: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(scfg());
+  let t1 = Instant::now();
+  e2.process_alive(alive_of(&test, 1), false, t1);
+  e2.age_member(test.id_ref(), Duration::from_secs(3600));
+  while e2.poll_event().is_some() {}
+  e2.process_suspect(suspect_of(test.id_ref(), e2.local_id_ref(), 1), t1);
+  e2.process_suspect(suspect_of(test.id_ref(), &src_b, 10), t1);
+  e2.drain_broadcasts();
+
+  let deadline = e2.poll_timeout().expect("suspicion deadline expected");
+  e2.handle_timeout(deadline + Duration::from_millis(1));
+  assert_eq!(
+    e2.member_liveness(test.id_ref()),
+    Some(State::Dead),
+    "the expired suspicion marks the node Dead"
+  );
+  assert_eq!(
+    drained_dead_incarnations(&mut e2, test.id_ref()),
+    vec![10],
+    "the synthesized Dead carries the recorded incarnation"
+  );
+}
+
+/// A remote `Dead` folded through `merge_state` (which routes it through
+/// `process_suspect`) advances the stored incarnation of an already-Dead member,
+/// so the anti-entropy path also blocks a stale-Alive resurrection.
+#[test]
+fn suspect_on_dead_records_incarnation() {
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  let test = node("test", 8000);
+
+  let t0 = Instant::now();
+  e.process_alive(alive_of(&test, 1), false, t0);
+  e.age_member(test.id_ref(), Duration::from_secs(3600));
+  e.process_dead(dead_of(test.id_ref(), e.local_id_ref(), 1), t0);
+  assert_eq!(e.member_liveness(test.id_ref()), Some(State::Dead));
+  while e.poll_event().is_some() {}
+
+  // A remote push/pull batch reports the node Dead at incarnation 10.
+  let remote = [pns_of(&test, 10, State::Dead)];
+  e.merge_state(&remote, t0);
+  assert_eq!(
+    e.node_incarnation(test.id_ref()),
+    Some(10),
+    "a remote Dead advances the stored incarnation through anti-entropy"
+  );
+  assert_eq!(
+    e.member_liveness(test.id_ref()),
+    Some(State::Dead),
+    "a remote Dead keeps the member Dead"
+  );
+
+  // A stale Alive@2 is rejected; a newer Alive@11 resurrects.
+  e.process_alive(alive_of(&test, 2), false, Instant::now());
+  assert_eq!(
+    e.member_liveness(test.id_ref()),
+    Some(State::Dead),
+    "a stale lower-incarnation Alive must not resurrect"
+  );
+  e.process_alive(alive_of(&test, 11), false, Instant::now());
+  assert_eq!(
+    e.member_liveness(test.id_ref()),
+    Some(State::Alive),
+    "an Alive past the recorded maximum resurrects"
+  );
+}
+
+/// Equal-incarnation duplicates (redelivered by design) leave the stored
+/// incarnation — already at the maximum — untouched and must NOT bump the
+/// snapshot version, so a gossip duplicate never churns the push/pull cache.
+#[test]
+fn equal_incarnation_duplicates_do_not_bump_snapshot_version() {
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  let dead_peer = node("deadpeer", 8000);
+  let susp_peer = node("susppeer", 8001);
+
+  let t0 = Instant::now();
+  e.process_alive(alive_of(&dead_peer, 1), false, t0);
+  e.process_alive(alive_of(&susp_peer, 1), false, t0);
+  e.age_member(dead_peer.id_ref(), Duration::from_secs(3600));
+  e.age_member(susp_peer.id_ref(), Duration::from_secs(3600));
+
+  // Kill one peer and drive its stored incarnation to 10; suspect the other and
+  // confirm it up to 10. Both advances have already bumped the snapshot.
+  e.process_dead(dead_of(dead_peer.id_ref(), e.local_id_ref(), 1), t0);
+  e.process_dead(dead_of(dead_peer.id_ref(), e.local_id_ref(), 10), t0);
+  e.process_suspect(suspect_of(susp_peer.id_ref(), e.local_id_ref(), 1), t0);
+  e.process_suspect(
+    suspect_of(susp_peer.id_ref(), &SmolStr::new("srcB"), 10),
+    t0,
+  );
+  assert_eq!(e.node_incarnation(dead_peer.id_ref()), Some(10));
+  assert_eq!(e.node_incarnation(susp_peer.id_ref()), Some(10));
+
+  let version_before = e.snapshot_version();
+
+  // Equal-incarnation duplicates: the stored value is already the maximum, so
+  // the strict-`>` guard is a no-op and the snapshot version must not move.
+  e.process_dead(dead_of(dead_peer.id_ref(), e.local_id_ref(), 10), t0);
+  e.process_suspect(
+    suspect_of(susp_peer.id_ref(), &SmolStr::new("srcC"), 10),
+    t0,
+  );
+
+  assert_eq!(
+    e.snapshot_version(),
+    version_before,
+    "an equal-incarnation duplicate must not bump the snapshot version"
   );
 }
 


### PR DESCRIPTION
Addresses #157 finding **P3** — the core-FSM incarnation-monotonicity hole (membership resurrection).

## The bug

A member's stored incarnation was not advanced by higher-incarnation **failure** evidence on three decider paths, while the `Alive` resurrection gate (`process_alive_decided`, `alive_incarnation <= local_incarnation`) compares against that stale stored value. So a killed node could be **resurrected by a stale, lower-incarnation `Alive`**:

`Alive@1 → Dead@1` (stored inc = 1) `→ Dead@10` (dropped without advancing stored inc) `→` a delayed/duplicated `Alive@2` passes `2 > 1` and resurrects a node the `Dead@10` evidence had killed. The bug is inherited from HashiCorp Go memberlist (whose `deadNode`/`suspectNode` have the identical hole); it is fixed here in the port per the project's fix-upstream-bugs rule. Local decider state only — no wire or compatibility change.

## The fix

Stored incarnation is now **monotone**: it records the highest incarnation carried by any admitted evidence (Alive/Suspect/Dead; gossip, probe escalation, suspicion expiry, or push/pull merge) for the member's current instance, even when the evidence causes no state transition. On each of three paths, when `inc > local_inc`, do `set_incarnation(inc)` + `bump_snapshot_version()` — with **no** state change, event, broadcast, or suspicion re-arm:

1. `process_dead` already-Dead/Left branch (additionally guarded on `lifecycle.is_running()` for drain inertness).
2. `process_suspect` has-suspicion confirm branch.
3. `process_suspect` non-Alive branch — **required**: `merge_state` funnels remote Dead/Suspect push/pull entries through `process_suspect`, so without it anti-entropy could never advance a dead member's stored incarnation and the hole would survive the push/pull path.

Two design subtleties (surfaced by the cross-model design review):
- **The snapshot-version bump is load-bearing**: the inbound push/pull response cache rebuilds only when `snapshot_version` changes, so without it the corrected incarnation would never propagate to peers via anti-entropy.
- **Strict `>` (not `>=`)**: at equality the stored value is already the maximum; an unconditional write would bump the version on every gossip *duplicate* (redelivered by design) and churn the push/pull cache.

Preserved behavior: a genuine rejoin still resurrects the standard SWIM way (an `Alive` at an incarnation *above* the recorded maximum passes the gate, learned via gossip/anti-entropy + `refute`); equal-incarnation refutation is unaffected; and the address-change reclaim path (`updates_address`, a fresh generation) is untouched.
