### PR TITLE
fix(proto): close the self-leave member-ID takeover (Dead not Left; reject unrefutable MAX evidence) (#158 F1)

### DIFF
--- a/memberlist-proto/src/endpoint/mod.rs
+++ b/memberlist-proto/src/endpoint/mod.rs
@@ -1966,12 +1966,34 @@ where
   }
 
   /// Driver feeds an incoming Suspect message.
+  ///
+  /// A `u32::MAX` incarnation is the single unrefutable accusation: a node
+  /// accused at MAX cannot advance its own incarnation past it (`refute` wraps
+  /// `MAX + 1` to `0`, which peers reject as `0 < MAX`), so it can never
+  /// self-heal. An honest node never reaches MAX — its incarnation advances only
+  /// through its own refutations — so failure evidence (`Dead`/`Suspect`) at MAX
+  /// about a live peer can only be forged, and a plaintext deployment lets an
+  /// external party forge it. Storing it would pin the target un-refutably and,
+  /// once the tombstone is reclaimed, let its id be redirected to a new address.
+  /// Refuse it here, at the external funnels only; locally-synthesized failure
+  /// detection (suspicion expiry, probe failure) still fires at any incarnation,
+  /// so a member forced to MAX by a forged `Alive` is never rendered un-failable.
   pub(crate) fn handle_suspect(&mut self, _from: A, suspect: Suspect<I>, at: Instant) {
+    if suspect.incarnation() == u32::MAX {
+      self.metrics.unrefutable_failure_rejected += 1;
+      return;
+    }
     self.process_suspect(suspect, at);
   }
 
-  /// Driver feeds an incoming Dead message.
+  /// Driver feeds an incoming Dead message. Failure evidence at the unrefutable
+  /// `u32::MAX` incarnation is refused at this external funnel; see
+  /// [`handle_suspect`](Self::handle_suspect) for the full rationale.
   pub(crate) fn handle_dead(&mut self, _from: A, dead: Dead<I>, at: Instant) {
+    if dead.incarnation() == u32::MAX {
+      self.metrics.unrefutable_failure_rejected += 1;
+      return;
+    }
     self.process_dead(dead, at);
   }
 
