### PR TITLE
fix(reactor): gate the QUIC driver timeout on inbound quiescence and sample the clock fresh (#157 R3/R5)

### DIFF
--- a/memberlist-reactor/src/driver/mod.rs
+++ b/memberlist-reactor/src/driver/mod.rs
@@ -14,6 +14,17 @@ use smallvec::SmallVec;
 #[cfg(any(feature = "tcp", feature = "tls", feature = "quic"))]
 use std::net::SocketAddr;
 
+/// Wall-clock bound on deferring a DUE `handle_timeout` behind capped inbound
+/// paths. Inbound drains roughly FIFO, so the pre-deadline backlog clears
+/// within a bounded number of capped polls (microseconds at gossip datagram
+/// sizes) — the grace exists so a sustained external flood that keeps every
+/// poll capped cannot suppress failure detection, while a burst that merely
+/// truncated one batch never prematurely times out the input it buffered.
+/// Shared by every reliable-plane driver so both gates use the same bound.
+#[cfg(any(feature = "tcp", feature = "tls", feature = "quic"))]
+pub(crate) const TIMEOUT_STALENESS_GRACE: core::time::Duration =
+  core::time::Duration::from_millis(5);
+
 /// Build a fully-resolved join's reply from its reached set and requested count.
 /// A non-empty set resolves `Ok(set)`; an empty set is the all-failed case,
 /// surfacing `JoinFailed { requested, contacted: 0 }` with an empty

--- a/memberlist-reactor/src/driver/quic/mod.rs
+++ b/memberlist-reactor/src/driver/quic/mod.rs
@@ -50,7 +50,7 @@ use crate::{
     Command, JoinCmd, JoinReply, LeaveCmd, PingCmd, QueueUserBroadcastCmd, SendReliableCmd,
     SendUserCmd, SetAckPayloadCmd, SetLocalStateCmd, ShutdownCmd, UpdateNodeMetadataCmd,
   },
-  driver::join_reply,
+  driver::{TIMEOUT_STALENESS_GRACE, join_reply},
   error::{Error, JoinFailed, UserDialBacklogFull},
   observation::observation_payload_bytes,
   shared::Shared,
@@ -216,6 +216,11 @@ where
   transmit_batch: usize,
   timer: Option<Pin<Box<R::Sleep>>>,
   timer_deadline: Option<Instant>,
+  /// Anchored the first poll a DUE deadline is held back by a capped inbound
+  /// path; `handle_timeout` force-fires once
+  /// [`TIMEOUT_STALENESS_GRACE`] has elapsed since this anchor, so a
+  /// sustained inbound flood cannot suppress failure detection.
+  timeout_stall_since: Option<Instant>,
   idle_wake: Duration,
   /// CIDR transport-source filter: a UDP packet (QUIC handshake or gossip
   /// datagram) from a blocked source IP is dropped before the machine sees it, so
@@ -268,6 +273,7 @@ where
       transmit_batch,
       timer: None,
       timer_deadline: None,
+      timeout_stall_since: None,
       idle_wake: Duration::from_secs(1),
       cidr_policy,
     }
@@ -1160,40 +1166,86 @@ where
       progress = true;
     }
     // A saturated batch (recv_n == recv_batch) means more datagrams may still be
-    // queued in the socket; self-wake so the next poll drains the rest.
-    if recv_n == this.recv_batch {
-      more = true;
-    }
+    // queued in the socket; self-wake so the next poll drains the rest. Kept in
+    // scope for the timeout gate below.
+    let recv_capped = recv_n == this.recv_batch;
+    more |= recv_capped;
 
     // Drain machine surfaces (bounded per surface).
     let (drained, drain_more) = this.drain_surfaces(cx);
     progress |= drained;
     more |= drain_more;
 
