### PR TITLE
fix(driver): close the #157 low-severity lifecycle and ordering gaps (compio + reactor)

### DIFF
--- a/memberlist-compio/src/bridge/mod.rs
+++ b/memberlist-compio/src/bridge/mod.rs
@@ -151,16 +151,25 @@ use crate::driver::{
 ///   fires the cancel arm nor drops a write mid-flight — the queued `Bytes`
 ///   then `Close` in `out_rx` flush first.
 /// - `inbound_tx`: bytes / eof / error events the driver consumes.
-/// - `close_timeout`: no-progress (idle) bound on a drain. A graceful Close has
-///   no remaining cancel path, so a peer that stopped reading would wedge the
-///   drain forever; if a single partial write makes NO progress for this long
-///   the drain is abandoned and the bridge tears down (RST). A peer that keeps
-///   reading — even slowly enough that the whole frame outlasts `close_timeout`
-///   — resets the deadline on every chunk and never trips it.
+/// - `stream_timeout`: no-progress (idle) bound governing an ACTIVE exchange's
+///   writes (the both-halves-live arm). This is the machine's per-exchange
+///   deadline: the coordinator arms the same `stream_timeout` and fires the
+///   `Abort` that preempts a stalled active write, so bounding the write by it
+///   keeps the driver-side idle guard from tripping ahead of that `Abort`. A
+///   `close_timeout` shorter than `stream_timeout` therefore cannot truncate an
+///   in-progress exchange.
+/// - `close_timeout`: no-progress (idle) bound on the POST-half-close drain (the
+///   read-closed arm). Once the peer has FIN'd, the reply is drained toward
+///   teardown with no remaining cancel path, so a peer that stopped reading would
+///   wedge the drain forever; if a single partial write makes NO progress for
+///   this long the drain is abandoned and the bridge tears down (RST). A peer
+///   that keeps reading — even slowly enough that the whole frame outlasts
+///   `close_timeout` — resets the deadline on every chunk and never trips it.
 ///
 /// All `Sender::send_async` failures are ignored with a justification: if
 /// the driver dropped the inbound receiver we are already shutting down
 /// and the event can be discarded.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn bridge_task<S>(
   stream: S,
   eid: ExchangeId,
@@ -168,6 +177,7 @@ pub(crate) async fn bridge_task<S>(
   cancel_rx: futures_channel::oneshot::Receiver<()>,
   inbound_tx: Sender<BridgeInbound>,
   recv_buf_len: usize,
+  stream_timeout: Duration,
   close_timeout: Duration,
 ) where
   S: Splittable,
@@ -299,14 +309,15 @@ pub(crate) async fn bridge_task<S>(
             continue;
           }
           // Race each partial write against the cancel future AND a fresh
-          // `close_timeout`. An explicit abort preempts a write already in
-          // flight; the idle timeout bounds a post-Close drain whose peer
-          // stopped reading (no remaining cancel path, else it blocks forever,
-          // leaking the bridge and socket). `cancel_fut` resolves only on a
-          // real abort, so a graceful Close never drops a progressing write
-          // mid-flight; progress resets the deadline, so only a peer making NO
-          // progress for the full `close_timeout` times out.
-          match write_cancellable(&mut write_half, bytes, &mut cancel_fut, close_timeout).await {
+          // `stream_timeout`. This is an ACTIVE exchange: the machine arms the
+          // same `stream_timeout` and fires the `Abort` that resolves
+          // `cancel_fut`, so the idle bound must match it — a shorter
+          // `close_timeout` would truncate a live exchange whose peer merely
+          // reads slowly. `cancel_fut` resolves only on a real abort, so a
+          // graceful Close never drops a progressing write mid-flight; progress
+          // resets the deadline, so only a peer making NO progress for the full
+          // `stream_timeout` times out.
+          match write_cancellable(&mut write_half, bytes, &mut cancel_fut, stream_timeout).await {
             WriteStatus::Aborted | WriteStatus::TimedOut => break,
             WriteStatus::Wrote(res) => {
               if let Err(err) = res {

--- a/memberlist-compio/src/bridge/tests.rs
+++ b/memberlist-compio/src/bridge/tests.rs
@@ -93,6 +93,7 @@ async fn graceful_close_drains_queued_bytes_before_exit() {
     inbound_tx,
     64,
     Duration::from_secs(60),
+    Duration::from_secs(60),
   ));
 
   // Drop the handle: `cancel_tx` disconnects (the graceful-Close shape).
@@ -150,6 +151,7 @@ async fn explicit_abort_discards_queued_bytes() {
     cancel_rx,
     inbound_tx,
     64,
+    Duration::from_secs(60),
     Duration::from_secs(60),
   ));
 
@@ -213,6 +215,7 @@ async fn explicit_abort_preempts_in_flight_write() {
     cancel_rx,
     inbound_tx,
     64,
+    Duration::from_secs(60),
     Duration::from_secs(60),
   ));
 
@@ -278,6 +281,7 @@ async fn graceful_close_drain_bounded_by_close_timeout_when_peer_stalls() {
     cancel_rx,
     inbound_tx,
     64,
+    Duration::from_secs(60),
     close_timeout,
   ));
 
@@ -437,6 +441,7 @@ async fn recv_forwards_peer_bytes_to_driver() {
     inbound_tx,
     64,
     Duration::from_secs(60),
+    Duration::from_secs(60),
   ));
 
   // The peer writes a request; the bridge's recv `Ok(n)` arm forwards it.
@@ -492,6 +497,7 @@ async fn read_closed_mode_writes_late_response_then_closes() {
     cancel_rx,
     inbound_tx,
     64,
+    Duration::from_secs(60),
     Duration::from_secs(60),
   ));
 
@@ -553,6 +559,7 @@ async fn shutdown_write_half_closes_peer_read_side() {
     cancel_rx,
     inbound_tx,
     64,
+    Duration::from_secs(60),
     Duration::from_secs(60),
   ));
 
@@ -619,6 +626,68 @@ async fn explicit_abort_preempts_stalled_write() {
   );
 }
 
+/// A `close_timeout` shorter than `stream_timeout` must NOT abort an ACTIVE
+/// (both-halves-live) write. A live exchange is governed by the machine's
+/// `stream_timeout` (it arms that deadline and fires the `Abort` that preempts a
+/// stalled write), so the both-halves-live arm bounds its writes by
+/// `stream_timeout`; the shorter graceful-drain `close_timeout` is reserved for
+/// the post-half-close drain. Here the peer never reads and never half-closes, so
+/// the write stalls in the active arm — and must survive well past
+/// `close_timeout`.
+#[cfg_attr(
+  windows,
+  ignore = "Windows buffers the oversized response in chunks; the zero-window stall never forms"
+)]
+#[compio::test]
+async fn active_write_governed_by_stream_timeout_not_close_timeout() {
+  // The client is held open, never reads, and never half-closes — so the bridge
+  // stays in both-halves-live mode with a stalled write.
+  let (server, _client) = loopback_pair().await;
+  let eid = fresh_eid();
+  let (out_tx, out_rx) = lochan::mpsc::unbounded::<BridgeOut>();
+  let (cancel_tx, cancel_rx) = futures_channel::oneshot::channel::<()>();
+  let (inbound_tx, _inbound_rx) = lochan::mpsc::unbounded::<BridgeInbound>();
+
+  // A SHORT close_timeout and a LONG stream_timeout: the pre-fix code bounded the
+  // active write by `close_timeout` and would tear down at ~150ms.
+  let close_timeout = Duration::from_millis(150);
+  let stream_timeout = Duration::from_secs(4);
+
+  // A response far larger than any socket buffer: with the peer never reading, the
+  // window collapses to zero and the write stalls once the buffers fill.
+  let response = vec![0x5Au8; 16 * 1024 * 1024];
+
+  let bridge = compio::runtime::spawn(bridge_task(
+    server,
+    eid,
+    out_rx,
+    cancel_rx,
+    inbound_tx,
+    64,
+    stream_timeout,
+    close_timeout,
+  ));
+
+  // Queue the oversized response; keep `out_tx` and `cancel_tx` alive so the ONLY
+  // teardown that could fire is a write timeout (no Close disconnect, no abort).
+  out_tx
+    .try_send(BridgeOut::Bytes(response))
+    .expect("queue oversized response");
+
+  // Wait well past `close_timeout`, comfortably short of `stream_timeout`: the
+  // bridge must still be alive — the active write was NOT aborted early.
+  compio::time::sleep(close_timeout * 4).await;
+  assert!(
+    !bridge.is_finished(),
+    "an active both-halves-live write must be governed by stream_timeout, not \
+       aborted at the shorter close_timeout"
+  );
+
+  // Clean up deterministically: an explicit abort preempts the stalled write.
+  cancel_tx.send(()).expect("signal explicit abort");
+  bridge.await.expect("bridge exits on the abort");
+}
+
 /// A stream whose write half always fails and whose read half blocks forever —
 /// drives the byte-mover's write-error arm without racing a peer FIN.
 struct FailingStream;
@@ -677,6 +746,7 @@ async fn write_failure_surfaces_bridge_error() {
     inbound_tx,
     64,
     Duration::from_secs(60),
+    Duration::from_secs(60),
   ));
 
   out_tx
@@ -718,6 +788,7 @@ async fn out_sender_drop_without_close_sends_eof() {
     cancel_rx,
     inbound_tx,
     64,
+    Duration::from_secs(60),
     Duration::from_secs(60),
   ));
 
@@ -778,6 +849,7 @@ async fn read_closed_write_failure_surfaces_error() {
     inbound_tx,
     64,
     Duration::from_secs(60),
+    Duration::from_secs(60),
   ));
 
   // The immediate FIN surfaces an Eof and enters read-closed mode.
@@ -827,6 +899,7 @@ async fn bytes_after_shutdown_write_are_discarded() {
     cancel_rx,
     inbound_tx,
     64,
+    Duration::from_secs(60),
     Duration::from_secs(60),
   ));
 