@@ -4179,6 +4201,12 @@ where
           self.process_alive(alive, false, now);
         }
         State::Left => {
+          // Unrefutable `u32::MAX` failure evidence is refused at this external
+          // funnel; see [`handle_suspect`](Self::handle_suspect).
+          if inc == u32::MAX {
+            self.metrics.unrefutable_failure_rejected += 1;
+            continue;
+          }
           // `from` MUST be the local id, NOT `id`. `process_dead` records
           // `State::Left` only when `node == from` (the genuine self-leave
           // sentinel), otherwise `State::Dead`. `State::Left` is
@@ -4190,6 +4218,12 @@ where
           self.process_dead(dead, now);
         }
         State::Dead | State::Suspect => {
+          // Unrefutable `u32::MAX` failure evidence is refused at this external
+          // funnel; see [`handle_suspect`](Self::handle_suspect).
+          if inc == u32::MAX {
+            self.metrics.unrefutable_failure_rejected += 1;
+            continue;
+          }
           let from = self.cfg.local_id_ref().cheap_clone();
           let s = Suspect::new(inc, id, from);
           self.process_suspect(s, now);

--- a/memberlist-proto/src/endpoint/mod.rs
+++ b/memberlist-proto/src/endpoint/mod.rs
@@ -1821,8 +1821,6 @@ where
 
     let local_id = self.cfg.local_id_ref().cheap_clone();
     let is_self = target == local_id;
-    // "self-marked-itself-dead" sentinel: target == from.
-    let self_marked = target == from;
 
     let (local_inc, current_state) = {
       let m = self.members.get(&target).unwrap();
@@ -1899,12 +1897,22 @@ where
     if let Some(m) = self.members.get_mut(&target) {
       let current_state = m.state_mut();
       current_state.set_incarnation(inc);
-      let new_state = if self_marked {
-        State::Left
-      } else {
-        State::Dead
-      };
-      current_state.set_state(new_state, now);
+      // Remote ingress records `State::Dead` unconditionally — never
+      // `State::Left`, even for the `node == from` self-marked-departure
+      // sentinel. `State::Left` is immediately address-reclaimable and exempt
+      // from the Alive incarnation-staleness guard; granting it off a payload
+      // whose only self-leave signal is two fields being equal would let an
+      // unauthenticated forger flip a live peer to `Left` and instantly
+      // redirect its id to an attacker-chosen address. A self-leave is
+      // unattributable in plaintext gossip — SWIM relays `Dead{X, X}` through
+      // arbitrary peers, so the transport source is never X — so it is
+      // downgraded to reclaim-protected `Dead`: peers still reap the target,
+      // and its address is reused only after `dead_node_reclaim_time` or the
+      // `reset_nodes` reap window, never instantly off an unattributed message.
+      // `State::Left` is reserved for the local node leaving itself (the
+      // `is_self` branch above) and mirrors the push/pull ingress
+      // (`merge_state` rewrites remote `Left` to `Dead`).
+      current_state.set_state(State::Dead, now);
     }
 
     self.broadcast_message(

--- a/memberlist-proto/src/endpoint/swim_parity_tests.rs
+++ b/memberlist-proto/src/endpoint/swim_parity_tests.rs
@@ -57,8 +57,9 @@ fn alive_of(n: &Node<SmolStr, SocketAddr>, inc: u32) -> Alive<SmolStr, SocketAdd
 }
 
 /// A `Dead` for `target` accused by `from` at incarnation `inc`. When
-/// `target == from` this is the self-marked-departure sentinel that resolves to
-/// `State::Left` rather than `State::Dead`.
+/// `target == from` this is the self-marked-departure sentinel; on remote
+/// ingress it resolves to reclaim-protected `State::Dead` (`State::Left` is
+/// local-only, reserved for the local node leaving itself).
 fn dead_of(target: &SmolStr, from: &SmolStr, inc: u32) -> Dead<SmolStr> {
   Dead::new(inc, target.cheap_clone(), from.cheap_clone())
 }
@@ -996,9 +997,10 @@ fn dead_node_old_dead() {
   );
 }
 
-/// The `node == from` self-marked-departure sentinel resolves to `State::Left`
-/// (not `State::Dead`), emits `NodeLeft`, and gossips a `Dead`. After the
-/// reclaim window a fresh `Alive` at a new address re-adopts the id.
+/// The `node == from` self-marked-departure sentinel resolves to
+/// reclaim-protected `State::Dead` (never the reclaimable `State::Left`), emits
+/// `NodeLeft`, and gossips a `Dead`. After `dead_node_reclaim_time` a fresh
+/// `Alive` at a new address re-adopts the id.
 #[test]
 fn dead_node_left() {
   let mut e: Endpoint<SmolStr, SocketAddr> =
@@ -1014,8 +1016,8 @@ fn dead_node_left() {
   e.process_dead(dead_of(&id, &id, 1), t0);
   assert_eq!(
     e.member_liveness(&id),
-    Some(State::Left),
-    "a self-marked Dead resolves to Left, not Dead"
+    Some(State::Dead),
+    "a remote self-marked Dead resolves to reclaim-protected Dead, not Left"
   );
 
   let ev = e.poll_event().expect("expected NodeLeft");
@@ -1023,7 +1025,7 @@ fn dead_node_left() {
     Event::NodeLeft(n) => assert_eq!(n.id_ref(), &id),
     other => panic!("expected NodeLeft, got {other:?}"),
   }
-  // A Left transition still gossips the Dead.
+  // The Dead transition still gossips the Dead.
   assert_eq!(
     drained_dead_incarnations(&mut e, &id),
     vec![1],

--- a/memberlist-proto/src/endpoint/tests.rs
+++ b/memberlist-proto/src/endpoint/tests.rs
@@ -354,14 +354,125 @@ fn dead_self_when_not_leaving_refutes() {
 }
 
 #[test]
-fn dead_self_marked_message_treats_as_left() {
+fn remote_self_marked_dead_marks_dead_not_left() {
+  // A remote self-marked departure (node == from) records reclaim-protected
+  // State::Dead, NEVER State::Left. State::Left is immediately
+  // address-reclaimable and exempt from the incarnation-staleness guard, so
+  // granting it off an unattributable gossip payload would let a forger take
+  // over a live id. State::Left is reserved for the local self-leave.
   let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
   process_alive_auto(&mut e, alive("bob", 7001, 1), false, Instant::now());
   while e.poll_event().is_some() {}
   // node==from convention: bob is announcing his own departure.
   e.process_dead(dead("bob", "bob", 1), Instant::now());
   let bob = e.members.get(&SmolStr::new("bob")).unwrap();
-  assert_eq!(bob.state_ref().state(), State::Left);
+  assert_eq!(bob.state_ref().state(), State::Dead);
+}
+
+/// A remote self-marked `Dead{X, from: X}` must not grant the privileged
+/// `State::Left` that would let an unauthenticated forger instantly redirect a
+/// live peer's id to an attacker-chosen address. The target
+/// becomes reclaim-protected `State::Dead`, so a lower- or higher-incarnation
+/// `Alive` at a fresh address is rejected/conflicted rather than adopted; only a
+/// genuine same-address refutation revives it.
+#[test]
+fn remote_self_leave_cannot_takeover_id() {
+  let real: SocketAddr = "127.0.0.1:7001".parse().unwrap();
+  let attacker: SocketAddr = "127.0.0.1:6666".parse().unwrap();
+  let x = SmolStr::new("x");
+
+  // Default cfg: dead_node_reclaim_time == 0, so a Dead id is never instantly
+  // reclaimable — only State::Left would be.
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  let now = Instant::now();
+  process_alive_auto(&mut e, alive("x", 7001, 5), false, now);
+  while e.poll_event().is_some() {}
+
+  // The forger relays a self-marked Dead for x (node == from). It must record
+  // reclaim-protected Dead, not Left.
+  e.process_dead(dead("x", "x", 5), now);
+  assert_eq!(
+    e.member_liveness(&x),
+    Some(State::Dead),
+    "a remote self-marked Dead must record Dead, never the reclaimable Left"
+  );
+
+  // A lower-incarnation Alive at the attacker's address must not resurrect x:
+  // the incarnation-staleness guard rejects it (Dead is not exempt).
+  e.process_alive(alive("x", 6666, 0), false, now);
+  assert_eq!(
+    e.member(&x).unwrap().address_ref(),
+    &real,
+    "a stale lower-incarnation Alive must not adopt the attacker address"
+  );
+  while e.poll_event().is_some() {}
+
+  // A higher-incarnation Alive at the attacker's address is a genuine
+  // address-conflict for a Dead (non-reclaimable) member: NodeConflict is
+  // emitted and the tracked address stays @real.
+  e.process_alive(alive("x", 6666, 6), false, now);
+  let ev = e.poll_event().expect("expected NodeConflict");
+  match ev {
+    Event::NodeConflict(p) => {
+      assert_eq!(p.existing_ref().address_ref(), &real);
+      assert_eq!(p.other_ref().address_ref(), &attacker);
+    }
+    other => panic!("expected NodeConflict, got {other:?}"),
+  }
+  assert_eq!(
+    e.member(&x).unwrap().address_ref(),
+    &real,
+    "a higher-incarnation Alive at a new address must conflict, not take over"
+  );
+
+  // A genuine refutation from x's real address at a higher incarnation revives
+  // it in place — the legitimate recovery path is preserved.
+  e.process_alive(alive("x", 7001, 6), false, now);
+  assert_eq!(
+    e.member_liveness(&x),
+    Some(State::Alive),
+    "genuine refute revives x"
+  );
+  assert_eq!(e.member(&x).unwrap().address_ref(), &real);
+}
+
+/// Control: the LOCAL node leaving itself still transitions to `State::Left`
+/// (the `is_self` self-leave branch, checked before the remote block). Only the
+/// remote-ingress mapping changed.
+#[test]
+fn local_self_leave_still_marks_left() {
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  while e.poll_event().is_some() {}
+  e.leave(Instant::now()).expect("leave ok");
+  while e.poll_transmit().is_some() {}
+  while e.poll_event().is_some() {}
+  assert_eq!(e.member_liveness(&SmolStr::new("local")), Some(State::Left));
+  assert!(e.is_left());
+}
+
+/// Liveness control: a genuine remote departure is still reclaimable once
+/// `dead_node_reclaim_time` elapses — the downgrade to Dead delays reclaim, it
+/// does not forbid it.
+#[test]
+fn remote_self_leave_reclaimable_after_window() {
+  let mut e: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(cfg().with_dead_node_reclaim_time(Duration::from_millis(10)));
+  let t0 = Instant::now();
+  process_alive_auto(&mut e, alive("bob", 7001, 1), false, t0);
+  while e.poll_event().is_some() {}
+
+  e.process_dead(dead("bob", "bob", 1), t0);
+  assert_eq!(e.member_liveness(&SmolStr::new("bob")), Some(State::Dead));
+
+  // Past the reclaim window, a higher-incarnation Alive at a new address is
+  // adopted.
+  let later = t0 + Duration::from_millis(11);
+  e.process_alive_decided(alive("bob", 7777, 2), false, later);
+  assert_eq!(e.member_liveness(&SmolStr::new("bob")), Some(State::Alive));
+  assert_eq!(
+    e.member(&SmolStr::new("bob")).unwrap().address_ref().port(),
+    7777
+  );
 }
 
 use PushNodeState;
@@ -8833,10 +8944,11 @@ fn ping_untracked_node_synthesizes_target_state() {
 }
 
 #[test]
-fn gossip_scheduler_skips_left_members_as_candidates() {
-  // A Left member is not a gossip candidate (the `_ => false` filter arm). With
-  // only a Left peer present, gossip selects no target and emits nothing, yet
-  // does not panic and reschedules.
+fn gossip_scheduler_skips_out_of_window_dead_members_as_candidates() {
+  // A Dead member past the `gossip_to_the_dead_time` window is not a gossip
+  // candidate (the Dead-window / `_ => false` filter arms). With only such a
+  // peer present, gossip selects no target and emits nothing, yet does not
+  // panic and reschedules.
   let cfg = EndpointOptions::<SmolStr, SocketAddr>::new(
     SmolStr::new("local"),
     "127.0.0.1:7946".parse().unwrap(),
@@ -8844,24 +8956,28 @@ fn gossip_scheduler_skips_left_members_as_candidates() {
   .with_probe_interval(Duration::ZERO)
   .with_gossip_interval(Duration::from_millis(50))
   .with_gossip_nodes(2)
+  .with_gossip_to_the_dead_time(Duration::ZERO)
   .with_push_pull_interval(Duration::ZERO);
   let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg);
   let t0 = Instant::now();
   process_alive_auto(&mut e, alive("gone", 7947, 1), false, t0);
-  // Mark "gone" as Left (self-marked dead sentinel: node == from).
+  // A remote self-marked departure (node == from) records reclaim-protected
+  // Dead.
   e.process_dead(dead("gone", "gone", 2), t0);
-  assert_eq!(e.member_liveness(&SmolStr::new("gone")), Some(State::Left));
+  assert_eq!(e.member_liveness(&SmolStr::new("gone")), Some(State::Dead));
   while e.poll_event().is_some() {}
   while e.poll_transmit().is_some() {}
 
   e.queue_user_broadcast(bytes::Bytes::from_static(b"x"))
     .unwrap();
-  e.next_gossip = Some(t0);
-  e.handle_timeout(t0);
-  // The only peer is Left ⇒ no gossip target ⇒ nothing transmitted.
+  // Gossip one tick past the zero-length dead window: the only peer is Dead and
+  // out of window ⇒ no gossip target ⇒ nothing transmitted.
+  let later = t0 + Duration::from_millis(1);
+  e.next_gossip = Some(later);
+  e.handle_timeout(later);
   assert!(
     e.poll_transmit().is_none(),
-    "a Left-only membership must yield no gossip target"
+    "a Dead-out-of-window-only membership must yield no gossip target"
   );
 }
 
@@ -9873,7 +9989,11 @@ fn probe_expiry_does_not_suspect_a_readdressed_replacement() {
   let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(
     cfg()
       .with_probe_timeout(Duration::from_millis(50))
-      .with_probe_interval(Duration::from_millis(80)),
+      .with_probe_interval(Duration::from_millis(80))
+      // Short reclaim window so the departed bob's address is legitimately
+      // adoptable once it elapses (a remote self-marked Dead is
+      // reclaim-protected, not instantly reclaimable like the old Left).
+      .with_dead_node_reclaim_time(Duration::from_millis(5)),
   );
   let t0 = Instant::now();
   // bob@7001 admitted Alive at incarnation 10.
@@ -9909,11 +10029,11 @@ fn probe_expiry_does_not_suspect_a_readdressed_replacement() {
   probe.dispatched = true;
   e.probes.insert(seq, probe);
 
-  // bob gracefully leaves (self-marked Dead ⇒ State::Left, immediately
-  // address-reclaimable), then a NEW bob instance is admitted at a DIFFERENT
-  // address (7777) with a LOWER incarnation (2) than the probe snapshot (10).
-  // The address-adoption path bypasses the incarnation guard, so bob@7777 is
-  // admitted at incarnation 2.
+  // bob gracefully leaves (self-marked Dead ⇒ reclaim-protected State::Dead).
+  // Once the reclaim window elapses, a NEW bob instance is admitted at a
+  // DIFFERENT address (7777) with a LOWER incarnation (2) than the probe
+  // snapshot (10). The address-adoption path bypasses the incarnation guard, so
+  // bob@7777 is admitted at incarnation 2.
   e.process_dead(dead("bob", "bob", 10), t0 + Duration::from_millis(10));
   e.process_alive_decided(alive("bob", 7777, 2), false, t0 + Duration::from_millis(20));
   {
@@ -10015,16 +10135,17 @@ fn probe_expiry_does_not_suspect_a_same_address_lower_incarnation_replacement() 
   probe.dispatched = true;
   e.probes.insert(seq, probe);
 
-  // bob gracefully leaves (self-marked Dead ⇒ State::Left), is reclaimed by
-  // reset_nodes once past gossip_to_the_dead_time, then a NEW bob is admitted at
-  // the SAME address 7001 with a LOWER incarnation (2). Because the id was
-  // removed first, this hits the new-member branch, which sets incarnation to 2
-  // (a same-address Alive would otherwise be rejected as `inc <= local_inc`).
+  // bob gracefully leaves (self-marked Dead ⇒ reclaim-protected State::Dead),
+  // is reclaimed by reset_nodes once past gossip_to_the_dead_time, then a NEW
+  // bob is admitted at the SAME address 7001 with a LOWER incarnation (2).
+  // Because the id was removed first, this hits the new-member branch, which
+  // sets incarnation to 2 (a same-address Alive would otherwise be rejected as
+  // `inc <= local_inc`).
   e.process_dead(dead("bob", "bob", 10), t0 + Duration::from_millis(10));
   assert_eq!(
     e.member_liveness(&SmolStr::new("bob")),
-    Some(State::Left),
-    "bob self-marked Left"
+    Some(State::Dead),
+    "bob self-marked Dead"
   );
   e.reset_nodes(t0 + Duration::from_millis(20));
   assert!(
@@ -10123,16 +10244,16 @@ fn probe_expiry_does_not_suspect_an_equal_incarnation_reset_readmit_replacement(
     "the probe snapshots the original instance's generation"
   );
 
-  // bob gracefully leaves (State::Left), reset_nodes reclaims it, then a FRESH
-  // bob is admitted at the SAME address 7001 and the SAME incarnation 1. Because
-  // the id was removed first, this hits the new-member branch, which draws a NEW
-  // generation — so (id, address, incarnation) all match the probed instance yet
-  // the generation differs.
+  // bob gracefully leaves (reclaim-protected State::Dead), reset_nodes reclaims
+  // it, then a FRESH bob is admitted at the SAME address 7001 and the SAME
+  // incarnation 1. Because the id was removed first, this hits the new-member
+  // branch, which draws a NEW generation — so (id, address, incarnation) all
+  // match the probed instance yet the generation differs.
   e.process_dead(dead("bob", "bob", 1), t0 + Duration::from_millis(10));
   assert_eq!(
     e.member_liveness(&SmolStr::new("bob")),
-    Some(State::Left),
-    "bob self-marked Left"
+    Some(State::Dead),
+    "bob self-marked Dead"
   );
   e.reset_nodes(t0 + Duration::from_millis(20));
   assert!(

--- a/memberlist-proto/src/endpoint/tests.rs
+++ b/memberlist-proto/src/endpoint/tests.rs
@@ -475,6 +475,183 @@ fn remote_self_leave_reclaimable_after_window() {
   );
 }
 
+/// A remote `Dead` at the unrefutable `u32::MAX` incarnation is refused at the
+/// external funnel: a live peer accused at MAX could never advance its own
+/// incarnation past it, so such evidence can only be forged. X stays Alive.
+#[test]
+fn remote_dead_at_max_incarnation_rejected() {
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  let now = Instant::now();
+  process_alive_auto(&mut e, alive("x", 7001, 5), false, now);
+  while e.poll_event().is_some() {}
+  let relay: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+  e.handle_dead(relay, dead("x", "relay", u32::MAX), now);
+  let x = e.members.get(&SmolStr::new("x")).unwrap();
+  assert_eq!(x.state_ref().state(), State::Alive, "X must stay Alive");
+  assert_eq!(x.state_ref().incarnation(), 5, "incarnation untouched");
+  assert!(e.poll_event().is_none(), "no NodeLeft may be emitted");
+  assert_eq!(e.metrics().unrefutable_failure_rejected, 1);
+}
+
+/// Symmetric to `remote_dead_at_max_incarnation_rejected` on the `Suspect`
+/// funnel: no suspicion timer is armed and X stays Alive.
+#[test]
+fn remote_suspect_at_max_incarnation_rejected() {
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  let now = Instant::now();
+  process_alive_auto(&mut e, alive("x", 7001, 5), false, now);
+  while e.poll_event().is_some() {}
+  let relay: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+  e.handle_suspect(relay, suspect("x", "relay", u32::MAX), now);
+  let x = e.members.get(&SmolStr::new("x")).unwrap();
+  assert_eq!(x.state_ref().state(), State::Alive, "X must stay Alive");
+  assert_eq!(x.state_ref().incarnation(), 5, "incarnation untouched");
+  assert!(x.suspicion().is_none(), "no suspicion may be armed");
+  assert_eq!(e.metrics().unrefutable_failure_rejected, 1);
+}
+
+/// A forged self-`Dead` at `u32::MAX` must be dropped at the external funnel
+/// BEFORE it can reach `refute`, so the local incarnation never wraps to 0. The
+/// external guard, not the wrap, is what protects the local node here.
+#[test]
+fn self_dead_at_max_does_not_wrap_local_incarnation() {
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  while e.poll_event().is_some() {}
+  let starting_inc = e
+    .members
+    .get(&SmolStr::new("local"))
+    .unwrap()
+    .state_ref()
+    .incarnation();
+  let relay: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+  e.handle_dead(relay, dead("local", "relay", u32::MAX), Instant::now());
+  let local = e.members.get(&SmolStr::new("local")).unwrap();
+  assert_eq!(
+    local.state_ref().incarnation(),
+    starting_inc,
+    "local incarnation must be untouched (no refute, no wrap to 0)"
+  );
+  assert_eq!(local.state_ref().state(), State::Alive);
+  assert_eq!(e.metrics().unrefutable_failure_rejected, 1);
+}
+
+/// Anti-entropy push/pull `Dead` and `Left` entries at `u32::MAX` are refused in
+/// `merge_state`, so a forged pull payload cannot pin a live id un-refutably.
+#[test]
+fn merge_state_dead_at_max_rejected() {
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  let now = Instant::now();
+  process_alive_auto(&mut e, alive("x", 7001, 5), false, now);
+  while e.poll_event().is_some() {}
+  e.merge_state(&[pns("x", 7001, u32::MAX, State::Dead)], now);
+  e.merge_state(&[pns("x", 7001, u32::MAX, State::Left)], now);
+  let x = e.members.get(&SmolStr::new("x")).unwrap();
+  assert_eq!(
+    x.state_ref().state(),
+    State::Alive,
+    "X must survive as Alive"
+  );
+  assert_eq!(x.state_ref().incarnation(), 5, "incarnation untouched");
+  assert!(x.suspicion().is_none(), "no suspicion may be armed");
+  assert_eq!(e.metrics().unrefutable_failure_rejected, 2);
+}
+
+/// End-to-end takeover-blocked: a forged `Dead{X, u32::MAX}` must never open the
+/// delayed id-takeover window. Because the evidence is refused, X stays Alive and
+/// `reset_nodes` never reaps it — so no reclaim window opens and an `Alive{X}` at
+/// an attacker address conflicts instead of being adopted.
+#[test]
+fn max_forgery_cannot_take_over_id_after_reclaim() {
+  let real: SocketAddr = "127.0.0.1:7001".parse().unwrap();
+  let attacker: SocketAddr = "127.0.0.1:6666".parse().unwrap();
+  let x = SmolStr::new("x");
+
+  let mut e: Endpoint<SmolStr, SocketAddr> =
+    Endpoint::new_seeded(cfg().with_gossip_to_the_dead_time(Duration::from_millis(5)));
+  let t0 = Instant::now();
+  process_alive_auto(&mut e, alive("x", 7001, 5), false, t0);
+  while e.poll_event().is_some() {}
+
+  // The forger relays a self-marked Dead for X at the unrefutable MAX. It is
+  // dropped at the external funnel: X stays Alive at its real address.
+  let relay: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+  e.handle_dead(relay, dead("x", "x", u32::MAX), t0);
+  assert_eq!(
+    e.member_liveness(&x),
+    Some(State::Alive),
+    "forged MAX Dead must not make X Dead"
+  );
+
+  // Past gossip_to_the_dead_time, reset_nodes reaps only Dead/Left tombstones.
+  // X is Alive, so it is never reaped — no reclaim window ever opens.
+  e.reset_nodes(t0 + Duration::from_millis(10));
+  assert!(
+    e.members.get(&x).is_some(),
+    "an Alive X must not be reaped by reset_nodes"
+  );
+  assert_eq!(e.member_liveness(&x), Some(State::Alive));
+
+  // A subsequent Alive{X} at the attacker's address cannot take over: X is still
+  // Alive at its real address, so this is an address conflict, not an admission.
+  e.process_alive(alive("x", 6666, 6), false, t0 + Duration::from_millis(11));
+  assert_eq!(
+    e.member(&x).unwrap().address_ref(),
+    &real,
+    "the attacker address must NOT be adopted"
+  );
+  assert_ne!(
+    e.member(&x).unwrap().address_ref(),
+    &attacker,
+    "no takeover: X keeps its real address"
+  );
+}
+
+/// Liveness-preserved counter-test to the external-only placement: a member
+/// forced to stored incarnation `u32::MAX` via a forged `Alive@MAX` (the
+/// non-failure path, still accepted) must remain LOCALLY failable. A real
+/// suspicion that expires still synthesizes its `Dead` and transitions X to
+/// `Dead` — the ingress guard did not render a MAX member un-failable.
+#[test]
+fn max_incarnation_member_still_locally_failable() {
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(
+    cfg()
+      .with_probe_interval(Duration::from_millis(10))
+      .with_suspicion_mult(1)
+      .with_suspicion_max_timeout_mult(1),
+  );
+  let t0 = Instant::now();
+  // Forge X up to stored incarnation MAX via the Alive path (unchanged, still
+  // accepted — only failure evidence at MAX is refused).
+  process_alive_auto(&mut e, alive("x", 7001, u32::MAX), false, t0);
+  assert_eq!(
+    e.members
+      .get(&SmolStr::new("x"))
+      .unwrap()
+      .state_ref()
+      .incarnation(),
+    u32::MAX,
+    "X is forced to stored incarnation MAX"
+  );
+
+  // Arm a REAL suspicion (as a local synthesizer would) and expire it. This
+  // routes through process_suspect / fire_expired_suspicions, which the external
+  // guard does not touch.
+  e.process_suspect(suspect("x", "carol", u32::MAX), t0);
+  let deadline = e.poll_timeout().expect("suspicion deadline expected");
+  e.handle_timeout(deadline + Duration::from_millis(10));
+  assert_eq!(
+    e.members
+      .get(&SmolStr::new("x"))
+      .unwrap()
+      .state_ref()
+      .state(),
+    State::Dead,
+    "a MAX-incarnation member must still be locally failable"
+  );
+  // No failure evidence entered through an external funnel.
+  assert_eq!(e.metrics().unrefutable_failure_rejected, 0);
+}
+
 use PushNodeState;
 
 fn pns(node_id: &str, port: u16, inc: u32, st: State) -> PushNodeState<SmolStr, SocketAddr> {

--- a/memberlist-proto/src/metrics.rs
+++ b/memberlist-proto/src/metrics.rs
@@ -50,4 +50,10 @@ pub struct Metrics {
   /// tracked member's address (`ack_payload_to_members_only`), bounding the
   /// reflective byte-amplification a spoofed-source ping can elicit.
   pub ack_payloads_withheld: u64,
+  /// Inbound failure evidence (`Dead`/`Suspect`) refused at an external ingress
+  /// funnel because its incarnation was `u32::MAX` — the single unrefutable
+  /// accusation, which an honest node never emits about a live peer. Refusing it
+  /// keeps a plaintext forger from pinning a live id un-refutably. Locally
+  /// synthesized failure detection is unaffected.
+  pub unrefutable_failure_rejected: u64,
 }


### PR DESCRIPTION
Addresses #158 finding **F1** (High) — packet-source-independent self-leave permits immediate member-ID takeover — and the un-refutable-incarnation variant the adversarial review surfaced while closing it.

## The takeover (external, plaintext-reachable)

A remote self-marked `Dead` (payload `node == from`) flipped the target to the privileged `State::Left`, which is **immediately** address-reclaimable (bypasses `dead_node_reclaim_time`) and **exempt** from the Alive incarnation-staleness guard. Both takeover legs hang off `Left`. In a plaintext deployment an **external** attacker forges `Dead{X, X, n}` from any address → X becomes `Left` (false `NodeLeft` for a live member) → `Alive{X@attacker, inc:0}` is adopted immediately, redirecting X's identity to an attacker-chosen address. (memberlist supports plaintext; HashiCorp Go carries the same hole there — this is the fix-upstream-bug class, not a parity concern.)

## The fix (two legs)

1. **Remote self-marked `Dead` records reclaim-protected `Dead`, never `Left`.** A self-leave is unattributable in plaintext gossip — SWIM relays `Dead{X,X}` through arbitrary peers, so the transport source is never X — so it is downgraded to `Dead`: peers still reap the target, but its address is reused only after `dead_node_reclaim_time` or the `reset_nodes` reap window, never instantly off an unattributed message. `State::Left` is now **local-only** (the node leaving *itself*, the `is_self` branch), mirroring the push/pull ingress (`merge_state` already rewrites remote `Left`→`Dead`).
2. **Reject un-refutable (`u32::MAX`) failure evidence at the external ingress.** Closing leg 1 exposed a delayed takeover: a forged `Dead{X, X, u32::MAX}` pins X un-refutably (`refute(MAX)` wraps to 0, so X's `Alive@0` is rejected against the stored `MAX` and X can't self-heal), and once `reset_nodes` reaps the tombstone the attacker wins admission at a new address. `u32::MAX` is the single un-refutable accusation, and an honest node never reaches it (incarnation advances only via its own ~2³² refutations), so failure evidence at `MAX` about a live peer can only be forged. It is now refused at the **three external funnels** (`handle_dead`, `handle_suspect`, and `merge_state`'s Left/Dead/Suspect arms) — **not** at `process_dead`/`process_suspect`, because those are also the funnel for the *internal* synthesizers (suspicion expiry, probe failure): a member driven to `MAX` by a forged `Alive@MAX` must still be **locally** failable. `refute`'s wrap and the pinned Alive-path wrap test are untouched. A new `unrefutable_failure_rejected` metric counts refusals.

## Scope note

A forged `Alive@MAX` about a *remote* peer still bumps that peer's stored incarnation to `MAX` — no identity theft, just a marginal nuisance requiring active forgery; full MAX-hardening of the remote-`Alive` path is a documented defense-in-depth follow-up, not part of this takeover fix.