-    // Timer: advance membership time on schedule. A past-due deadline fires
-    // `handle_timeout` now; otherwise (re)arm and poll the sleep. This runs every
-    // poll regardless of the receive batch: `drain_surfaces` above decoded the
-    // inbound ingress to empty (a datagram-carried probe Ack is already applied),
-    // and the probe FSM anchors success on an absolute `failure_deadline`, so an
-    // Ack decoded slightly later still rescues the probe regardless of
-    // handle_ack-vs-handle_timeout ordering — no recv-saturation gate is needed.
+    // Timer, gated on INBOUND quiescence. Two deadline classes reach
+    // `handle_timeout`, and only one needs the gate:
+    //
+    // The PROBE class is ordering-independent. `complete_probe_success` rejects
+    // a late-decoded Ack against the probe FSM's absolute `failure_deadline`
+    // exactly as `handle_timeout` would, so no driver ordering (a gate, or
+    // draining the socket before the timer) can rescue a probe Ack whose decode
+    // crosses that cutoff — the QUIC / UDP gossip path carries no per-datagram
+    // arrival timestamp to reinstate. A sustained flood that pushes a probe Ack's
+    // decode past the deadline is therefore a bounded decode-lag capacity limit,
+    // absorbed by Lifeguard / awareness refutation, NOT a gate-fixable ordering
+    // bug — so unbounded drain-before-timer stays forbidden for probes.
+    //
+    // The gate exists for the ORDERING-DEPENDENT classes — suspicion expiry,
+    // indirect-probe forwards, and stream intents — whose refuting or completing
+    // inputs (e.g. an `Alive(inc+1)` clearing a suspicion) carry NO wall-clock
+    // cutoff. Such an input can sit kernel-buffered behind a saturated recv
+    // batch, and firing `handle_timeout` past it would broadcast a false `Dead`
+    // cluster-wide. The super-machine's `handle_timeout` contract presumes a
+    // driver that defers on inbound quiescence; a DUE deadline therefore DEFERS
+    // while the recv batch is capped (the `more` self-wake re-polls and each
+    // capped batch drains FIFO), bounded by a wall-clock staleness grace so a
+    // sustained flood cannot suppress failure detection past it.
+    //
+    // `recv_capped` is the ONLY inbound backlog term with a QUIC analog: unlike
+    // the stream driver, `handle_udp` never backpressures (an over-cap datagram
+    // is dropped, not deferred), `drain_surfaces` empties the memberlist ingress
+    // every poll, and reliable-plane residue is self-scheduled by the machine's
+    // own `poll_timeout` anchors — so none of the stream terms
+    // (recv_gated / ingress_capped / inbound_capped) has a counterpart here.
+    let inbound_backlog = recv_capped;
+    // Sample the clock FRESH for the timeout decision: the recv loop and
+    // `drain_surfaces` above take real time, and a deadline that was in the
+    // future at poll entry may have been crossed during them — evaluating
+    // against the stale entry `now` would route that crossed deadline to the
+    // armed-sleep arm below, which must never fire.
+    let decision_now = Instant::now();
     let target = match this.endpoint.poll_timeout() {
-      Some(d) => d.min(now + this.idle_wake),
-      None => now + this.idle_wake,
+      Some(d) => d.min(decision_now + this.idle_wake),
+      None => decision_now + this.idle_wake,
     };