--- a/memberlist-compio/src/bridge/tests.rs
+++ b/memberlist-compio/src/bridge/tests.rs
@@ -265,7 +265,7 @@ async fn graceful_close_drain_bounded_by_close_timeout_when_peer_stalls() {
   let eid = fresh_eid();
   let (out_tx, out_rx) = lochan::mpsc::unbounded::<BridgeOut>();
   let (cancel_tx, cancel_rx) = futures_channel::oneshot::channel::<()>();
-  let (inbound_tx, _inbound_rx) = lochan::mpsc::unbounded::<BridgeInbound>();
+  let (inbound_tx, mut inbound_rx) = lochan::mpsc::unbounded::<BridgeInbound>();
 
   let close_timeout = Duration::from_millis(300);
 
@@ -293,6 +293,18 @@ async fn graceful_close_drain_bounded_by_close_timeout_when_peer_stalls() {
     .shutdown()
     .await
     .expect("half-close client write side");
+
+  // Wait until the bridge REPORTS the request EOF: only then is it actually
+  // in read-closed mode. The live-mode select prioritizes outbound data over
+  // reads, so enqueueing the response before this point can let the write
+  // start while `read_closed` is still false — the bridge would then apply
+  // the (here 60s) active `stream_timeout` instead of `close_timeout`.
+  loop {
+    match inbound_rx.recv().await.expect("bridge reports inbound") {
+      BridgeInbound::Eof(_) | BridgeInbound::Error(_) => break,
+      BridgeInbound::Bytes(_) => continue,
+    }
+  }
 
   // Queue the oversized response and drop the whole handle: the graceful-Close
   // shape (`out_tx` and `cancel_tx` both disconnect, the response queued). No

--- a/memberlist-compio/src/driver/stream/mod.rs
+++ b/memberlist-compio/src/driver/stream/mod.rs
@@ -1424,6 +1424,8 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
     &mut pending,
     stream_opts,
     &cidr_policy,
+    &snapshot,
+    &mut last_snapshot_version,
   )
   .await;
 
@@ -2891,6 +2893,8 @@ async fn freeze_and_drain_bridges_to_disconnected<I, A, R, G>(
   pending: &mut PendingCommands,
   stream_opts: StreamTransportOptions,
   cidr_policy: &CidrFilter,
+  snapshot: &SnapshotCell<I, A>,
+  last_snapshot_version: &mut u64,
 ) where
   I: memberlist_proto::Id,
   A: memberlist_proto::Data + memberlist_proto::CheapClone + Eq + core::hash::Hash + 'static,
@@ -2929,6 +2933,11 @@ async fn freeze_and_drain_bridges_to_disconnected<I, A, R, G>(
       drain_actions::<I, A, R, G>(endpoint, bridges, bridge_ready_tx, stream_opts, cidr_policy);
     let did_transports = drain_transport_transmits::<I, A, R, G>(endpoint, bridges);
     let did_transmits = drain_transmits::<I, A, R, G>(endpoint, gossip_socket, label.clone()).await;
+    // Publish the post-transition snapshot BEFORE `drain_events` resolves
+    // parked waiters / hands events to the obs task, so a caller woken by a
+    // completion that landed during the shutdown drain observes the new
+    // membership, never the pre-transition snapshot.
+    refresh_snapshot_if_changed::<I, A, R, G>(endpoint, snapshot, last_snapshot_version);
     let did_events = drain_events(
       endpoint,
       obs_tx,

--- a/memberlist-compio/src/driver/stream/mod.rs
+++ b/memberlist-compio/src/driver/stream/mod.rs
@@ -123,9 +123,12 @@ struct PendingJoin {
 /// drained through `poll_transmit`. The driver parks this here and
 /// replies only once that `LeftCluster` arrives (success) or
 /// `deadline` elapses ([`MemberlistError::LeaveTimeout`]) — so a
-/// returned `Ok(())` means the leave actually reached the wire, never
-/// merely that it was queued. Mirrors the [`PendingJoin`] /
-/// `shutdown_reply` parking pattern.
+/// returned `Ok(())` means the machine completed the leave locally and
+/// its `Dead`-self notices were queued to the gossip socket. It is NOT a
+/// wire-delivery guarantee: those notices are best-effort UDP whose
+/// transient send errors are non-fatal (a peer that never receives one
+/// still reaps the departed node via failure detection). Mirrors the
+/// [`PendingJoin`] / `shutdown_reply` parking pattern.
 ///
 /// Leave is a SHARED operation: a second `Command::Leave` racing an
 /// in-flight one (cloned `Memberlist` handles can both call `leave()`)
@@ -668,6 +671,10 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
     let did_transports = drain_transport_transmits::<I, A, R, G>(&mut endpoint, &bridges);
     let did_transmits =
       drain_transmits::<I, A, R, G>(&mut endpoint, &gossip_socket, label.clone()).await;
+    // Publish the post-transition snapshot BEFORE `drain_events` resolves
+    // parked waiters / hands events to the obs task, so a woken caller
+    // observes the new membership, never the pre-transition snapshot.
+    refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
     let did_events = drain_events(
       &mut endpoint,
       &obs_tx,
@@ -683,7 +690,6 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
   }
   reap_pending_joins(&mut pending.joins, Instant::now()).await;
   reap_pending_leave(&mut pending.leave, Instant::now()).await;
-  refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
   refresh_metrics_if_changed::<I, A, R, G>(&endpoint, &metrics, &mut last_metrics);
 
   // Hoist the listener-accept future ACROSS loop iterations. On a
@@ -848,14 +854,9 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
     // arm fires. Run the drain phase + snapshot so the post-shutdown
     // state is flushed, then break.
     if exit {
-      // Exit-path snapshot gate (mirror-symmetric with the QUIC
-      // driver): publish a fresh snapshot iff the teardown drain
-      // itself produced observable progress, NOT on the iteration
-      // `dirty` flag. The drain-progress signal is the precise
-      // "did teardown change published state" question; gating on it
-      // (in both drivers) avoids a redundant publish when nothing
-      // drained and keeps the two exit paths identical in shape.
-      let mut drained_any = false;
+      // The drain loop publishes the refreshed snapshot before each
+      // `drain_events` pass, so the post-teardown state is flushed (and
+      // observed by any waiter it resolves) without a separate post-loop gate.
       loop {
         let did_actions = drain_actions::<I, A, R, G>(
           &mut endpoint,
@@ -867,6 +868,10 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
         let did_transports = drain_transport_transmits::<I, A, R, G>(&mut endpoint, &bridges);
         let did_transmits =
           drain_transmits::<I, A, R, G>(&mut endpoint, &gossip_socket, label.clone()).await;
+        // Publish the post-transition snapshot BEFORE `drain_events` resolves
+        // parked waiters / hands events to the obs task, so a woken caller
+        // observes the new membership, never the pre-transition snapshot.
+        refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
         let did_events = drain_events(
           &mut endpoint,
           &obs_tx,
@@ -879,7 +884,6 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
         if !(did_actions || did_transports || did_transmits || did_events) {
           break;
         }
-        drained_any = true;
       }
       // Do NOT deadline-reap the parked joins on the shutdown path: the
       // post-loop freeze->drain barrier is the sole owner of join reaping. It
@@ -889,9 +893,6 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
       // `contacted` that drops a completed seed. Leave carries no
       // barrier-folded data, so its deadline reap is unaffected.
       reap_pending_leave(&mut pending.leave, Instant::now()).await;
-      if drained_any {
-        refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
-      }
       // Publish the counters unconditionally before exit: a load-shed (e.g. a
       // rejected accept at the max_inbound_streams cap) can bump them on a path
       // that produced no drainable work, so gating on `drained_any` would drop
@@ -1008,6 +1009,10 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
         let did_transports = drain_transport_transmits::<I, A, R, G>(&mut endpoint, &bridges);
         let did_transmits =
           drain_transmits::<I, A, R, G>(&mut endpoint, &gossip_socket, label.clone()).await;
+        // Publish the post-transition snapshot BEFORE `drain_events` resolves
+        // parked waiters / hands events to the obs task, so a woken caller
+        // observes the new membership, never the pre-transition snapshot.
+        refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
         let did_events = drain_events(
           &mut endpoint,
           &obs_tx,
@@ -1029,7 +1034,6 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
       }
       reap_pending_leave(&mut pending.leave, Instant::now()).await;
       if dirty {
-        refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
         refresh_metrics_if_changed::<I, A, R, G>(&endpoint, &metrics, &mut last_metrics);
       }
       if exit {
@@ -1055,6 +1059,10 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
         let did_transports = drain_transport_transmits::<I, A, R, G>(&mut endpoint, &bridges);
         let did_transmits =
           drain_transmits::<I, A, R, G>(&mut endpoint, &gossip_socket, label.clone()).await;
+        // Publish the post-transition snapshot BEFORE `drain_events` resolves
+        // parked waiters / hands events to the obs task, so a woken caller
+        // observes the new membership, never the pre-transition snapshot.
+        refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
         let did_events = drain_events(
           &mut endpoint,
           &obs_tx,
@@ -1075,7 +1083,6 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
         reap_pending_joins(&mut pending.joins, Instant::now()).await;
       }
       reap_pending_leave(&mut pending.leave, Instant::now()).await;
-      refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
       refresh_metrics_if_changed::<I, A, R, G>(&endpoint, &metrics, &mut last_metrics);
       dirty = false;
     }
@@ -1291,6 +1298,10 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
       let did_transports = drain_transport_transmits::<I, A, R, G>(&mut endpoint, &bridges);
       let did_transmits =
         drain_transmits::<I, A, R, G>(&mut endpoint, &gossip_socket, label.clone()).await;
+      // Publish the post-transition snapshot BEFORE `drain_events` resolves
+      // parked waiters / hands events to the obs task, so a woken caller
+      // observes the new membership, never the pre-transition snapshot.
+      refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
       let did_events = drain_events(
         &mut endpoint,
         &obs_tx,
@@ -1313,7 +1324,6 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
     reap_pending_leave(&mut pending.leave, Instant::now()).await;
 
     if dirty {
-      refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
       refresh_metrics_if_changed::<I, A, R, G>(&endpoint, &metrics, &mut last_metrics);
     }
 
@@ -1669,9 +1679,10 @@ async fn dispatch_command<I, A, R, G>(
           .map_err(|e| MemberlistError::Io(io::Error::other(e.to_string())));
         match res {
           Ok(()) if was_running => {
-            // Initiated → park. A returned `Ok(())` then means the leave
-            // actually reached the wire (`LeftCluster`), never merely
-            // that it was queued.
+            // Initiated → park. A returned `Ok(())` then means the machine
+            // completed the leave locally and queued its `Dead`-self notices
+            // to the gossip socket (`LeftCluster`) — best-effort UDP, not a
+            // wire-delivery guarantee.
             pending.leave = Some(PendingLeave {
               repliers: vec![reply],
               deadline: now + leave_timeout,
@@ -3152,6 +3163,7 @@ fn handle_bridge_ready<I, A, R, G>(
         cancel_rx,
         bridge_inbound_tx,
         recv_buf_len,
+        endpoint.stream_timeout(),
         close_timeout,
       );
     }
@@ -3236,6 +3248,7 @@ where
         cancel_rx,
         bridge_inbound_tx,
         stream_opts.bridge_recv_buf_len(),
+        endpoint.stream_timeout(),
         stream_opts.close_timeout(),
       );
       true
@@ -3253,6 +3266,7 @@ where
 /// (out_tx) so any bytes queued before the bridge spawned reach the
 /// wire via the `out_rx` handed in here. The task is detached — see
 /// the [`BridgeHandle`] docstring for the rationale.
+#[allow(clippy::too_many_arguments)]
 fn spawn_bridge(
   stream: TcpStream,
   eid: ExchangeId,
@@ -3260,6 +3274,7 @@ fn spawn_bridge(
   cancel_rx: futures_channel::oneshot::Receiver<()>,
   bridge_inbound_tx: &mpsc::Sender<BridgeInbound>,
   recv_buf_len: usize,
+  stream_timeout: Duration,
   close_timeout: Duration,
 ) {
   let inbound_tx = bridge_inbound_tx.clone();
@@ -3270,6 +3285,7 @@ fn spawn_bridge(
     cancel_rx,
     inbound_tx,
     recv_buf_len,
+    stream_timeout,
     close_timeout,
   ))
   .detach();

--- a/memberlist-compio/src/driver/stream/mod.rs
+++ b/memberlist-compio/src/driver/stream/mod.rs
@@ -671,12 +671,10 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
     let did_transports = drain_transport_transmits::<I, A, R, G>(&mut endpoint, &bridges);
     let did_transmits =
       drain_transmits::<I, A, R, G>(&mut endpoint, &gossip_socket, label.clone()).await;
-    // Publish the post-transition snapshot BEFORE `drain_events` resolves
-    // parked waiters / hands events to the obs task, so a woken caller
-    // observes the new membership, never the pre-transition snapshot.
-    refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
-    let did_events = drain_events(
+    let did_events = publish_snapshot_then_drain_events::<I, A, R, G>(
       &mut endpoint,
+      &snapshot,
+      &mut last_snapshot_version,
       &obs_tx,
       &observation_dropped,
       &obs_payload_bytes,
@@ -868,12 +866,10 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
         let did_transports = drain_transport_transmits::<I, A, R, G>(&mut endpoint, &bridges);
         let did_transmits =
           drain_transmits::<I, A, R, G>(&mut endpoint, &gossip_socket, label.clone()).await;
-        // Publish the post-transition snapshot BEFORE `drain_events` resolves
-        // parked waiters / hands events to the obs task, so a woken caller
-        // observes the new membership, never the pre-transition snapshot.
-        refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
-        let did_events = drain_events(
+        let did_events = publish_snapshot_then_drain_events::<I, A, R, G>(
           &mut endpoint,
+          &snapshot,
+          &mut last_snapshot_version,
           &obs_tx,
           &observation_dropped,
           &obs_payload_bytes,
@@ -1009,12 +1005,10 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
         let did_transports = drain_transport_transmits::<I, A, R, G>(&mut endpoint, &bridges);
         let did_transmits =
           drain_transmits::<I, A, R, G>(&mut endpoint, &gossip_socket, label.clone()).await;
-        // Publish the post-transition snapshot BEFORE `drain_events` resolves
-        // parked waiters / hands events to the obs task, so a woken caller
-        // observes the new membership, never the pre-transition snapshot.
-        refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
-        let did_events = drain_events(
+        let did_events = publish_snapshot_then_drain_events::<I, A, R, G>(
           &mut endpoint,
+          &snapshot,
+          &mut last_snapshot_version,
           &obs_tx,
           &observation_dropped,
           &obs_payload_bytes,
@@ -1059,12 +1053,10 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
         let did_transports = drain_transport_transmits::<I, A, R, G>(&mut endpoint, &bridges);
         let did_transmits =
           drain_transmits::<I, A, R, G>(&mut endpoint, &gossip_socket, label.clone()).await;
-        // Publish the post-transition snapshot BEFORE `drain_events` resolves
-        // parked waiters / hands events to the obs task, so a woken caller
-        // observes the new membership, never the pre-transition snapshot.
-        refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
-        let did_events = drain_events(
+        let did_events = publish_snapshot_then_drain_events::<I, A, R, G>(
           &mut endpoint,
+          &snapshot,
+          &mut last_snapshot_version,
           &obs_tx,
           &observation_dropped,
           &obs_payload_bytes,
@@ -1298,12 +1290,10 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
       let did_transports = drain_transport_transmits::<I, A, R, G>(&mut endpoint, &bridges);
       let did_transmits =
         drain_transmits::<I, A, R, G>(&mut endpoint, &gossip_socket, label.clone()).await;
-      // Publish the post-transition snapshot BEFORE `drain_events` resolves
-      // parked waiters / hands events to the obs task, so a woken caller
-      // observes the new membership, never the pre-transition snapshot.
-      refresh_snapshot_if_changed::<I, A, R, G>(&endpoint, &snapshot, &mut last_snapshot_version);
-      let did_events = drain_events(
+      let did_events = publish_snapshot_then_drain_events::<I, A, R, G>(
         &mut endpoint,
+        &snapshot,
+        &mut last_snapshot_version,
         &obs_tx,
         &observation_dropped,
         &obs_payload_bytes,
@@ -2696,6 +2686,44 @@ where
   drained
 }
 
+/// Publish the refreshed membership snapshot, then drain the machine's events.
+///
+/// This ordering is load-bearing: [`refresh_snapshot_if_changed`] MUST run
+/// before [`drain_events`], because `drain_events` resolves parked `join`/`leave`
+/// waiters and hands events to the observation task. Publishing first guarantees
+/// a caller woken by a resolution observes the new membership, never the
+/// pre-transition snapshot. Every drain-loop site — the live loop and the
+/// shutdown freeze-drain barrier — funnels through this one helper so the
+/// ordering cannot drift or be reordered per-site. Returns whatever
+/// `drain_events` returns (`true` iff it made progress).
+#[allow(clippy::too_many_arguments)]
+async fn publish_snapshot_then_drain_events<I, A, R, G>(
+  endpoint: &mut StreamEndpoint<I, A, R, G>,
+  snapshot: &SnapshotCell<I, A>,
+  last_snapshot_version: &mut u64,
+  obs_tx: &mpsc::Sender<Event<I, A>>,
+  observation_dropped: &Cell<u64>,
+  obs_payload_bytes: &Cell<u64>,
+  obs_payload_budget: Option<u64>,
+  pending: &mut PendingCommands,
+) -> bool
+where
+  I: memberlist_proto::Id,
+  A: memberlist_proto::Data + memberlist_proto::CheapClone + Eq + core::hash::Hash + 'static,
+  R: StreamTransport,
+{
+  refresh_snapshot_if_changed::<I, A, R, G>(endpoint, snapshot, last_snapshot_version);
+  drain_events::<I, A, R, G>(
+    endpoint,
+    obs_tx,
+    observation_dropped,
+    obs_payload_bytes,
+    obs_payload_budget,
+    pending,
+  )
+  .await
+}
+
 /// Per-driver observation task: dispatch each event's [`Delegate`] hook, then
 /// fan membership / control events out to the `EventStream`, OFF the driver
 /// loop.
@@ -2933,13 +2961,10 @@ async fn freeze_and_drain_bridges_to_disconnected<I, A, R, G>(
       drain_actions::<I, A, R, G>(endpoint, bridges, bridge_ready_tx, stream_opts, cidr_policy);
     let did_transports = drain_transport_transmits::<I, A, R, G>(endpoint, bridges);
     let did_transmits = drain_transmits::<I, A, R, G>(endpoint, gossip_socket, label.clone()).await;
-    // Publish the post-transition snapshot BEFORE `drain_events` resolves
-    // parked waiters / hands events to the obs task, so a caller woken by a
-    // completion that landed during the shutdown drain observes the new
-    // membership, never the pre-transition snapshot.
-    refresh_snapshot_if_changed::<I, A, R, G>(endpoint, snapshot, last_snapshot_version);
-    let did_events = drain_events(
+    let did_events = publish_snapshot_then_drain_events::<I, A, R, G>(
       endpoint,
+      snapshot,
+      last_snapshot_version,
       obs_tx,
       observation_dropped,
       obs_payload_bytes,

--- a/memberlist-compio/src/driver/stream/tests.rs
+++ b/memberlist-compio/src/driver/stream/tests.rs
@@ -1808,7 +1808,7 @@ async fn shutdown_drain_folds_completion_that_lost_the_select() {
 ///
 /// This reads the cell AFTER the whole drain, so it anchors REMOVING the publish
 /// but not a publish-AFTER-notify reorder (both have happened by then);
-/// `shutdown_drain_publishes_snapshot_before_resolving_waiter_inline` anchors the
+/// `helper_publishes_snapshot_before_resolving_waiter_inline` anchors the
 /// reorder by capturing the snapshot at the resolution instant.
 #[compio::test]
 async fn shutdown_drain_publishes_snapshot_before_waking_waiter() {
@@ -1893,82 +1893,93 @@ async fn shutdown_drain_publishes_snapshot_before_waking_waiter() {
   );
 }
 
-/// Records — at the instant a parked waiter is resolved — whether the merged
-/// `seed` is already in the published snapshot. Fired synchronously by the
-/// driver's own `reply.send`, so it observes the publish-vs-notify order the
-/// black-box post-drain read cannot. `Cell`, not an atomic: the compio driver is
-/// single-threaded, and this probe only ever fires on that thread.
+thread_local! {
+  /// The published snapshot cell the inline [`ResolutionProbe`] reads at the
+  /// wake instant, set on the driver thread for the duration of the ordering
+  /// test. It is a thread-local, not a field on the probe, precisely because a
+  /// [`Waker`](std::task::Waker) is `Send + Sync` by contract and so its backing
+  /// `Wake` value cannot hold the `!Send`, `Rc`-based `SnapshotCell`. The cell
+  /// stored here is a clone of the very `Rc` the helper publishes into, so the
+  /// probe observes the real publish; the probe only ever fires on this same
+  /// driver thread.
+  static RESOLUTION_PROBE_SNAPSHOT: RefCell<Option<SnapshotCell<SmolStr>>> =
+    const { RefCell::new(None) };
+}
+
+/// A genuinely `Send + Sync` probe (backed only by atomics) that records — at
+/// the instant a parked waiter is resolved — whether the merged `seed` is
+/// already in the published snapshot. Fired synchronously by the driver's own
+/// `reply.send`, so it observes the publish-vs-notify order the black-box
+/// post-drain read cannot. It reads the (`!Send`) published cell through the
+/// driver-thread [`RESOLUTION_PROBE_SNAPSHOT`] thread-local, honouring the
+/// `Waker` `Send + Sync` contract without any `unsafe` `RawWaker`. Mirrors the
+/// reactor's `AtResolution` probe, whose store is `Send + Sync` directly.
 struct ResolutionProbe {
-  snapshot: SnapshotCell<SmolStr>,
-  fired: Cell<bool>,
-  seed_published_at_resolution: Cell<bool>,
+  fired: std::sync::atomic::AtomicBool,
+  seed_published_at_resolution: std::sync::atomic::AtomicBool,
 }
 
-impl ResolutionProbe {
-  fn record(&self) {
-    self.fired.set(true);
-    let present = self
-      .snapshot
-      .borrow()
-      .by_id(&SmolStr::new("seed"))
-      .is_some();
-    self.seed_published_at_resolution.set(present);
+impl std::task::Wake for ResolutionProbe {
+  fn wake(self: std::sync::Arc<Self>) {
+    self.wake_by_ref();
+  }
+
+  fn wake_by_ref(self: &std::sync::Arc<Self>) {
+    use std::sync::atomic::Ordering;
+    self.fired.store(true, Ordering::SeqCst);
+    let present = RESOLUTION_PROBE_SNAPSHOT.with(|cell| {
+      cell
+        .borrow()
+        .as_ref()
+        .is_some_and(|snapshot| snapshot.borrow().by_id(&SmolStr::new("seed")).is_some())
+    });
+    self
+      .seed_published_at_resolution
+      .store(present, Ordering::SeqCst);
   }
 }
 
-/// A [`Waker`](core::task::Waker) that runs [`ResolutionProbe::record`] on wake.
-/// Hand-rolled because the probe holds a `!Send` `Rc` snapshot cell, which a safe
-/// `Waker::from(Arc<W>)` (requiring `Send + Sync`) cannot carry.
-fn resolution_probe_waker(probe: &ResolutionProbe) -> core::task::Waker {
-  use core::task::{RawWaker, RawWakerVTable, Waker};
-
-  fn record(ptr: *const ()) {
-    // SAFETY: `ptr` is the `&ResolutionProbe` passed to `RawWaker::new` below. It
-    // outlives every wake — the probe is held on the test's stack across the
-    // whole drain — and the compio driver is single-threaded, so this fires on
-    // the same thread that owns the `Rc` cell. `record` takes `&self` and mutates
-    // only through `Cell`, so no aliasing `&mut` is ever formed.
-    let probe = unsafe { &*(ptr as *const ResolutionProbe) };
-    probe.record();
-  }
-  fn clone(ptr: *const ()) -> RawWaker {
-    RawWaker::new(ptr, &VTABLE)
-  }
-  fn noop(_: *const ()) {}
-  static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, record, record, noop);
-
-  let raw = RawWaker::new(probe as *const ResolutionProbe as *const (), &VTABLE);
-  // SAFETY: the vtable's `wake`/`wake_by_ref` re-borrow the same live probe
-  // pointer (see `record`); `clone` re-derives an identical raw waker; `drop` is a
-  // no-op because the waker does not own the probe.
-  unsafe { Waker::from_raw(raw) }
-}
-
-/// Ordering guard for the shutdown drain's publish-BEFORE-notify contract:
-/// `freeze_and_drain_bridges_to_disconnected` must republish the post-transition
-/// snapshot BEFORE `drain_events` resolves a parked waiter.
+/// Ordering guard for the publish-BEFORE-notify contract centralised in
+/// `publish_snapshot_then_drain_events` — the single helper every drain-loop site
+/// (live loop and shutdown freeze-drain barrier) funnels through. The helper must
+/// republish the post-transition snapshot BEFORE `drain_events` resolves a parked
+/// waiter, so a caller woken by its own completion never reads the pre-transition
+/// snapshot. Guarding the one helper covers all six former call sites at once.
 ///
 /// The sibling `shutdown_drain_publishes_snapshot_before_waking_waiter` reads the
 /// snapshot AFTER the whole drain, so it anchors REMOVING the publish but cannot
 /// distinguish publish-before-notify from publish-AFTER-notify — both have
 /// happened by then, and on compio's single-thread executor a real woken waiter
 /// task only runs post-drain regardless. This test instead captures the snapshot
-/// AT the resolution instant via an instrumented waker: `oneshot::Sender::send`
+/// AT the resolution instant via a sound `Arc<Wake>` probe: `oneshot::Sender::send`
 /// wakes the receiver's registered waker synchronously, so the driver's own
-/// `reply.send` (inside `drain_events`) runs the probe INLINE, mid-drain. Under
+/// `reply.send` (inside `drain_events`) runs the probe INLINE, mid-helper. Under
 /// the correct order the merged seed is already published; a reorder that moves
 /// the publish AFTER `drain_events` leaves it stale at that instant. (The reactor
 /// carries the same guard for the shared design in
 /// `drive_pass_publishes_snapshot_before_resolving_join_waiter`.)
 #[compio::test]
-async fn shutdown_drain_publishes_snapshot_before_resolving_waiter_inline() {
+async fn helper_publishes_snapshot_before_resolving_waiter_inline() {
   let now = Instant::now();
   let mut endpoint = unlabeled_endpoint("dialer", "127.0.0.1:0".parse().unwrap());
   endpoint.start_scheduling(now);
 
   let addr_a = addr(7831);
-  // The peer entry is named "seed"; folding its pull response merges it.
+  // The peer entry is named "seed". Drive the exchange, then fold its pull
+  // response + FIN straight into the endpoint: this merges "seed" (advancing the
+  // machine's snapshot version) AND queues the terminal `ExchangeCompleted` — but
+  // publishes nothing, so the published snapshot going into the helper is stale.
   let (eid_a, response_a) = drive_push_to_queued_response(&mut endpoint, addr_a, now);
+  let stale_version = endpoint.endpoint_ref().snapshot_version();
+  for chunk in &response_a {
+    endpoint.handle_transport_data(eid_a, chunk, false, now);
+  }
+  endpoint.handle_transport_data(eid_a, &[], true, now);
+  assert_ne!(
+    endpoint.endpoint_ref().snapshot_version(),
+    stale_version,
+    "precondition: folding the response advanced the machine's snapshot version",
+  );
 
   // A 1-seed WaitForCompletion join resolved inline when eid_a completes.
   let (tx, mut rx) = futures_channel::oneshot::channel::<super::JoinReply>();
@@ -1982,67 +1993,60 @@ async fn shutdown_drain_publishes_snapshot_before_resolving_waiter_inline() {
     reply: tx,
   });
 
-  let (bridge_inbound_tx, mut bridge_inbound_rx) = mpsc::unbounded::<super::BridgeInbound>();
-  let (bridge_ready_tx, _bridge_ready_rx) = flume::unbounded::<BridgeReady>();
-  for chunk in response_a {
-    queue_inbound(
-      &bridge_inbound_tx,
-      super::BridgeInbound::Bytes(super::BridgeBytes {
-        eid: eid_a,
-        bytes: chunk,
-        received_at: now,
-      }),
-    );
-  }
-  queue_inbound(
-    &bridge_inbound_tx,
-    super::BridgeInbound::Eof(super::BridgeEof {
-      eid: eid_a,
-      received_at: now,
-    }),
-  );
-
-  // The snapshot cell the drain publishes to, owned here so the probe can read it
-  // at the resolution instant. Bootstrapped from the pre-drain membership — no peer.
+  // The snapshot cell the helper publishes to, plus the stale last-published
+  // version so `refresh_snapshot_if_changed` actually republishes. Bootstrapped
+  // from the pre-fold membership — no peer.
   let snapshot = boot_snapshot_cell(&endpoint);
+  let mut last_snapshot_version = stale_version;
   assert!(
     snapshot.borrow().by_id(&SmolStr::new("seed")).is_none(),
     "precondition: the bootstrap snapshot does not yet carry the peer",
   );
 
-  let probe = ResolutionProbe {
-    snapshot: snapshot.clone(),
-    fired: Cell::new(false),
-    seed_published_at_resolution: Cell::new(false),
-  };
+  // The probe reads the published cell at the resolution instant through the
+  // driver-thread thread-local; the cell stored there is a clone of the very `Rc`
+  // the helper publishes into.
+  let probe = std::sync::Arc::new(ResolutionProbe {
+    fired: std::sync::atomic::AtomicBool::new(false),
+    seed_published_at_resolution: std::sync::atomic::AtomicBool::new(false),
+  });
+  RESOLUTION_PROBE_SNAPSHOT.with(|cell| *cell.borrow_mut() = Some(snapshot.clone()));
+
   // Register the probe waker on the reply receiver, so the driver's `reply.send`
-  // inside the drain wakes it. The poll returns Pending (nothing resolved yet).
-  let waker = resolution_probe_waker(&probe);
+  // inside the helper wakes it. The poll returns Pending (nothing resolved yet).
+  let waker = std::task::Waker::from(probe.clone());
   let mut cx = core::task::Context::from_waker(&waker);
   assert!(
     core::future::Future::poll(core::pin::Pin::new(&mut rx), &mut cx).is_pending(),
     "the reply is not yet resolved; this poll registers the probe waker",
   );
 
-  let mut bridges: HashMap<ExchangeId, BridgeHandle> = HashMap::new();
-  run_shutdown_drain_publishing_to(
+  let (obs_tx, _obs_rx) = mpsc::unbounded::<memberlist_proto::event::Event<SmolStr, SocketAddr>>();
+  let observation_dropped = Cell::new(0u64);
+  let obs_payload_bytes = Cell::new(0u64);
+  let did_events = super::publish_snapshot_then_drain_events::<SmolStr, SocketAddr, RawRecords, _>(
     &mut endpoint,
-    &mut bridges,
-    bridge_inbound_tx,
-    &mut bridge_inbound_rx,
-    &bridge_ready_tx,
-    &mut pending,
     &snapshot,
+    &mut last_snapshot_version,
+    &obs_tx,
+    &observation_dropped,
+    &obs_payload_bytes,
+    None,
+    &mut pending,
   )
   .await;
 
+  RESOLUTION_PROBE_SNAPSHOT.with(|cell| *cell.borrow_mut() = None);
+
+  use std::sync::atomic::Ordering;
+  assert!(did_events, "the helper drained the completion event");
   assert!(
-    probe.fired.get(),
-    "the drain must have resolved the join waiter (else this test proves nothing)",
+    probe.fired.load(Ordering::SeqCst),
+    "the helper must have resolved the join waiter (else this test proves nothing)",
   );
   assert!(
-    probe.seed_published_at_resolution.get(),
-    "publish-before-notify: at the instant the drain resolved the join waiter the \
+    probe.seed_published_at_resolution.load(Ordering::SeqCst),
+    "publish-before-notify: at the instant the helper resolved the join waiter the \
      merged seed was ALREADY in the published snapshot — a reorder publishing AFTER \
      the notify would leave it stale here",
   );

--- a/memberlist-compio/src/driver/stream/tests.rs
+++ b/memberlist-compio/src/driver/stream/tests.rs
@@ -2059,6 +2059,7 @@ async fn shutdown_command_does_not_fabricate_response_without_fin() {
     &bridge_inbound_tx,
     64,
     Duration::from_secs(60),
+    Duration::from_secs(60),
   );
 
   // A 1-seed join awaiting A.

--- a/memberlist-compio/src/driver/stream/tests.rs
+++ b/memberlist-compio/src/driver/stream/tests.rs
@@ -1520,13 +1520,33 @@ async fn run_shutdown_drain(
   bridge_inbound_rx: &mut mpsc::Receiver<super::BridgeInbound>,
   bridge_ready_tx: &flume::Sender<BridgeReady>,
   pending: &mut PendingCommands,
-) {
+) -> SnapshotCell<SmolStr> {
   let gossip_socket = compio::net::UdpSocket::bind("127.0.0.1:0")
     .await
     .expect("bind loopback udp");
   let (obs_tx, _obs_rx) = mpsc::unbounded::<memberlist_proto::event::Event<SmolStr, SocketAddr>>();
   let observation_dropped = Cell::new(0u64);
   let obs_payload_bytes = Cell::new(0u64);
+
+  // Bootstrap the snapshot cell from the pre-drain membership. If the drain folds
+  // a completion that changes membership, the freeze helper republishes the cell
+  // before it resolves the woken waiter.
+  let snapshot: SnapshotCell<SmolStr> = {
+    let ep_ref = endpoint.endpoint_ref();
+    let local = ep_ref
+      .member(ep_ref.local_id_ref())
+      .expect("the local node is always a member");
+    let boot = MemberlistSnapshot::new(
+      vec![local.clone()],
+      local,
+      1,
+      ep_ref.num_members(),
+      ep_ref.health_score(),
+    );
+    Rc::new(RefCell::new(Rc::new(boot)))
+  };
+  let mut last_snapshot_version = endpoint.endpoint_ref().snapshot_version();
+
   freeze_and_drain_bridges_to_disconnected::<SmolStr, SocketAddr, RawRecords, _>(
     endpoint,
     bridges,
@@ -1542,8 +1562,11 @@ async fn run_shutdown_drain(
     pending,
     StreamTransportOptions::default(),
     &Default::default(),
+    &snapshot,
+    &mut last_snapshot_version,
   )
   .await;
+  snapshot
 }
 
 /// Regression: a successful push/pull completion buffered PAST the per-iteration
@@ -1745,6 +1768,96 @@ async fn shutdown_drain_folds_completion_that_lost_the_select() {
     ),
     other => panic!("expected Ok(reached) for a fully-completed join; got {other:?}"),
   }
+}
+
+/// Regression: a completion that changes membership AND resolves its waiter during
+/// the shutdown drain publishes the post-transition snapshot BEFORE the waiter is
+/// woken — the woken caller observes the new membership, never the pre-transition
+/// snapshot the drain started from. The bootstrap cell holds only the local node;
+/// folding the push/pull completion merges the peer, so the republished cell must
+/// carry it. Without the pre-`drain_events` republish, the cell keeps the
+/// bootstrap membership and the peer is absent.
+#[compio::test]
+async fn shutdown_drain_publishes_snapshot_before_waking_waiter() {
+  let now = Instant::now();
+  let mut endpoint = unlabeled_endpoint("dialer", "127.0.0.1:0".parse().unwrap());
+  endpoint.start_scheduling(now);
+
+  let addr_a = addr(7830);
+  // The peer entry is named "seed" (see `drive_push_to_queued_response`); folding
+  // its pull response merges it into the dialer's membership.
+  let (eid_a, response_a) = drive_push_to_queued_response(&mut endpoint, addr_a, now);
+
+  // A 1-seed WaitForCompletion join: when eid_a completes the join resolves and
+  // its waiter is woken inside the drain.
+  let (tx, rx) = futures_channel::oneshot::channel::<super::JoinReply>();
+  let mut pending = empty_pending();
+  pending.joins.push(PendingJoin {
+    pending: HashSet::from([eid_a]),
+    addr_by_eid: HashMap::from([(eid_a, addr_a)]),
+    contacted: smallvec::SmallVec::new(),
+    requested: 1,
+    deadline: now + Duration::from_secs(30),
+    reply: tx,
+  });
+
+  let (bridge_inbound_tx, mut bridge_inbound_rx) = mpsc::unbounded::<super::BridgeInbound>();
+  let (bridge_ready_tx, _bridge_ready_rx) = flume::unbounded::<BridgeReady>();
+  for chunk in response_a {
+    queue_inbound(
+      &bridge_inbound_tx,
+      super::BridgeInbound::Bytes(super::BridgeBytes {
+        eid: eid_a,
+        bytes: chunk,
+        received_at: now,
+      }),
+    );
+  }
+  queue_inbound(
+    &bridge_inbound_tx,
+    super::BridgeInbound::Eof(super::BridgeEof {
+      eid: eid_a,
+      received_at: now,
+    }),
+  );
+
+  // The bootstrap snapshot (built inside `run_shutdown_drain` from the pre-drain
+  // membership) does NOT yet carry the peer.
+  let mut bridges: HashMap<ExchangeId, BridgeHandle> = HashMap::new();
+  let snapshot = run_shutdown_drain(
+    &mut endpoint,
+    &mut bridges,
+    bridge_inbound_tx,
+    &mut bridge_inbound_rx,
+    &bridge_ready_tx,
+    &mut pending,
+  )
+  .await;
+
+  // The waiter was resolved inside the drain.
+  assert!(
+    pending.joins.is_empty(),
+    "the fully-resolved join was replied + removed inline by the drain",
+  );
+  match rx.await {
+    Ok(Ok(reached)) => assert!(
+      reached.contains(&addr_a),
+      "the completion resolved the join Ok: {reached:?}",
+    ),
+    other => panic!("expected Ok(reached) for a fully-completed join; got {other:?}"),
+  }
+
+  // The republished snapshot the woken waiter would read carries the merged peer.
+  let published = snapshot.borrow().clone();
+  assert!(
+    published.by_id(&SmolStr::new("seed")).is_some(),
+    "the post-transition snapshot published before the waiter woke carries the merged peer; members: {:?}",
+    published
+      .members()
+      .iter()
+      .map(|ns| ns.id_ref().as_str())
+      .collect::<Vec<_>>(),
+  );
 }
 
 /// Regression: the shutdown drain TERMINATES against a backlog far deeper than

--- a/memberlist-compio/src/driver/stream/tests.rs
+++ b/memberlist-compio/src/driver/stream/tests.rs
@@ -1521,30 +1521,59 @@ async fn run_shutdown_drain(
   bridge_ready_tx: &flume::Sender<BridgeReady>,
   pending: &mut PendingCommands,
 ) -> SnapshotCell<SmolStr> {
+  // Bootstrap the snapshot cell from the pre-drain membership. If the drain folds
+  // a completion that changes membership, the freeze helper republishes the cell
+  // before it resolves the woken waiter.
+  let snapshot = boot_snapshot_cell(endpoint);
+  run_shutdown_drain_publishing_to(
+    endpoint,
+    bridges,
+    bridge_inbound_tx,
+    bridge_inbound_rx,
+    bridge_ready_tx,
+    pending,
+    &snapshot,
+  )
+  .await;
+  snapshot
+}
+
+/// The pre-drain bootstrap snapshot cell, built from the local node only (it does
+/// not yet carry any peer a folded completion would merge).
+fn boot_snapshot_cell(
+  endpoint: &StreamEndpoint<SmolStr, SocketAddr, RawRecords>,
+) -> SnapshotCell<SmolStr> {
+  let ep_ref = endpoint.endpoint_ref();
+  let local = ep_ref
+    .member(ep_ref.local_id_ref())
+    .expect("the local node is always a member");
+  let boot = MemberlistSnapshot::new(
+    vec![local.clone()],
+    local,
+    1,
+    ep_ref.num_members(),
+    ep_ref.health_score(),
+  );
+  Rc::new(RefCell::new(Rc::new(boot)))
+}
+
+/// [`run_shutdown_drain`] publishing to a CALLER-OWNED snapshot cell, so a test
+/// can observe the republished snapshot the drain hands the woken waiter.
+async fn run_shutdown_drain_publishing_to(
+  endpoint: &mut StreamEndpoint<SmolStr, SocketAddr, RawRecords>,
+  bridges: &mut HashMap<ExchangeId, BridgeHandle>,
+  bridge_inbound_tx: mpsc::Sender<super::BridgeInbound>,
+  bridge_inbound_rx: &mut mpsc::Receiver<super::BridgeInbound>,
+  bridge_ready_tx: &flume::Sender<BridgeReady>,
+  pending: &mut PendingCommands,
+  snapshot: &SnapshotCell<SmolStr>,
+) {
   let gossip_socket = compio::net::UdpSocket::bind("127.0.0.1:0")
     .await
     .expect("bind loopback udp");
   let (obs_tx, _obs_rx) = mpsc::unbounded::<memberlist_proto::event::Event<SmolStr, SocketAddr>>();
   let observation_dropped = Cell::new(0u64);
   let obs_payload_bytes = Cell::new(0u64);
-
-  // Bootstrap the snapshot cell from the pre-drain membership. If the drain folds
-  // a completion that changes membership, the freeze helper republishes the cell
-  // before it resolves the woken waiter.
-  let snapshot: SnapshotCell<SmolStr> = {
-    let ep_ref = endpoint.endpoint_ref();
-    let local = ep_ref
-      .member(ep_ref.local_id_ref())
-      .expect("the local node is always a member");
-    let boot = MemberlistSnapshot::new(
-      vec![local.clone()],
-      local,
-      1,
-      ep_ref.num_members(),
-      ep_ref.health_score(),
-    );
-    Rc::new(RefCell::new(Rc::new(boot)))
-  };
   let mut last_snapshot_version = endpoint.endpoint_ref().snapshot_version();
 
   freeze_and_drain_bridges_to_disconnected::<SmolStr, SocketAddr, RawRecords, _>(
@@ -1562,11 +1591,10 @@ async fn run_shutdown_drain(
     pending,
     StreamTransportOptions::default(),
     &Default::default(),
-    &snapshot,
+    snapshot,
     &mut last_snapshot_version,
   )
   .await;
-  snapshot
 }
 
 /// Regression: a successful push/pull completion buffered PAST the per-iteration
@@ -1777,6 +1805,11 @@ async fn shutdown_drain_folds_completion_that_lost_the_select() {
 /// folding the push/pull completion merges the peer, so the republished cell must
 /// carry it. Without the pre-`drain_events` republish, the cell keeps the
 /// bootstrap membership and the peer is absent.
+///
+/// This reads the cell AFTER the whole drain, so it anchors REMOVING the publish
+/// but not a publish-AFTER-notify reorder (both have happened by then);
+/// `shutdown_drain_publishes_snapshot_before_resolving_waiter_inline` anchors the
+/// reorder by capturing the snapshot at the resolution instant.
 #[compio::test]
 async fn shutdown_drain_publishes_snapshot_before_waking_waiter() {
   let now = Instant::now();
@@ -1858,6 +1891,168 @@ async fn shutdown_drain_publishes_snapshot_before_waking_waiter() {
       .map(|ns| ns.id_ref().as_str())
       .collect::<Vec<_>>(),
   );
+}
+
+/// Records — at the instant a parked waiter is resolved — whether the merged
+/// `seed` is already in the published snapshot. Fired synchronously by the
+/// driver's own `reply.send`, so it observes the publish-vs-notify order the
+/// black-box post-drain read cannot. `Cell`, not an atomic: the compio driver is
+/// single-threaded, and this probe only ever fires on that thread.
+struct ResolutionProbe {
+  snapshot: SnapshotCell<SmolStr>,
+  fired: Cell<bool>,
+  seed_published_at_resolution: Cell<bool>,
+}
+
+impl ResolutionProbe {
+  fn record(&self) {
+    self.fired.set(true);
+    let present = self
+      .snapshot
+      .borrow()
+      .by_id(&SmolStr::new("seed"))
+      .is_some();
+    self.seed_published_at_resolution.set(present);
+  }
+}
+
+/// A [`Waker`](core::task::Waker) that runs [`ResolutionProbe::record`] on wake.
+/// Hand-rolled because the probe holds a `!Send` `Rc` snapshot cell, which a safe
+/// `Waker::from(Arc<W>)` (requiring `Send + Sync`) cannot carry.
+fn resolution_probe_waker(probe: &ResolutionProbe) -> core::task::Waker {
+  use core::task::{RawWaker, RawWakerVTable, Waker};
+
+  fn record(ptr: *const ()) {
+    // SAFETY: `ptr` is the `&ResolutionProbe` passed to `RawWaker::new` below. It
+    // outlives every wake — the probe is held on the test's stack across the
+    // whole drain — and the compio driver is single-threaded, so this fires on
+    // the same thread that owns the `Rc` cell. `record` takes `&self` and mutates
+    // only through `Cell`, so no aliasing `&mut` is ever formed.
+    let probe = unsafe { &*(ptr as *const ResolutionProbe) };
+    probe.record();
+  }
+  fn clone(ptr: *const ()) -> RawWaker {
+    RawWaker::new(ptr, &VTABLE)
+  }
+  fn noop(_: *const ()) {}
+  static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, record, record, noop);
+
+  let raw = RawWaker::new(probe as *const ResolutionProbe as *const (), &VTABLE);
+  // SAFETY: the vtable's `wake`/`wake_by_ref` re-borrow the same live probe
+  // pointer (see `record`); `clone` re-derives an identical raw waker; `drop` is a
+  // no-op because the waker does not own the probe.
+  unsafe { Waker::from_raw(raw) }
+}
+
+/// Ordering guard for the shutdown drain's publish-BEFORE-notify contract:
+/// `freeze_and_drain_bridges_to_disconnected` must republish the post-transition
+/// snapshot BEFORE `drain_events` resolves a parked waiter.
+///
+/// The sibling `shutdown_drain_publishes_snapshot_before_waking_waiter` reads the
+/// snapshot AFTER the whole drain, so it anchors REMOVING the publish but cannot
+/// distinguish publish-before-notify from publish-AFTER-notify — both have
+/// happened by then, and on compio's single-thread executor a real woken waiter
+/// task only runs post-drain regardless. This test instead captures the snapshot
+/// AT the resolution instant via an instrumented waker: `oneshot::Sender::send`
+/// wakes the receiver's registered waker synchronously, so the driver's own
+/// `reply.send` (inside `drain_events`) runs the probe INLINE, mid-drain. Under
+/// the correct order the merged seed is already published; a reorder that moves
+/// the publish AFTER `drain_events` leaves it stale at that instant. (The reactor
+/// carries the same guard for the shared design in
+/// `drive_pass_publishes_snapshot_before_resolving_join_waiter`.)
+#[compio::test]
+async fn shutdown_drain_publishes_snapshot_before_resolving_waiter_inline() {
+  let now = Instant::now();
+  let mut endpoint = unlabeled_endpoint("dialer", "127.0.0.1:0".parse().unwrap());
+  endpoint.start_scheduling(now);
+
+  let addr_a = addr(7831);
+  // The peer entry is named "seed"; folding its pull response merges it.
+  let (eid_a, response_a) = drive_push_to_queued_response(&mut endpoint, addr_a, now);
+
+  // A 1-seed WaitForCompletion join resolved inline when eid_a completes.
+  let (tx, mut rx) = futures_channel::oneshot::channel::<super::JoinReply>();
+  let mut pending = empty_pending();
+  pending.joins.push(PendingJoin {
+    pending: HashSet::from([eid_a]),
+    addr_by_eid: HashMap::from([(eid_a, addr_a)]),
+    contacted: smallvec::SmallVec::new(),
+    requested: 1,
+    deadline: now + Duration::from_secs(30),
+    reply: tx,
+  });
+
+  let (bridge_inbound_tx, mut bridge_inbound_rx) = mpsc::unbounded::<super::BridgeInbound>();
+  let (bridge_ready_tx, _bridge_ready_rx) = flume::unbounded::<BridgeReady>();
+  for chunk in response_a {
+    queue_inbound(
+      &bridge_inbound_tx,
+      super::BridgeInbound::Bytes(super::BridgeBytes {
+        eid: eid_a,
+        bytes: chunk,
+        received_at: now,
+      }),
+    );
+  }
+  queue_inbound(
+    &bridge_inbound_tx,
+    super::BridgeInbound::Eof(super::BridgeEof {
+      eid: eid_a,
+      received_at: now,
+    }),
+  );
+
+  // The snapshot cell the drain publishes to, owned here so the probe can read it
+  // at the resolution instant. Bootstrapped from the pre-drain membership — no peer.
+  let snapshot = boot_snapshot_cell(&endpoint);
+  assert!(
+    snapshot.borrow().by_id(&SmolStr::new("seed")).is_none(),
+    "precondition: the bootstrap snapshot does not yet carry the peer",
+  );
+
+  let probe = ResolutionProbe {
+    snapshot: snapshot.clone(),
+    fired: Cell::new(false),
+    seed_published_at_resolution: Cell::new(false),
+  };
+  // Register the probe waker on the reply receiver, so the driver's `reply.send`
+  // inside the drain wakes it. The poll returns Pending (nothing resolved yet).
+  let waker = resolution_probe_waker(&probe);
+  let mut cx = core::task::Context::from_waker(&waker);
+  assert!(
+    core::future::Future::poll(core::pin::Pin::new(&mut rx), &mut cx).is_pending(),
+    "the reply is not yet resolved; this poll registers the probe waker",
+  );
+
+  let mut bridges: HashMap<ExchangeId, BridgeHandle> = HashMap::new();
+  run_shutdown_drain_publishing_to(
+    &mut endpoint,
+    &mut bridges,
+    bridge_inbound_tx,
+    &mut bridge_inbound_rx,
+    &bridge_ready_tx,
+    &mut pending,
+    &snapshot,
+  )
+  .await;
+
+  assert!(
+    probe.fired.get(),
+    "the drain must have resolved the join waiter (else this test proves nothing)",
+  );
+  assert!(
+    probe.seed_published_at_resolution.get(),
+    "publish-before-notify: at the instant the drain resolved the join waiter the \
+     merged seed was ALREADY in the published snapshot — a reorder publishing AFTER \
+     the notify would leave it stale here",
+  );
+  match rx.await {
+    Ok(Ok(reached)) => assert!(
+      reached.contains(&addr_a),
+      "the completion resolved the join Ok: {reached:?}",
+    ),
+    other => panic!("expected Ok(reached) for a fully-completed join; got {other:?}"),
+  }
 }
 
 /// Regression: the shutdown drain TERMINATES against a backlog far deeper than

--- a/memberlist-compio/src/memberlist/mod.rs
+++ b/memberlist-compio/src/memberlist/mod.rs
@@ -738,18 +738,25 @@ impl<I, A> Memberlist<I, A> {
 
   /// Leave the cluster gracefully.
   ///
-  /// Returns `Ok(())` once the leave broadcast has been flushed to
-  /// peers — i.e. once the direct `Dead`-self notices queued for every
-  /// live peer have been handed to the wire (the membership machine's
-  /// `Event::LeftCluster` completion signal). Until then the call is
-  /// in flight; subscribers observe `Event::NodeLeft(self)` on peers as
-  /// the notices land.
+  /// Returns `Ok(())` once the local leave has completed: the membership
+  /// machine has transitioned out of the cluster and its direct
+  /// `Dead`-self notices for every live peer have been handed to the
+  /// gossip socket (the machine's `Event::LeftCluster` completion
+  /// signal). This is a best-effort socket hand-off, NOT a wire- or
+  /// peer-delivery guarantee — the notices travel over the unreliable
+  /// gossip plane, a send error is ignored once its transmit is dequeued,
+  /// and even a successful send does not confirm any peer received it (a
+  /// peer that never sees a notice still reaps the departed node via
+  /// failure detection). Subscribers observe `Event::NodeLeft(self)` on
+  /// peers only as, and if, the notices land.
   ///
   /// The wait races the driver's `leave_timeout` (see
   /// [`RuntimeOptions::with_leave_timeout`](crate::RuntimeOptions::with_leave_timeout)):
-  /// if the flush does not complete within that budget the call returns
-  /// [`MemberlistError::LeaveTimeout`] — the local node has still left,
-  /// but the driver could not confirm peers were notified.
+  /// if the local leave does not complete within that budget the call
+  /// returns [`MemberlistError::LeaveTimeout`] — the node's own departure
+  /// may still finish, but the driver did not observe local completion in
+  /// time. The timeout reflects local completion only; it never confirmed
+  /// peer notification.
   #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
   pub async fn leave(&self) -> Result<()> {
     if self.shutdown_flag.get() {

--- a/memberlist-compio/src/memberlist/mod.rs
+++ b/memberlist-compio/src/memberlist/mod.rs
@@ -33,7 +33,6 @@ use std::{
 
 use crate::snapshot::SnapshotCell;
 use bytes::Bytes;
-use compio::runtime::JoinHandle;
 use flume::{Receiver, Sender};
 #[cfg(checksum)]
 use memberlist_proto::ChecksumOptions;
@@ -70,13 +69,13 @@ use rand::rngs::StdRng;
 
 /// Cheaply clonable handle to a running memberlist driver.
 ///
-/// Every clone shares the same command channel, snapshot, events receiver,
-/// and driver-task handle. The driver task is spawned once at construction
-/// (see [`Memberlist::new`]) and lives until either [`Memberlist::shutdown`]
-/// resolves or every clone is dropped (the latter closes the command
-/// channel, which the driver observes as a shutdown request and exits its
-/// loop; the [`JoinHandle`] held inside the last `Arc` cancels the task on
-/// drop, which is a no-op if the loop already exited cleanly).
+/// Every clone shares the same command channel, snapshot, and events receiver.
+/// The driver task is spawned once at construction (see [`Memberlist::new`]) and
+/// lives until either [`Memberlist::shutdown`] resolves or every clone is dropped
+/// (the latter closes the command channel, which the driver observes as a
+/// shutdown request and exits its loop). The task is detached at spawn, so
+/// dropping the last handle does NOT cancel it mid-teardown — it runs its orderly
+/// shutdown to completion.
 ///
 /// `Memberlist<I, A>` carries the wire id type `I` and the transport's
 /// unresolved address type `A`. `I` flows into the snapshot and events channel,
@@ -100,11 +99,6 @@ pub struct Memberlist<I, A> {
   /// Shared events receiver — `events()` clones this into a fresh
   /// [`EventStream`].
   events_rx: Receiver<Event<I, SocketAddr>>,
-  /// Driver-task handle. Wrapped in `Arc` so clones share ownership;
-  /// dropping the last `Arc` drops the inner [`JoinHandle`], which
-  /// cancels the task. After [`Memberlist::shutdown`] the task has
-  /// already exited and the cancel is a no-op.
-  driver_handle: Rc<JoinHandle<()>>,
   /// Shutdown flag — set by the driver's post-loop cleanup
   /// BEFORE the cleanup drain runs. Every command-sending method on
   /// this handle (and its clones) reads the flag at entry and returns
@@ -151,7 +145,6 @@ impl<I, A> Clone for Memberlist<I, A> {
       snapshot: self.snapshot.clone(),
       metrics: self.metrics.clone(),
       events_rx: self.events_rx.clone(),
-      driver_handle: self.driver_handle.clone(),
       shutdown_flag: self.shutdown_flag.clone(),
       shutdown_done_rx: self.shutdown_done_rx.clone(),
       events_dropped: self.events_dropped.clone(),
@@ -423,17 +416,25 @@ where
     // when `run` returns (all sockets closed), unblocking any `shutdown` caller
     // that lost the flag race (see `shutdown`).
     let (shutdown_done_tx, shutdown_done_rx) = flume::bounded::<()>(1);
-    let driver_handle = compio::runtime::spawn(async move {
+    // Detach the driver task instead of holding its `JoinHandle`: a compio
+    // `JoinHandle` hard-cancels its task on drop, so keeping it in the handle
+    // would cancel the driver the instant the last `Memberlist` dropped — before
+    // the runtime could poll it to observe the closed command channel and run its
+    // orderly teardown (freeze, drain, waiter cleanup, shutdown publication).
+    // Detached, the driver instead survives the last handle drop and reaches that
+    // teardown on its own; an explicit `shutdown()` is still coordinated through
+    // `shutdown_done_rx`, which the task drops only after `run` returns.
+    compio::runtime::spawn(async move {
       transport.run(runtime, rng).await;
       drop(shutdown_done_tx);
-    });
+    })
+    .detach();
 
     Ok(Self {
       commands: commands_tx,
       snapshot,
       metrics,
       events_rx,
-      driver_handle: Rc::new(driver_handle),
       shutdown_flag,
       shutdown_done_rx,
       events_dropped,

--- a/memberlist-compio/src/memberlist/tests.rs
+++ b/memberlist-compio/src/memberlist/tests.rs
@@ -63,6 +63,14 @@ async fn tcp_two_node_join_via_new() {
 /// `join()` waiter, so the seed is already counted the moment `join().await`
 /// returns — a caller woken by its own join completion never reads the
 /// pre-transition snapshot.
+///
+/// This end-to-end read is taken AFTER `join().await` returns, on the single-
+/// thread compio executor where the woken caller only runs once the driver poll
+/// has completed — so it observes post-poll state and cannot distinguish
+/// publish-before-notify from a publish-AFTER-notify reorder. It anchors that the
+/// publish is not REMOVED; the deterministic reorder guard is the white-box
+/// `shutdown_drain_publishes_snapshot_before_resolving_waiter_inline`, which
+/// captures the snapshot at the exact resolution instant.
 #[compio::test]
 async fn join_completion_observes_post_transition_snapshot() {
   let n1 = spawn_node("seed").await;

--- a/memberlist-compio/src/memberlist/tests.rs
+++ b/memberlist-compio/src/memberlist/tests.rs
@@ -69,7 +69,7 @@ async fn tcp_two_node_join_via_new() {
 /// has completed — so it observes post-poll state and cannot distinguish
 /// publish-before-notify from a publish-AFTER-notify reorder. It anchors that the
 /// publish is not REMOVED; the deterministic reorder guard is the white-box
-/// `shutdown_drain_publishes_snapshot_before_resolving_waiter_inline`, which
+/// `helper_publishes_snapshot_before_resolving_waiter_inline`, which
 /// captures the snapshot at the exact resolution instant.
 #[compio::test]
 async fn join_completion_observes_post_transition_snapshot() {

--- a/memberlist-compio/src/memberlist/tests.rs
+++ b/memberlist-compio/src/memberlist/tests.rs
@@ -58,6 +58,36 @@ async fn tcp_two_node_join_via_new() {
   n2.shutdown().await.ok();
 }
 
+/// The snapshot a join waiter observes on completion reflects the joined peer.
+/// The driver publishes the post-transition snapshot BEFORE resolving the
+/// `join()` waiter, so the seed is already counted the moment `join().await`
+/// returns — a caller woken by its own join completion never reads the
+/// pre-transition snapshot.
+#[compio::test]
+async fn join_completion_observes_post_transition_snapshot() {
+  let n1 = spawn_node("seed").await;
+  let n1_addr = *n1.local_node().addr_ref();
+  let n2 = spawn_node("joiner").await;
+
+  n2.join(&OsResolver, &[MaybeResolved::Resolved(n1_addr)])
+    .await
+    .expect("join seed");
+
+  // No poll: the waiter resolved only after the driver republished the snapshot.
+  assert_eq!(
+    n2.member_count(),
+    2,
+    "the snapshot observed on join completion already counts the seed"
+  );
+  assert!(
+    n2.snapshot().by_id(&SmolStr::new("seed")).is_some(),
+    "the joined seed appears in the post-join snapshot"
+  );
+
+  n1.shutdown().await.ok();
+  n2.shutdown().await.ok();
+}
+
 // The handle is thread-per-core: its `Rc` / `Cell` / `RefCell` bookkeeping pins
 // it to the driver's thread, so `Memberlist` must stay `!Send` — it cannot be
 // moved to another thread. This fails to compile if a field is ever switched
@@ -72,4 +102,34 @@ fn handle_is_not_send() {
   // Resolves only while `Memberlist` is `!Send` (one matching impl); the moment
   // it becomes `Send`, both impls match and this is an ambiguity compile error.
   let _ = <Memberlist<SmolStr, SocketAddr> as AmbiguousIfSend<_>>::check;
+}
+
+/// Dropping the last handle WITHOUT `shutdown()` must run the driver's orderly
+/// teardown, not hard-cancel it. The detached task survives the last handle drop,
+/// observes the closed command channel, and reaches the post-loop cleanup that
+/// flips `shutdown_flag`. A cancel-on-drop handle (the pre-fix design) would kill
+/// the task before that cleanup, leaving the flag unset.
+#[compio::test]
+async fn dropping_last_handle_runs_orderly_teardown() {
+  let n = spawn_node("orderly-drop").await;
+  // Clone the internal latches BEFORE the drop — neither holds a command sender,
+  // so the dropped `n` is genuinely the last handle and the command channel
+  // closes, which the driver observes as a shutdown request.
+  let flag = n.shutdown_flag.clone();
+  let done = n.shutdown_done_rx.clone();
+  drop(n);
+
+  // Yield to the runtime so the detached driver observes the closed command
+  // channel, tears down, and drops the done latch when `run` returns
+  // (`recv_async` then resolves with `Disconnected`).
+  done
+    .recv_async()
+    .await
+    .expect_err("the driver drops the done latch when `run` returns");
+
+  assert!(
+    flag.get(),
+    "the driver reached its post-loop cleanup (shutdown_flag set) — it ran the \
+       orderly teardown instead of being cancelled mid-flight"
+  );
 }

--- a/memberlist-proto/src/streams/mod.rs
+++ b/memberlist-proto/src/streams/mod.rs
@@ -492,6 +492,15 @@ where
     self.ep.gossip_mtu()
   }
 
+  /// The configured per-exchange reliable-stream deadline
+  /// ([`crate::config::EndpointOptions::stream_timeout`]). A driver governs an
+  /// ACTIVE exchange's writes by this bound — the machine arms the same deadline
+  /// and fires the `Abort` that preempts a stalled write — reserving the shorter
+  /// graceful-drain `close_timeout` for the post-`Close` residual flush.
+  pub fn stream_timeout(&self) -> core::time::Duration {
+    self.ep.stream_timeout()
+  }
+
   /// The configured cross-transport compression options.
   #[cfg(compression)]
   #[cfg_attr(

--- a/memberlist-reactor/src/driver/stream/mod.rs
+++ b/memberlist-reactor/src/driver/stream/mod.rs
@@ -626,6 +626,7 @@ where
         .expect("a bridge is only ever spawned while the driver is running, before the shutdown freeze drops the template inbound sender")
         .clone(),
       self.shared.clone(),
+      self.endpoint.stream_timeout(),
       self.close_timeout,
     ));
   }
@@ -755,8 +756,10 @@ where
           .map_err(|e| Error::Io(std::io::Error::other(e.to_string())));
         match res {
           // A running leave queues the Dead-self notices and WILL emit
-          // LeftCluster once they drain; park until then, so Ok means the leave
-          // reached the wire.
+          // LeftCluster once they drain; park until then, so Ok means the machine
+          // completed the leave locally and queued its Dead-self notices to the
+          // gossip socket — best-effort UDP, not a wire-delivery guarantee (a peer
+          // that never receives one still reaps the node via failure detection).
           Ok(()) if was_running => {
             self.pending_leave = Some(PendingLeave {
               repliers: vec![reply],
@@ -1330,6 +1333,14 @@ where
     worked |= sent > 0;
     more |= sent == budget;
 
+    // Publish the post-transition snapshot BEFORE the event drain resolves parked
+    // join/leave/ping/send waiters and hands events to the obs task: a caller
+    // woken by its completion (or an obs consumer) must observe the new
+    // membership this pass produced, never the pre-transition snapshot. The
+    // membership change was applied above by `handle_packet` / `handle_stream_action`;
+    // `poll_event` only drains the event queue, so the version is already final.
+    self.maybe_publish_snapshot();
+
     // Observation events: retry the overflow first, then drain to EMPTY (see
     // the pass doc for why this surface is uncapped).
     self.flush_obs_overflow();
@@ -1341,6 +1352,23 @@ where
     worked |= events;
 
     (worked, more, ingress_capped)
+  }
+
+  /// Republish the snapshot iff the endpoint's snapshot version advanced since the
+  /// last publish. The rebuild clones every `NodeState`, so the version gate skips
+  /// the work whenever membership/health did not actually change.
+  // `G: rand::Rng`: `snapshot_of` drives the endpoint's gossip RNG.
+  fn maybe_publish_snapshot(&mut self)
+  where
+    G: rand::Rng,
+  {
+    let v = self.endpoint.endpoint_ref().snapshot_version();
+    if v != self.last_snapshot_version {
+      self.last_snapshot_version = v;
+      self
+        .shared
+        .publish(snapshot_of(self.endpoint.endpoint_ref()));
+    }
   }
 
   /// Retries retained overflow events into the obs channel, stopping at the first
@@ -1388,29 +1416,49 @@ where
     if let Some(bytes) = payload {
       self.obs_payload_bytes.fetch_add(bytes, Ordering::Relaxed);
     }
+    // FIFO gate: if older events are still queued in the overflow, this one must
+    // not jump ahead of them. `flush_obs_overflow` retries the backlog before each
+    // event drain but stops at the first `Full`, so a slot freed since then would
+    // let `try_send` accept this newer event ahead of the queued ones — delivering
+    // it out of machine-event order. Route it behind the backlog exactly as a Full
+    // channel would, preserving order.
+    if !self.obs_overflow.is_empty() {
+      self.retain_or_drop_observation(ev, payload);
+      return;
+    }
     match self.obs_tx.try_send(ev) {
       // Reserved above; the obs task releases it on receive.
       Ok(()) => {}
-      Err(flume::TrySendError::Full(ev)) => match payload {
-        // Application data the event stream cannot reconstruct: retain (still
-        // reserved) for a retry.
-        Some(_) if self.obs_overflow.len() < OBS_OVERFLOW_MAX => {
-          self.obs_overflow.push_back(ev);
-        }
-        // Recoverable membership/control, or the overflow is full: drop, count,
-        // and roll back any reservation.
-        _ => {
-          if let Some(bytes) = payload {
-            self.obs_payload_bytes.fetch_sub(bytes, Ordering::Relaxed);
-          }
-          self.shared.add_observation_dropped(1);
-        }
-      },
+      Err(flume::TrySendError::Full(ev)) => self.retain_or_drop_observation(ev, payload),
       // The obs task is gone: roll back the reservation.
       Err(flume::TrySendError::Disconnected(_)) => {
         if let Some(bytes) = payload {
           self.obs_payload_bytes.fetch_sub(bytes, Ordering::Relaxed);
         }
+      }
+    }
+  }
+
+  /// Route an event the obs channel cannot take immediately (or that must wait
+  /// behind an existing overflow backlog): retain reconstructible-only application
+  /// data in the overflow (FIFO, still byte-reserved) while there is room;
+  /// otherwise drop it, roll back any reservation, and count it. Recoverable
+  /// membership/control events carry no reservation and are always dropped — the
+  /// snapshot reconstructs them.
+  fn retain_or_drop_observation(&mut self, ev: Event<I, SocketAddr>, payload: Option<u64>) {
+    match payload {
+      // Application data the event stream cannot reconstruct: retain (still
+      // reserved) for a retry.
+      Some(_) if self.obs_overflow.len() < OBS_OVERFLOW_MAX => {
+        self.obs_overflow.push_back(ev);
+      }
+      // Recoverable membership/control, or the overflow is full: drop, count,
+      // and roll back any reservation.
+      _ => {
+        if let Some(bytes) = payload {
+          self.obs_payload_bytes.fetch_sub(bytes, Ordering::Relaxed);
+        }
+        self.shared.add_observation_dropped(1);
       }
     }
   }
@@ -1904,13 +1952,11 @@ where
 
     // Republish the snapshot only when membership/health actually changed —
     // rebuilding clones every NodeState, so doing it on every productive poll is
-    // wasted under steady traffic.
-    let snap_v = this.endpoint.endpoint_ref().snapshot_version();
-    if progress && snap_v != this.last_snapshot_version {
-      this.last_snapshot_version = snap_v;
-      this
-        .shared
-        .publish(snapshot_of(this.endpoint.endpoint_ref()));
+    // wasted under steady traffic. `drain_surfaces` already published any change
+    // its passes produced (before those passes resolved waiters); this catches a
+    // change from the `handle_timeout` fired above, whose events drain next poll.
+    if progress {
+      this.maybe_publish_snapshot();
     }
     // Republish the load-shedding counters only when they change (a cheap u64
     // compare; the publish allocates only on a real change, which is rare).
@@ -2017,16 +2063,23 @@ async fn dial_task<I, R>(
 ///   no EOF; only a real `read == 0` does. An `inbound_tx` send already in flight
 ///   is awaited in an arm body, not the select, so it still completes first.
 ///
-/// A graceful Close has NO remaining cancel path (the handle is gone), so a peer
-/// that sent its request+FIN and then STOPPED reading would wedge the post-Close
-/// drain forever — leaking this detached task and its socket. The drain is
-/// therefore a chunked write loop, and EACH partial write is bounded by a fresh
-/// `close_timeout`. Because progress resets the deadline, this is a NO-PROGRESS
-/// (idle) timeout, not a cap on total drain duration: a peer that keeps reading
-/// — even slowly, so a large frame outlasts `close_timeout` overall — advances
-/// on every chunk and never trips it. It fires only when a single partial write
-/// makes NO progress for the full `close_timeout`; the bridge is then torn down,
-/// dropping the write half so the OS RSTs the stuck stream.
+/// A write's no-progress bound depends on the exchange phase. While BOTH halves
+/// are live the exchange is ACTIVE: the machine arms `stream_timeout` and fires
+/// the `Abort` (via `cancel_rx`) that preempts a stalled write, so that arm is
+/// bounded by `stream_timeout` — a shorter `close_timeout` must not truncate a
+/// live exchange whose peer merely reads slowly. Once the peer has half-closed
+/// (read-EOF), the reply is drained toward teardown: a graceful Close then has NO
+/// remaining cancel path (the handle is gone), so a peer that sent its request+FIN
+/// and then STOPPED reading would wedge the post-Close drain forever — leaking
+/// this detached task and its socket. That drain is therefore a chunked write
+/// loop bounded by a fresh `close_timeout`. Because progress resets either
+/// deadline, both are NO-PROGRESS (idle) timeouts, not caps on total drain
+/// duration: a peer that keeps reading — even slowly, so a large frame outlasts
+/// the bound overall — advances on every chunk and never trips it. A bound fires
+/// only when a single partial write makes NO progress for its full duration; the
+/// bridge is then torn down, dropping the write half so the OS RSTs the stuck
+/// stream.
+#[allow(clippy::too_many_arguments)]
 async fn bridge_task<I, R, S>(
   stream: S,
   eid: ExchangeId,
@@ -2034,6 +2087,7 @@ async fn bridge_task<I, R, S>(
   cancel_rx: oneshot::Receiver<()>,
   inbound_tx: Sender<BridgeInbound>,
   shared: Arc<Shared<I>>,
+  stream_timeout: Duration,
   close_timeout: Duration,
 ) where
   I: NodeId,
@@ -2105,16 +2159,18 @@ async fn bridge_task<I, R, S>(
       () = &mut cancel_fut => break,
       out = out_rx.recv_async().fuse() => match out {
         Ok(BridgeOut::Data(bytes)) => {
-          // Tear down on an explicit abort OR a drain that makes NO progress for
-          // `close_timeout` on a non-reading peer (the graceful-Close backstop).
-          // A slow-but-reading peer resets the deadline each chunk and is not
-          // timed out.
+          // ACTIVE exchange (both halves live): bound by `stream_timeout`, the
+          // machine's per-exchange deadline. The coordinator arms the same
+          // deadline and fires the `Abort` that resolves `cancel_fut`, so the
+          // idle bound must match it — a shorter `close_timeout` would truncate a
+          // live exchange whose peer merely reads slowly. A slow-but-reading peer
+          // resets the deadline each chunk and is not timed out.
           if !write_closed
             && write_cancellable::<_, R, _>(
               &mut write_half,
               &bytes,
               &mut cancel_fut,
-              close_timeout,
+              stream_timeout,
             )
             .await
           {

--- a/memberlist-reactor/src/driver/stream/mod.rs
+++ b/memberlist-reactor/src/driver/stream/mod.rs
@@ -1417,14 +1417,22 @@ where
       self.obs_payload_bytes.fetch_add(bytes, Ordering::Relaxed);
     }
     // FIFO gate: if older events are still queued in the overflow, this one must
-    // not jump ahead of them. `flush_obs_overflow` retries the backlog before each
-    // event drain but stops at the first `Full`, so a slot freed since then would
-    // let `try_send` accept this newer event ahead of the queued ones — delivering
-    // it out of machine-event order. Route it behind the backlog exactly as a Full
-    // channel would, preserving order.
+    // not jump ahead of them. A channel slot may have been freed since the last
+    // `flush_obs_overflow`, so drain the backlog into any freed slot(s) first —
+    // this both preserves machine-event order and lets a newly-freed slot be
+    // consumed by the oldest queued event rather than by this newer one.
     if !self.obs_overflow.is_empty() {
-      self.retain_or_drop_observation(ev, payload);
-      return;
+      self.flush_obs_overflow();
+      // Backlog still non-empty ⇒ the channel is full (flush stops at the first
+      // `Full`); queue this event behind it (or drop it only if the overflow is
+      // genuinely at cap). Order is preserved: the new event never precedes an
+      // older queued one.
+      if !self.obs_overflow.is_empty() {
+        self.retain_or_drop_observation(ev, payload);
+        return;
+      }
+      // The backlog fully drained into freed slots; fall through to try the new
+      // event against the now-emptied overflow / possibly-free channel.
     }
     match self.obs_tx.try_send(ev) {
       // Reserved above; the obs task releases it on receive.

--- a/memberlist-reactor/src/driver/stream/tests.rs
+++ b/memberlist-reactor/src/driver/stream/tests.rs
@@ -382,6 +382,37 @@ async fn obs_disconnected_rolls_back_reservation() {
   );
 }
 
+/// With older events still queued in the overflow, `send_observation` must route
+/// a new event BEHIND them, never `try_send` it into a slot freed since the last
+/// `flush_obs_overflow` — doing so would deliver it ahead of the queued events,
+/// out of machine-event order.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn obs_new_event_waits_behind_nonempty_overflow() {
+  // Capacity-1 channel, ample byte budget.
+  let (mut driver, obs_rx, _shared, _bytes) = build_driver(1, Some(1 << 20)).await;
+
+  driver.send_observation(user_packet(1)); // fills the capacity-1 channel
+  driver.send_observation(user_packet(2)); // channel full → retained in overflow
+  assert_eq!(driver.obs_overflow.len(), 1, "second event retained");
+
+  // Free a channel slot WITHOUT flushing the overflow: exactly the window where a
+  // naive `try_send` would jump the queue.
+  obs_rx.try_recv().expect("drain the queued first event");
+
+  driver.send_observation(user_packet(3)); // overflow non-empty → must wait behind
+
+  assert_eq!(
+    driver.obs_overflow.len(),
+    2,
+    "a new event with a non-empty overflow is appended behind the backlog, \
+       preserving FIFO order"
+  );
+  assert!(
+    obs_rx.try_recv().is_err(),
+    "the new event must NOT jump ahead into the freed slot"
+  );
+}
+
 /// `flush_obs_overflow` stops at the first `Full`, pushing the un-sendable event
 /// back to the FRONT so retry order is preserved.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1788,6 +1819,7 @@ async fn graceful_close_drains_queued_bytes_before_exit() {
     inbound_tx,
     shared,
     Duration::from_secs(60),
+    Duration::from_secs(60),
   ));
 
   // The peer sends its request, then half-closes its write side. The bridge
@@ -1874,6 +1906,7 @@ async fn explicit_abort_preempts_and_discards() {
     inbound_tx,
     shared,
     Duration::from_secs(60),
+    Duration::from_secs(60),
   ));
 
   // The peer must see EOF with NO bytes — the abort dropped the write side
@@ -1938,6 +1971,7 @@ async fn shutdown_cancel_beats_readable_peer_fin_so_no_eof_is_folded() {
     cancel_rx,
     inbound_tx,
     shared,
+    Duration::from_secs(60),
     Duration::from_secs(60),
   ));
 
@@ -2014,6 +2048,7 @@ async fn graceful_close_drain_bounded_by_close_timeout_when_peer_stalls() {
     cancel_rx,
     inbound_tx,
     shared,
+    Duration::from_secs(60),
     close_timeout,
   ));
 
@@ -2097,6 +2132,7 @@ async fn slow_but_progressing_reader_is_not_timed_out() {
     cancel_rx,
     inbound_tx,
     shared,
+    Duration::from_secs(60),
     close_timeout,
   ));
 
@@ -2168,6 +2204,68 @@ async fn slow_but_progressing_reader_is_not_timed_out() {
   bridge.await.expect("bridge task exits cleanly");
 }
 
+/// A `close_timeout` shorter than `stream_timeout` must NOT abort an ACTIVE
+/// (both-halves-live) write. A live exchange is governed by the machine's
+/// `stream_timeout` (it arms that deadline and fires the `Abort` that preempts a
+/// stalled write), so the both-halves-live arm bounds its writes by
+/// `stream_timeout`; the shorter graceful-drain `close_timeout` is reserved for
+/// the post-half-close drain. Here the peer never reads and never half-closes, so
+/// the write stalls in the active arm — and must survive well past `close_timeout`.
+#[cfg_attr(
+  windows,
+  ignore = "Windows buffers the oversized reply in chunks; the zero-window stall never forms"
+)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn active_write_governed_by_stream_timeout_not_close_timeout() {
+  // The client is held open, never reads, and never half-closes — so the bridge
+  // stays in both-halves-live mode with a stalled write.
+  let (server, _client) = loopback_pair().await;
+  let eid = fresh_eid();
+  let (out_tx, out_rx) = flume::unbounded::<BridgeOut>();
+  let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
+  let (inbound_tx, _inbound_rx) = flume::unbounded::<BridgeInbound>();
+  let shared = test_shared();
+
+  // A SHORT close_timeout and a LONG stream_timeout: the pre-fix code bounded the
+  // active write by `close_timeout` and would tear down at ~150ms.
+  let close_timeout = Duration::from_millis(150);
+  let stream_timeout = Duration::from_secs(4);
+
+  // A reply far larger than any socket buffer: with the peer never reading, the
+  // window collapses to zero and the write stalls once the buffers fill.
+  let response = vec![0x5Au8; 16 * 1024 * 1024];
+
+  let bridge = tokio::spawn(bridge_task::<SmolStr, TokioRuntime, TokioTcpStream>(
+    server,
+    eid,
+    out_rx,
+    cancel_rx,
+    inbound_tx,
+    shared,
+    stream_timeout,
+    close_timeout,
+  ));
+
+  // Queue the oversized reply; keep `out_tx` and `cancel_tx` alive so the ONLY
+  // teardown that could fire is a write timeout (no Close disconnect, no abort).
+  out_tx
+    .send(BridgeOut::Data(Bytes::from(response)))
+    .expect("queue oversized reply");
+
+  // Wait well past `close_timeout`, comfortably short of `stream_timeout`: the
+  // bridge must still be alive — the active write was NOT aborted early.
+  tokio::time::sleep(close_timeout * 4).await;
+  assert!(
+    !bridge.is_finished(),
+    "an active both-halves-live write must be governed by stream_timeout, not \
+       aborted at the shorter close_timeout"
+  );
+
+  // Clean up deterministically: an explicit abort preempts the stalled write.
+  cancel_tx.send(()).expect("signal explicit abort");
+  bridge.await.expect("bridge exits on the abort");
+}
+
 /// `BridgeOut::ShutdownWrite` (the machine's `StreamAction::Shutdown`,
 /// half-closing the write side after the send half retires) closes the bridge's
 /// write half — the peer reads EOF on its read side — while the bridge stays
@@ -2188,6 +2286,7 @@ async fn bridge_shutdown_write_half_closes_write_side() {
     cancel_rx,
     inbound_tx,
     shared,
+    Duration::from_secs(60),
     Duration::from_secs(60),
   ));
 
@@ -2229,6 +2328,7 @@ async fn bridge_write_error_tears_down() {
     cancel_rx,
     inbound_tx,
     shared,
+    Duration::from_secs(60),
     Duration::from_secs(60),
   ));
 

--- a/memberlist-reactor/src/driver/stream/tests.rs
+++ b/memberlist-reactor/src/driver/stream/tests.rs
@@ -893,6 +893,133 @@ async fn shutdown_drains_queued_inbound_completion_into_reached_before_reaping()
   }
 }
 
+/// Ordering guard for the publish-BEFORE-notify contract in
+/// `drain_surfaces_pass`: the pass must republish the post-transition snapshot
+/// BEFORE its event drain resolves a parked waiter, so a caller woken by its own
+/// completion never reads the pre-transition snapshot.
+///
+/// A black-box read taken AFTER the pass cannot distinguish publish-before-notify
+/// from publish-after-notify — both have happened by then. This test instead
+/// captures the snapshot AT THE INSTANT the waiter resolves, via an instrumented
+/// waker: `oneshot::Sender::send` synchronously wakes the receiver's registered
+/// waker, so the driver's own `pj.reply.send(..)` (inside `account_event`) runs
+/// the probe INLINE, mid-pass, before the pass returns. The probe reads the
+/// published snapshot then and there. Under the correct order the merged seed is
+/// already published; a reorder that moves the publish AFTER the event drain
+/// leaves it stale at that instant, which the probe catches.
+///
+/// Setup: seed A's push/pull response + EOF are folded directly into the endpoint
+/// so the fold both MERGES "seed" (advancing the snapshot version) and enqueues
+/// its terminal `ExchangeCompleted(Succeeded)` — WITHOUT publishing (only the
+/// driver's pass publishes), so the published snapshot is stale going into the
+/// pass. `drain_surfaces_pass` then publishes, then resolves.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn drive_pass_publishes_snapshot_before_resolving_join_waiter() {
+  let now = Instant::now();
+  let (mut driver, _obs_rx, shared, _bytes) = build_driver_with(64, None, 8, |ep| {
+    ep.start_scheduling(now);
+  })
+  .await;
+
+  let addr_a: SocketAddr = "127.0.0.1:7801".parse().unwrap();
+  // Drive seed A's push/pull, then fold its pull response + EOF straight into the
+  // endpoint: this merges "seed" and terminalizes the exchange (queuing its
+  // `ExchangeCompleted`) in one step, but publishes nothing.
+  let (eid_a, response_a) = drive_push_to_queued_response(&mut driver, addr_a, now);
+  for chunk in &response_a {
+    driver
+      .endpoint
+      .handle_transport_data(eid_a, chunk, false, now);
+  }
+  driver.endpoint.handle_transport_data(eid_a, &[], true, now);
+
+  // Precondition: the merge advanced the machine's membership, but the PUBLISHED
+  // snapshot the waiter would read is still the stale pre-merge one.
+  assert!(
+    shared
+      .load_snapshot()
+      .by_id(&SmolStr::new("seed"))
+      .is_none(),
+    "precondition: the merge is applied to the machine but not yet published",
+  );
+
+  // Install the 1-seed pending join awaiting eid_a.
+  let (tx, mut rx) = oneshot::channel::<crate::command::JoinReply>();
+  let mut pending_eids = HashSet::new();
+  pending_eids.insert(eid_a);
+  driver.pending_joins.insert(
+    0,
+    PendingJoin {
+      pending_eids,
+      contacted: SmallVec::new(),
+      requested: 1,
+      reply: tx,
+    },
+  );
+
+  // The instrumented waker: fired synchronously by the driver's `reply.send`, it
+  // records — AT the resolution instant — whether the merged seed is already in
+  // the published snapshot.
+  struct AtResolution {
+    shared: Arc<Shared<SmolStr>>,
+    fired: AtomicBool,
+    seed_published_at_resolution: AtomicBool,
+  }
+  impl Wake for AtResolution {
+    fn wake(self: Arc<Self>) {
+      self.wake_by_ref();
+    }
+    fn wake_by_ref(self: &Arc<Self>) {
+      self.fired.store(true, Ordering::SeqCst);
+      let present = self
+        .shared
+        .load_snapshot()
+        .by_id(&SmolStr::new("seed"))
+        .is_some();
+      self
+        .seed_published_at_resolution
+        .store(present, Ordering::SeqCst);
+    }
+  }
+  let probe = Arc::new(AtResolution {
+    shared: shared.clone(),
+    fired: AtomicBool::new(false),
+    seed_published_at_resolution: AtomicBool::new(false),
+  });
+  let probe_waker = Waker::from(probe.clone());
+  // Register the probe waker on the reply receiver (Pending stores the waker),
+  // so the driver's later `reply.send` wakes it.
+  let mut rx_cx = Context::from_waker(&probe_waker);
+  assert!(
+    Pin::new(&mut rx).poll(&mut rx_cx).is_pending(),
+    "the reply is not yet resolved; polling registers the probe waker",
+  );
+
+  // Run the exact production pass containing the publish + event-drain sequence.
+  let pass_waker = flag_waker();
+  let mut cx = Context::from_waker(&pass_waker);
+  let _ = driver.drain_surfaces_pass(&mut cx);
+
+  assert!(
+    probe.fired.load(Ordering::SeqCst),
+    "the pass must have resolved the join waiter (else this test proves nothing)",
+  );
+  assert!(
+    probe.seed_published_at_resolution.load(Ordering::SeqCst),
+    "publish-before-notify: at the instant the pass resolved the join waiter the \
+     merged seed was ALREADY in the published snapshot — a reorder that publishes \
+     AFTER the notify would leave it stale here",
+  );
+  // The reply itself carries the successful contacted set.
+  match rx.await {
+    Ok(Ok(reached)) => assert!(
+      reached.contains(&addr_a),
+      "the completed join resolved Ok with the contacted seed: {reached:?}",
+    ),
+    other => panic!("expected Ok(reached) for a completed join; got {other:?}"),
+  }
+}
+
 /// The real gate: a target join's terminal peer-FIN EOF PARKED on a bridge's
 /// SATURATED `inbound_tx.send` — sitting OUTSIDE the bounded channel buffer — is
 /// still folded into the reaped reached set. The earlier snapshot-bound drain

--- a/memberlist-reactor/src/driver/stream/tests.rs
+++ b/memberlist-reactor/src/driver/stream/tests.rs
@@ -120,6 +120,15 @@ fn user_packet(len: usize) -> Event<SmolStr, SocketAddr> {
   ))
 }
 
+/// The payload length of a `user_packet` event, for asserting WHICH event
+/// occupies a channel slot or overflow position. Panics on any other variant.
+fn user_packet_len(ev: &Event<SmolStr, SocketAddr>) -> usize {
+  match ev {
+    Event::UserPacket(up) => up.data_ref().len(),
+    other => panic!("expected a UserPacket event, got {other:?}"),
+  }
+}
+
 /// A control event carrying no app-data (`observation_payload_bytes` is `None`)
 /// and, with no parked leave/join/ping, a no-op for `account_event`. Used to
 /// drive the obs-channel `Full`-and-recoverable drop arm.
@@ -385,7 +394,8 @@ async fn obs_disconnected_rolls_back_reservation() {
 /// With older events still queued in the overflow, `send_observation` must route
 /// a new event BEHIND them, never `try_send` it into a slot freed since the last
 /// `flush_obs_overflow` — doing so would deliver it ahead of the queued events,
-/// out of machine-event order.
+/// out of machine-event order. A slot freed in that window is consumed by the
+/// OLDEST queued event, and the new one waits behind whatever backlog remains.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn obs_new_event_waits_behind_nonempty_overflow() {
   // Capacity-1 channel, ample byte budget.
@@ -399,17 +409,106 @@ async fn obs_new_event_waits_behind_nonempty_overflow() {
   // naive `try_send` would jump the queue.
   obs_rx.try_recv().expect("drain the queued first event");
 
-  driver.send_observation(user_packet(3)); // overflow non-empty → must wait behind
+  driver.send_observation(user_packet(3)); // overflow non-empty → drains behind
 
+  // The freed slot is consumed by the OLDER queued event (len 2), and the new
+  // event takes its place in the overflow — order preserved, nothing dropped.
   assert_eq!(
     driver.obs_overflow.len(),
-    2,
-    "a new event with a non-empty overflow is appended behind the backlog, \
-       preserving FIFO order"
+    1,
+    "the older queued event moved into the freed slot; the new event waits behind it"
   );
+  assert_eq!(
+    user_packet_len(
+      &obs_rx
+        .try_recv()
+        .expect("the freed slot now holds the older event")
+    ),
+    2,
+    "the OLDER queued event took the freed slot, not the new one — FIFO order",
+  );
+  assert_eq!(
+    user_packet_len(
+      driver
+        .obs_overflow
+        .back()
+        .expect("the new event is retained in the overflow")
+    ),
+    3,
+    "the new event is behind the backlog, never ahead of an older queued one",
+  );
+}
+
+/// With the overflow FULL at `OBS_OVERFLOW_MAX` but a channel slot freed since the
+/// last flush, a new app-data event must NOT be dropped: the freed slot is first
+/// consumed by the OLDEST queued event, and the new event is appended behind the
+/// remaining backlog. Dropping here would lose reconstructible app-data while a
+/// channel slot sat unused.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn obs_full_overflow_reuses_freed_slot_before_dropping() {
+  // Capacity-1 channel, ample byte budget so nothing is dropped for bytes.
+  let (mut driver, obs_rx, shared, _bytes) = build_driver(1, Some(1 << 20)).await;
+
+  // Fill the capacity-1 channel.
+  driver.send_observation(user_packet(1));
   assert!(
-    obs_rx.try_recv().is_err(),
-    "the new event must NOT jump ahead into the freed slot"
+    driver.obs_overflow.is_empty(),
+    "first event went to the channel"
+  );
+
+  // Fill the overflow to exactly OBS_OVERFLOW_MAX. Stage the items directly (the
+  // reservation path is exercised by the byte-accounting tests); the OLDEST is
+  // tagged with a distinct payload length so we can confirm it — not the new
+  // event — consumes the freed slot.
+  const OLDEST_LEN: usize = 200;
+  const NEW_LEN: usize = 99;
+  driver.obs_overflow.push_back(user_packet(OLDEST_LEN));
+  for _ in 1..OBS_OVERFLOW_MAX {
+    driver.obs_overflow.push_back(user_packet(50));
+  }
+  assert_eq!(
+    driver.obs_overflow.len(),
+    OBS_OVERFLOW_MAX,
+    "the overflow is staged at its cap"
+  );
+
+  // Free a channel slot WITHOUT flushing: the exact window where the old gate
+  // would drop the new event even though the channel has room.
+  obs_rx.try_recv().expect("drain the queued first event");
+
+  driver.send_observation(user_packet(NEW_LEN));
+
+  // No drop: the freed slot absorbed the oldest queued event, and the new event
+  // is retained behind the remaining backlog (overflow back at cap, not over).
+  assert_eq!(
+    shared.observation_dropped(),
+    0,
+    "a free channel slot must be reused before dropping — nothing is dropped"
+  );
+  assert_eq!(
+    driver.obs_overflow.len(),
+    OBS_OVERFLOW_MAX,
+    "the oldest event moved to the channel; the new event took its place at the back"
+  );
+
+  // FIFO: the freed slot holds the OLDEST queued event, never the newest.
+  let front = obs_rx
+    .try_recv()
+    .expect("the freed slot now holds an event");
+  assert_eq!(
+    user_packet_len(&front),
+    OLDEST_LEN,
+    "the oldest queued event consumed the freed slot, preserving FIFO order"
+  );
+  // The new event is at the back of the overflow, behind the remaining backlog.
+  let back = driver
+    .obs_overflow
+    .back()
+    .expect("the overflow still holds the appended new event");
+  assert_eq!(
+    user_packet_len(back),
+    NEW_LEN,
+    "the new event is appended at the back, never ahead of an older queued one"
   );
 }
 

--- a/memberlist-reactor/tests/tcp_smoke.rs
+++ b/memberlist-reactor/tests/tcp_smoke.rs
@@ -84,6 +84,14 @@ async fn two_nodes_join_converge() {
 /// its own join completion never reads the pre-transition snapshot. (The
 /// converge test above polls because it also waits on the SEED to learn the
 /// joiner, a separate gossip round; here the joiner's own view is immediate.)
+///
+/// This end-to-end read is taken AFTER `join().await` returns, so — like its
+/// compio sibling — it anchors that the publish is not REMOVED but cannot catch a
+/// publish-AFTER-notify reorder: the driver poll (including its end-of-poll
+/// republish) has finished by the time the woken caller reads. The deterministic
+/// reorder guard is the white-box unit test
+/// `drive_pass_publishes_snapshot_before_resolving_join_waiter`, which captures
+/// the snapshot at the exact instant the pass resolves the waiter.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn join_completion_observes_post_transition_snapshot() {
   let a = make("seed").await;

--- a/memberlist-reactor/tests/tcp_smoke.rs
+++ b/memberlist-reactor/tests/tcp_smoke.rs
@@ -78,6 +78,37 @@ async fn two_nodes_join_converge() {
   let _ = b.shutdown().await;
 }
 
+/// The snapshot a join waiter observes on completion reflects the joined peer.
+/// The driver publishes the post-transition snapshot BEFORE resolving the
+/// `join()` waiter, so the count is correct with NO polling — a caller woken by
+/// its own join completion never reads the pre-transition snapshot. (The
+/// converge test above polls because it also waits on the SEED to learn the
+/// joiner, a separate gossip round; here the joiner's own view is immediate.)
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn join_completion_observes_post_transition_snapshot() {
+  let a = make("seed").await;
+  let b = make("joiner").await;
+  let a_addr = *a.local().addr_ref();
+
+  b.join(&SocketAddrResolver, &[MaybeResolved::Resolved(a_addr)])
+    .await
+    .expect("join");
+
+  // No poll: the waiter resolved only after the driver republished the snapshot.
+  assert_eq!(
+    b.num_members(),
+    2,
+    "the snapshot observed on join completion already counts the seed"
+  );
+  assert!(
+    b.snapshot().by_id(&SmolStr::new("seed")).is_some(),
+    "the joined seed appears in the post-join snapshot"
+  );
+
+  let _ = a.shutdown().await;
+  let _ = b.shutdown().await;
+}
+
 /// A delegate that counts `notify_join` invocations.
 struct RecordingDelegate {
   joins: Arc<AtomicUsize>,


### PR DESCRIPTION
Closes out the deferred **low-severity** survivors of the #157 adversarial review — 8 fixed across the compio and reactor drivers; 1 (C2) excluded with rationale.

## Fixes

- **C1** (compio) — dropping the last `Memberlist` handle hard-cancelled the driver mid-teardown (the `JoinHandle` cancels on drop). Now the driver task is **detached**, so a last-handle drop drains on command-channel close and runs the terminal shutdown/publish instead of cancelling.
- **C4 / R6** (both drivers) — `leave()` returned `Ok(())` even when every leave datagram send was discarded. The public and internal **leave contract docs** are corrected: `Ok(())` = local leave completion plus best-effort socket hand-off, **not** a wire-/peer-delivery guarantee (a UDP leave is inherently best-effort; peers reap a dropped leave via failure detection).
- **C6 / R7** (both drivers) — parked waiters/events were resolved before the membership snapshot was published, so a woken consumer could read pre-transition state. Both drivers now **publish the snapshot before notifying**, at every drain path (including the compio shutdown-freeze barrier). On compio the six duplicated publish-then-drain sequences are **centralized into one helper** so the ordering can't drift.
- **C7 / R8** (both drivers) — an active both-halves-live write was governed by `close_timeout`, which a `close_timeout < stream_timeout` config could abort early. Active writes are now governed by the machine `stream_timeout` (new additive `StreamEndpoint::stream_timeout()` accessor); `close_timeout` is reserved for the post-Close drain.
- **R10** (reactor) — the observation overflow gate could deliver a new `UserPacket`/`RemoteStateReceived` ahead of older queued events, and (after the initial fix) could drop app-data while a channel slot was free. It now drains the backlog into any freed slot first, preserving FIFO and dropping only when genuinely at capacity.

## C2 excluded (documented)

C2 (compio one-datagram past-due peek → false `PingFailed`) is **not fixed here, deliberately**: its harm is the *probe* class, which is ordering-independent — `complete_probe_success` rejects a late-*decoded* Ack via its own absolute cutoff, so no socket-drain gate can change the outcome — and the slated arrival-timestamp fix is barred (receipt-threading was retired and must not return). Forcing a gate would add risk for no gain on the reported defect.