-    if target <= now {
-      this.endpoint.handle_timeout(now);
-      progress = true;
+    if target <= decision_now {
+      if inbound_backlog {
+        this.timeout_stall_since.get_or_insert(decision_now);
+      }
+      let grace_elapsed = this
+        .timeout_stall_since
+        .is_some_and(|t| decision_now.saturating_duration_since(t) >= TIMEOUT_STALENESS_GRACE);
+      if !inbound_backlog || grace_elapsed {
+        this.endpoint.handle_timeout(decision_now);
+        this.timeout_stall_since = None;
+        progress = true;
+      }
+      // Due (fired or deferred): self-wake either way — a fired deadline may
+      // have queued transmits/events this pass did not drain, and a deferred
+      // one needs the re-poll to drain the backlog toward quiescence.
       more = true;
     } else {
-      this.arm_timer(target, now);
+      this.timeout_stall_since = None;
+      this.arm_timer(target, decision_now);
       if let Some(timer) = this.timer.as_mut()
         && timer.as_mut().poll(cx).is_ready()
       {
-        this.endpoint.handle_timeout(Instant::now());
+        // The sleep elapsed at/just after arming (the deadline crossed between
+        // the fresh sample above and this poll). Do NOT fire here — every
+        // `handle_timeout` goes through the gated due branch, which the next
+        // poll's fresh sample reaches — just clear the consumed sleep and
+        // self-wake.
         this.timer = None;
         this.timer_deadline = None;
-        progress = true;
         more = true;
       }
     }

--- a/memberlist-reactor/src/driver/quic/tests.rs
+++ b/memberlist-reactor/src/driver/quic/tests.rs
@@ -4,7 +4,7 @@ use std::{
   thread,
 };
 
-use agnostic::{net::Net, tokio::TokioRuntime};
+use agnostic::{RuntimeLite, net::Net, tokio::TokioRuntime};
 #[cfg(checksum)]
 use memberlist_proto::ChecksumOptions;
 #[cfg(compression)]
@@ -13,10 +13,11 @@ use memberlist_proto::CompressionOptions;
 use memberlist_proto::EncryptionOptions;
 use memberlist_proto::{
   Node, QuicOptions, UnreliableTransport,
+  codec::{EncodeOptions, encode_outgoing},
   config::EndpointOptions,
   endpoint::Endpoint,
   event::{Reliability, UserPacket},
-  typed::{NodeState, State},
+  typed::{Alive, Message, NodeState, State, Suspect},
 };
 use quinn_proto::{ClientConfig, EndpointConfig, ServerConfig, TransportConfig};
 use rustls::RootCertStore;
@@ -977,5 +978,347 @@ async fn reliable_over_cap_repeated_bounded_and_per_peer() {
   assert!(
     matches!(rx.try_recv(), Ok(None)),
     "a send to a peer with capacity is admitted and parks, not refused"
+  );
+}
+
+/// Build a `QuicDriver` with an explicit `recv_batch` and a preparation hook run
+/// on the endpoint before the driver is built. The periodic schedulers are left
+/// OFF (no `start_scheduling`) so a staged suspicion timer is the machine's ONLY
+/// deadline, and the suspicion timeout is shortened via `suspicion_mult = 1` and
+/// the caller's `probe_interval` (its milliseconds are the suspicion timeout at a
+/// two-node cluster's unit node-scale), so a test can sleep to the due instant
+/// quickly.
+async fn build_driver_with(
+  obs_cap: usize,
+  obs_budget: Option<u64>,
+  recv_batch: usize,
+  probe_interval: Duration,
+  prep: impl FnOnce(&mut QuicEndpoint<SmolStr, rand::rngs::StdRng>),
+) -> (
+  QuicDriver<SmolStr, TokioRuntime>,
+  flume::Receiver<Event<SmolStr, SocketAddr>>,
+  Arc<Shared<SmolStr>>,
+  Arc<AtomicU64>,
+) {
+  let socket = <TokioNet as Net>::UdpSocket::bind("127.0.0.1:0")
+    .await
+    .expect("bind gossip socket");
+  let ep = Endpoint::new(
+    EndpointOptions::new(
+      SmolStr::new("qdrv"),
+      "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+    )
+    .with_suspicion_mult(1)
+    .with_probe_interval(probe_interval),
+    crate::gossip_rng().expect("test: OS entropy"),
+  );
+  let mut endpoint = QuicEndpoint::new(ep, self_trusted_quic());
+  prep(&mut endpoint);
+  let shared = Arc::new(Shared::new(snapshot_of(endpoint.endpoint_ref())));
+  let obs_payload_bytes = Arc::new(AtomicU64::new(0));
+  let (obs_tx, obs_rx) = flume::bounded(obs_cap);
+  let driver = QuicDriver::<SmolStr, TokioRuntime>::new(
+    endpoint,
+    socket,
+    shared.clone(),
+    recv_batch,
+    8,
+    obs_tx,
+    obs_payload_bytes.clone(),
+    obs_budget,
+    None,
+    #[cfg(feature = "cidr")]
+    None,
+    #[cfg(not(feature = "cidr"))]
+    (),
+  );
+  (driver, obs_rx, shared, obs_payload_bytes)
+}
+
+/// Stage a suspicion timer on a fresh peer: the machine's next deadline is its
+/// suspicion timeout (a fixed multiple of the probe interval, no random
+/// stagger), and its fire is OBSERVABLE as the peer turning `Dead` — so a test
+/// can distinguish a deferred timeout from a fired one by member state rather
+/// than by driver bookkeeping alone.
+fn stage_suspicion(
+  endpoint: &mut QuicEndpoint<SmolStr, rand::rngs::StdRng>,
+  id: &str,
+  peer_addr: SocketAddr,
+) {
+  let now = Instant::now();
+  endpoint.handle_alive(
+    peer_addr,
+    Alive::new(1, Node::new(SmolStr::new(id), peer_addr)),
+    now,
+  );
+  endpoint.handle_suspect(
+    peer_addr,
+    Suspect::new(1, SmolStr::new(id), SmolStr::new("qdrv")),
+    now,
+  );
+}
+
+/// The peer's gossip-tracked liveness, straight from the machine.
+fn peer_state(driver: &QuicDriver<SmolStr, TokioRuntime>, id: &str) -> Option<State> {
+  driver
+    .endpoint
+    .endpoint_ref()
+    .member_liveness(&SmolStr::new(id))
+}
+
+/// The plain gossip-frame bytes of an `Alive(inc)` for `id`@`peer_addr`, encoded
+/// through the PUBLIC codec exactly as the driver's outbound path emits gossip.
+/// With no gossip transforms configured on the default endpoint the inbound
+/// ingress path (`unwrap_transforms` / `decrypt_gossip`, then `decode_incoming`
+/// and `parse_messages`) round-trips it back to the same `Alive`, so a real UDP
+/// datagram carrying these bytes decodes and refutes the suspicion.
+fn refuting_alive_datagram(id: &str, peer_addr: SocketAddr, inc: u32) -> Vec<u8> {
+  let msg: Message<SmolStr, SocketAddr> =
+    Message::Alive(Alive::new(inc, Node::new(SmolStr::new(id), peer_addr)));
+  encode_outgoing(&msg, &EncodeOptions::new(None))
+    .expect("a well-formed Alive encodes")
+    .to_vec()
+}
+
+/// A DUE suspicion deadline must not fire while the gossip recv is capped: a
+/// refuting `Alive(inc+1)` that arrived before the deadline can still be
+/// buffered in the kernel socket behind a truncated batch, and firing past it
+/// would declare a live peer `Dead` cluster-wide. The pump anchors the deferral
+/// and self-wakes to drain instead; on the next poll the buffered `Alive`
+/// decodes and refutes the suspicion, so the peer ends `Alive`, never `Dead`.
+/// Deferral versus firing is read off the MACHINE (member state), so a
+/// `handle_timeout` call that is silently dropped or relocated past the gate
+/// fails this test rather than merely re-shuffling driver bookkeeping.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn due_timeout_defers_then_a_buffered_alive_refutes_the_suspicion() {
+  let peer_addr: SocketAddr = "127.0.0.1:39990".parse().unwrap();
+  // recv_batch == 1: every poll that reads a datagram is capped, so the two
+  // preloaded datagrams surface one per poll.
+  let (mut driver, _obs_rx, _shared, _bytes) =
+    build_driver_with(64, None, 1, Duration::from_millis(40), |endpoint| {
+      stage_suspicion(endpoint, "capped-peer", peer_addr);
+    })
+    .await;
+
+  // Let the suspicion deadline fall due while the pump is unpolled — the machine
+  // is passive, so the peer stays Suspect until a poll fires it.
+  let due_at = driver
+    .endpoint
+    .poll_timeout()
+    .expect("the staged suspicion arms a machine deadline");
+  TokioRuntime::sleep(due_at.saturating_duration_since(Instant::now()) + Duration::from_millis(20))
+    .await;
+
+  // Preload the kernel FIFO: one garbage datagram (dropped by classification, but
+  // still counts toward the batch) THEN the refuting Alive, from the same sender
+  // so loopback delivers them in order.
+  let gossip_addr = driver
+    .socket
+    .as_ref()
+    .expect("gossip socket held")
+    .local_addr()
+    .expect("gossip local addr");
+  let tx = <TokioNet as Net>::UdpSocket::bind("127.0.0.1:0")
+    .await
+    .expect("bind flood socket");
+  tx.send_to(&[0x20u8; 24], gossip_addr)
+    .await
+    .expect("garbage send");
+  tx.send_to(
+    &refuting_alive_datagram("capped-peer", peer_addr, 2),
+    gossip_addr,
+  )
+  .await
+  .expect("alive send");
+  // Let the kernel surface both datagrams to the receiving socket.
+  TokioRuntime::sleep(Duration::from_millis(50)).await;
+
+  // Poll 1 reads only the garbage (batch capped at 1) — the due deadline DEFERS.
+  let _ = poll_once(&mut driver);
+  assert!(
+    driver.timeout_stall_since.is_some(),
+    "a due deadline behind a capped recv batch must defer, not fire"
+  );
+  assert_eq!(
+    peer_state(&driver, "capped-peer"),
+    Some(State::Suspect),
+    "the deferred fire must leave the machine untouched: the suspicion has not \
+     completed while the recv batch is capped"
+  );
+
+  // Poll 2 (well inside the 5ms grace) reads the Alive, which decodes and refutes
+  // the suspicion BEFORE the timeout region runs — the peer is now Alive, so the
+  // deadline can never declare it Dead.
+  let _ = poll_once(&mut driver);
+  assert_eq!(
+    peer_state(&driver, "capped-peer"),
+    Some(State::Alive),
+    "the buffered Alive refutes the suspicion the deferral kept open — the peer \
+     is Alive, never Dead"
+  );
+}
+
+/// The deferral is bounded: a sustained flood that keeps every poll capped
+/// cannot suppress `handle_timeout` past the staleness grace — the due deadline
+/// force-fires even with the backlog still standing, observable as the suspicion
+/// completing (the peer turns `Dead`) with the socket still saturated.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn due_timeout_force_fires_past_the_staleness_grace() {
+  let peer_addr: SocketAddr = "127.0.0.1:39991".parse().unwrap();
+  let (mut driver, _obs_rx, _shared, _bytes) =
+    build_driver_with(64, None, 8, Duration::from_millis(40), |endpoint| {
+      stage_suspicion(endpoint, "flooded-peer", peer_addr);
+    })
+    .await;
+
+  let due_at = driver
+    .endpoint
+    .poll_timeout()
+    .expect("the staged suspicion arms a machine deadline");
+  TokioRuntime::sleep(due_at.saturating_duration_since(Instant::now()) + Duration::from_millis(20))
+    .await;
+
+  let gossip_addr = driver
+    .socket
+    .as_ref()
+    .expect("gossip socket held")
+    .local_addr()
+    .expect("gossip local addr");
+  let tx = <TokioNet as Net>::UdpSocket::bind("127.0.0.1:0")
+    .await
+    .expect("bind flood socket");
+
+  // Anchor the deferral with a first capped poll: the due suspicion is held.
+  for _ in 0..24 {
+    tx.send_to(&[0x20u8; 24], gossip_addr)
+      .await
+      .expect("flood send");
+  }
+  TokioRuntime::sleep(Duration::from_millis(50)).await;
+  let _ = poll_once(&mut driver);
+  assert!(
+    driver.timeout_stall_since.is_some(),
+    "the flood must anchor a deferral first"
+  );
+  assert_eq!(
+    peer_state(&driver, "flooded-peer"),
+    Some(State::Suspect),
+    "the anchored deferral must hold the due suspicion open"
+  );
+
+  // Keep the socket saturated past the grace, then poll: the due deadline must
+  // force-fire despite the standing backlog.
+  for _ in 0..24 {
+    tx.send_to(&[0x20u8; 24], gossip_addr)
+      .await
+      .expect("flood send");
+  }
+  TokioRuntime::sleep(TIMEOUT_STALENESS_GRACE + Duration::from_millis(10)).await;
+  let _ = poll_once(&mut driver);
+  assert_eq!(
+    peer_state(&driver, "flooded-peer"),
+    Some(State::Dead),
+    "a sustained flood must not suppress the deadline past the staleness grace: \
+     the force-fire completes the suspicion"
+  );
+  assert!(
+    driver.timeout_stall_since.is_none(),
+    "the force-fire clears the deferral anchor"
+  );
+}
+
+/// The armed-sleep arm is machine-neutral: when the sleep polls Ready, the pump
+/// clears it and self-wakes — it never touches the endpoint. Entering that arm
+/// requires a STABLE future target (a machine deadline below the idle wake), else
+/// `arm_timer` replaces the staged sleep with a fresh one before it is ever
+/// polled; a staged suspicion supplies one, and swapping the armed sleep for an
+/// elapsed one while keeping `timer_deadline` drives the arm deterministically.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ready_sleep_is_cleared_without_touching_the_machine() {
+  let peer_addr: SocketAddr = "127.0.0.1:39992".parse().unwrap();
+  // A 1s probe interval puts the suspicion deadline ~1s out — comfortably beyond
+  // this test's microsecond-scale polls and the 20ms swap wait, yet below the
+  // idle wake set next.
+  let (mut driver, _obs_rx, _shared, _bytes) =
+    build_driver_with(64, None, 8, Duration::from_secs(1), |endpoint| {
+      stage_suspicion(endpoint, "suspect-peer", peer_addr);
+    })
+    .await;
+  // Keep the idle wake above the suspicion deadline so the machine deadline is
+  // the arm target — a nearer idle target recomputes fresh every poll and would
+  // replace the staged sleep.
+  driver.idle_wake = Duration::from_secs(600);
+
+  // Quiescent poll arms the sleep toward the machine deadline.
+  let _ = poll_once(&mut driver);
+  let armed = driver.timer_deadline;
+  let machine_deadline = driver.endpoint.poll_timeout();
+  assert_eq!(
+    armed, machine_deadline,
+    "with a machine deadline below the idle wake, the timer arms toward it"
+  );
+  let target = armed.expect("the quiescent poll arms the sleep");
+
+  // Swap in an elapsed sleep, keeping the recorded deadline: the next poll
+  // recomputes the SAME stable target, so `arm_timer` keeps this sleep and polls
+  // it Ready — the exact shape of a deadline crossing between the fresh clock
+  // sample and the timer poll. The wait lets the zero-duration sleep pass the
+  // timer wheel's coarse elapse check while the suspicion deadline stays future.
+  driver.timer = Some(Box::pin(TokioRuntime::sleep(Duration::ZERO)));
+  TokioRuntime::sleep(Duration::from_millis(20)).await;
+  assert!(
+    Instant::now() < target,
+    "precondition: the machine deadline is still in the future"
+  );
+  let _ = poll_once(&mut driver);
+
+  assert!(
+    driver.timer.is_none() && driver.timer_deadline.is_none(),
+    "the ready sleep is consumed by the armed-sleep arm, not replaced"
+  );
+  assert_eq!(
+    driver.endpoint.poll_timeout(),
+    machine_deadline,
+    "the armed-sleep arm must not fire the machine timer: the deadline is \
+     untouched and fires later through the gated due branch"
+  );
+  assert!(
+    driver.timeout_stall_since.is_none(),
+    "clearing a ready sleep must not anchor a deferral"
+  );
+}
+
+/// The inbound-quiescence gate is sound only if the machine timer can fire
+/// nowhere else: every `handle_timeout` must route through the single gated
+/// decision (fresh clock sample, backlog deferral, staleness grace). Pin that
+/// structurally — the pump source carries exactly one call site AND it sits
+/// inside the gated block, so the call can neither gain a sibling nor be
+/// relocated to an arm (the ready-sleep arm in particular) that bypasses the
+/// gate.
+#[test]
+fn the_pump_fires_timeouts_only_inside_the_gated_branch() {
+  let src = include_str!("mod.rs");
+  assert_eq!(
+    src.matches(".handle_timeout(").count(),
+    1,
+    "a second handle_timeout call site can fire a due deadline past capped \
+     inbound backlog holding a deadline-refuting input"
+  );
+  let gate = src
+    .find("if !inbound_backlog || grace_elapsed")
+    .expect("the gated due decision exists in the pump");
+  // The gated block holds straight-line statements only, so its first `}` is its
+  // closing brace; the sole call must sit between the condition and it.
+  let gate_close = gate
+    + src[gate..]
+      .find('}')
+      .expect("the gated due decision block closes");
+  let call = src
+    .find(".handle_timeout(")
+    .expect("the single call site exists");
+  assert!(
+    gate < call && call < gate_close,
+    "the sole handle_timeout call must sit inside the gated due decision — \
+     anywhere else can fire past capped inbound backlog"
   );
 }

--- a/memberlist-reactor/src/driver/stream/mod.rs
+++ b/memberlist-reactor/src/driver/stream/mod.rs
@@ -74,7 +74,7 @@ use crate::{
     Command, JoinCmd, JoinReply, LeaveCmd, PingCmd, QueueUserBroadcastCmd, SendReliableCmd,
     SendUserCmd, SetAckPayloadCmd, SetLocalStateCmd, ShutdownCmd, UpdateNodeMetadataCmd,
   },
-  driver::join_reply,
+  driver::{TIMEOUT_STALENESS_GRACE, join_reply},
   error::{Error, JoinFailed},
   observation::observation_payload_bytes,
   shared::Shared,
@@ -85,14 +85,6 @@ use smallvec::SmallVec;
 
 /// IP-layer UDP payload maximum; caps the per-recv gossip buffer.
 const GOSSIP_RECV_BUF_MAX: usize = 65507;
-
-/// Wall-clock bound on deferring a DUE `handle_timeout` behind capped inbound
-/// paths. Inbound drains roughly FIFO, so the pre-deadline backlog clears
-/// within a bounded number of capped polls (microseconds at gossip datagram
-/// sizes) — the grace exists so a sustained external flood that keeps every
-/// poll capped cannot suppress failure detection, while a burst that merely
-/// truncated one batch never prematurely times out the input it buffered.
-const TIMEOUT_STALENESS_GRACE: core::time::Duration = core::time::Duration::from_millis(5);
 
 /// The largest the encrypted wrapper can inflate a gossip datagram, or `0` when
 /// no encryption backend is built in. The proto const exists only under an


### PR DESCRIPTION
Addresses #157 findings **R3** and **R5** — the reactor QUIC driver's per-poll timeout region.

## The bugs

The reactor QUIC driver fired `handle_timeout` **unconditionally** on a clock sampled once at poll entry, before the recv loop and `drain_surfaces`:

- **R5 (stale clock):** a deadline that was in the future at poll entry but crossed during the recv/decode work failed `target <= now_entry`, took the arm-sleep branch, and `arm_timer` slept `target - now_entry` from an already-past instant → overshoot, precisely under load. The armed-sleep branch also fired `handle_timeout` inline, bypassing the gate below.
- **R3 (no inbound-quiescence gate):** with no recv-saturation gate, a due deadline fired even while a valid inbound datagram sat kernel-buffered beyond `recv_batch`. The QUIC super-machine's own `handle_timeout` contract already **presumes** a driver that gates on inbound quiescence (the stream driver has always had this gate); the QUIC driver never implemented it, and its comment justified the omission by over-generalizing a probe-only property.

**The two deadline classes (the design correction):**
- The **probe** class is ordering-*independent*: `complete_probe_success` rejects a late-*decoded* Ack (`now >= failure_deadline`) via its own path — identical to `handle_timeout` firing — so no driver ordering fix can change a probe outcome. The false-`PingFailed`-under-flood is a decode-lag capacity limit (the UDP path has no arrival timestamps), absorbed by Lifeguard refutation; it is deliberately **not** what this gate targets. "Don't drain-socket-before-timer" stands for probes.
- The **refutable** classes — suspicion expiry, indirect forwards, stream intents — are ordering-*dependent*: their refuting/completing inputs (e.g. `Alive(inc+1)`) carry **no** wall-clock cutoff, so a refutation kernel-buffered behind a saturated batch loses the race to an unconditional `handle_timeout` → **false `Dead` broadcast** cluster-wide. This is the real, external-flood-reachable defect.

## The fix

- Sample a **fresh `decision_now`** for the timeout decision (R5), and the armed-sleep branch no longer fires inline — it clears the sleep and self-wakes so every fire routes through the gated due branch (exactly one `handle_timeout` call site now).
- **Gate `handle_timeout` on inbound quiescence** (R3): when `recv_capped` (`recv_n == recv_batch`), a due deadline **defers** (self-waking to drain another batch), bounded by a 5 ms `TIMEOUT_STALENESS_GRACE` so a sustained flood can never suppress failure detection. `recv_capped` is the sole QUIC backlog term — the other three stream terms provably have no QUIC analog (`handle_udp` never backpressures; `drain_surfaces` empties `mem_ingress` every poll; reliable-plane residue is self-scheduled by the machine's own `poll_timeout` anchors). `TIMEOUT_STALENESS_GRACE` is hoisted to the shared `driver` module.
- The over-generalized comment is rewritten to the two-class truth, citing the super-machine contract.
