### PR TITLE
fix(proto): cap inbound gossip datagram size to bound the ingress queue's memory (#158 F5)

### DIFF
--- a/memberlist-proto/src/metrics.rs
+++ b/memberlist-proto/src/metrics.rs
@@ -17,6 +17,16 @@ pub struct Metrics {
   /// was already full (a memory-DoS backstop against a driver that does not gate
   /// its socket reads).
   pub gossip_ingress_dropped: u64,
+  /// Inbound gossip datagrams rejected at admission because they exceeded the
+  /// endpoint's own configured gossip MTU (plus its wrapper overheads) —
+  /// closing the gap where a source-rotating flood of near-max-datagram-size
+  /// frames could otherwise fill `gossip_ingress_dropped`'s count cap at
+  /// hundreds of MiB of attacker-controlled queued bytes. Distinct from
+  /// `gossip_ingress_dropped`: this is a SIZE rejection, counted before the
+  /// datagram can count against either the per-peer or the node-global
+  /// ingress cap, never a count-cap load-shed. Zero on a transport with no
+  /// per-datagram size cap.
+  pub gossip_ingress_oversized: u64,
   /// New nodes refused admission at the optional `max_members` ceiling. A
   /// refused node is never added to membership; existing members are unaffected.
   pub members_rejected: u64,

--- a/memberlist-proto/src/quic/mod.rs
+++ b/memberlist-proto/src/quic/mod.rs
@@ -1625,14 +1625,21 @@ impl<I, R> QuicEndpoint<I, R> {
   /// [`gossip_ingress_dropped`](crate::metrics::Metrics::gossip_ingress_dropped)
   /// — the inner `Endpoint`'s own gossip-ingress count is the STREAM plane's
   /// (zero on a QUIC endpoint) — so a driver reads one unified counter regardless
-  /// of transport.
+  /// of transport. Also surfaces the per-datagram size rejection
+  /// (`oversized_datagram_dropped`) on
+  /// [`gossip_ingress_oversized`](crate::metrics::Metrics::gossip_ingress_oversized)
+  /// so an oversized-datagram flood is visible in the PUBLIC snapshot, not
+  /// just the internal counter.
   pub fn metrics(&self) -> crate::metrics::Metrics {
     // `Endpoint::metrics` returns a borrow; `Metrics` is `Copy`, so take an
-    // owned copy to fold in this endpoint's datagram-plane shed count.
+    // owned copy to fold in this endpoint's datagram-plane shed counts.
     let mut m = *self.ep.metrics();
     m.gossip_ingress_dropped = m
       .gossip_ingress_dropped
       .saturating_add(self.datagram_ingress_dropped);
+    m.gossip_ingress_oversized = m
+      .gossip_ingress_oversized
+      .saturating_add(self.oversized_datagram_dropped);
     m
   }
 

--- a/memberlist-proto/src/quic/mod.rs
+++ b/memberlist-proto/src/quic/mod.rs
@@ -132,6 +132,25 @@ const MAX_MEM_INGRESS_DATAGRAMS: usize = 8192;
 /// is popped from quinn (so its buffer cannot accumulate) and dropped.
 const MAX_INGRESS_DATAGRAMS_PER_PEER: usize = 1024;
 
+/// The largest the encrypted wrapper can inflate a gossip datagram, or `0`
+/// when no encryption backend is built in. The crate-root
+/// [`crate::ENCRYPTED_WRAPPER_OVERHEAD`] re-export is itself gated on the
+/// same `encryption` cfg, so it does not exist to reference when no backend
+/// is compiled in; this local alias mirrors the pattern the compio/reactor
+/// drivers use to size their gossip receive buffers.
+#[cfg(encryption)]
+const ENCRYPTED_WRAPPER_OVERHEAD: usize = crate::ENCRYPTED_WRAPPER_OVERHEAD;
+#[cfg(not(encryption))]
+const ENCRYPTED_WRAPPER_OVERHEAD: usize = 0;
+
+/// The largest the checksum wrapper can inflate a gossip datagram, or `0`
+/// when no checksum backend is built in. Same rationale as
+/// [`ENCRYPTED_WRAPPER_OVERHEAD`] above.
+#[cfg(checksum)]
+const CHECKSUMED_WRAPPER_OVERHEAD: usize = crate::CHECKSUMED_WRAPPER_OVERHEAD;
+#[cfg(not(checksum))]
+const CHECKSUMED_WRAPPER_OVERHEAD: usize = 0;
+
 /// Maximum ready bridges the datagram service path pumps in ONE pass. Overflow
 /// stays queued in `ready_bridges` (its `Bridge::queued` flag set) and drains on
 /// the next pass — popped FRONT-first, so oldest-first round-robin — or on the
@@ -318,28 +337,52 @@ const _: () = assert!(
 );
 
 /// Push one inbound unreliable payload (a QUIC datagram or a plain-UDP gossip
-/// frame) into the shared coordinator ingress queue, enforcing the per-peer
-/// standing-share cap AND the node-global cap so neither source can exceed the
-/// bound. Drops and counts when either cap is reached; returns whether it was
+/// frame) into the shared coordinator ingress queue, enforcing a per-datagram
+/// wire-size cap, the per-peer standing-share cap, AND the node-global cap so
+/// neither an oversized frame nor a source-rotating flood can exceed the
+/// bound. Drops and counts when any cap is reached; returns whether it was
 /// queued. The per-peer counter is maintained here so a flood on EITHER
 /// transport cannot starve another peer's probe Ack and the global cap is a
 /// hard memory bound regardless of source.
 ///
-/// The payload is supplied as a thunk and built ONLY on admission: a rejected
-/// frame never materializes its `Bytes`, so a saturated queue cannot force an
-/// allocation/copy per dropped frame on the unauthenticated plain-UDP path
-/// (where the payload would otherwise be a fresh `Bytes::copy_from_slice`).
+/// `max_datagram_bytes` (the caller's [`QuicEndpoint::max_gossip_datagram_bytes`])
+/// bounds a SINGLE entry's size: a `Class::Memberlist` datagram larger than
+/// the endpoint's own configured gossip MTU (plus its wrapper overheads) is
+/// not legitimate gossip, so it is rejected before it can count against
+/// either the per-peer or the node-global cap. Combined with the node-global
+/// count cap, this bounds the shared queue's total bytes to
+/// `MAX_MEM_INGRESS_DATAGRAMS * max_gossip_datagram_bytes` regardless of how
+/// many distinct source addresses a flood rotates through — closing the count-
+/// only cap's gap, where a source-rotating flood of near-64KiB datagrams could
+/// fill the 8192-entry cap at hundreds of MiB.
 ///
-/// Borrows only the three disjoint ingress fields (never all of `self`) so the
+/// The payload is supplied as a thunk and built ONLY on admission: a rejected
+/// frame never materializes its `Bytes`, so a saturated queue OR an oversized
+/// frame cannot force an allocation/copy per dropped frame on the
+/// unauthenticated plain-UDP path (where the payload would otherwise be a
+/// fresh `Bytes::copy_from_slice`).
+///
+/// Borrows only the four disjoint ingress fields (never all of `self`) so the
 /// QUIC datagram drain in `service_quinn` can call it while the
 /// `self.conns.get_mut(..)` connection borrow is still live.
+#[allow(clippy::too_many_arguments)]
 fn push_mem_ingress_capped(
   mem_ingress: &mut VecDeque<(SocketAddr, Bytes)>,
   per_peer: &mut HashMap<SocketAddr, usize>,
   dropped: &mut u64,
+  oversized_dropped: &mut u64,
   from: SocketAddr,
+  max_datagram_bytes: usize,
+  datagram_len: usize,
   make_payload: impl FnOnce() -> Bytes,
 ) -> bool {
+  // Size gate FIRST, before either count check and before the payload thunk
+  // runs: an oversized datagram must count against neither cap (it is
+  // rejected outright, not merely load-shed) and must never be materialized.
+  if datagram_len > max_datagram_bytes {
+    *oversized_dropped = oversized_dropped.saturating_add(1);
+    return false;
+  }
   let queued = per_peer.get(&from).copied().unwrap_or(0);
   if queued >= MAX_INGRESS_DATAGRAMS_PER_PEER || mem_ingress.len() >= MAX_MEM_INGRESS_DATAGRAMS {
     // Reject WITHOUT constructing the payload: a saturated queue must not let a
@@ -832,6 +875,18 @@ pub struct QuicEndpoint<I, R = SmallRng> {
   /// bounded here by popping-and-dropping past either limit. Best-effort
   /// accounting only — never a membership signal.
   datagram_ingress_dropped: u64,
+  /// Count of inbound `Class::Memberlist` datagrams (plain-UDP or QUIC
+  /// datagram) rejected at admission because they exceeded
+  /// [`Self::max_gossip_datagram_bytes`] — the endpoint's own configured
+  /// gossip MTU plus its wrapper overheads. A datagram this large is not
+  /// legitimate gossip regardless of source, so it is rejected before it can
+  /// count against either the per-peer or the node-global ingress cap.
+  /// Distinct from [`Self::datagram_ingress_dropped`] (which counts drops
+  /// past the ingress COUNT cap): this counts a SIZE rejection, closing the
+  /// gap where a source-rotating flood of near-max-UDP-size datagrams could
+  /// otherwise fill the count cap at hundreds of MiB. Best-effort accounting
+  /// only — never a membership signal.
+  oversized_datagram_dropped: u64,
   /// Count of inbound application datagrams the `service_quinn` receive drain
   /// popped from quinn but DROPPED because the connection had not yet reached
   /// its application-readiness boundary (`established_at_least_once()` still
@@ -1222,6 +1277,7 @@ impl<I, R> QuicEndpoint<I, R> {
       last_now: None,
       datagram_dropped: 0,
       datagram_ingress_dropped: 0,
+      oversized_datagram_dropped: 0,
       pre_established_datagrams_dropped: 0,
       deadline_index: DeadlineIndex::new(),
       conns_with_pending_events: HashSet::new(),
@@ -1720,6 +1776,23 @@ impl<I, R> QuicEndpoint<I, R> {
   /// encryption is enabled.
   pub fn gossip_mtu(&self) -> usize {
     self.ep.gossip_mtu()
+  }
+
+  /// The largest legitimate on-wire `Class::Memberlist` datagram this
+  /// endpoint should ever emit or accept: [`Self::gossip_mtu`] plus the
+  /// encrypted and checksummed wrapper overheads (each `0` when its backend
+  /// is not built in) — the SAME formula the driver's `gossip_recv_buf_len`
+  /// uses to size its receive buffer. An inbound `Class::Memberlist`
+  /// datagram larger than this is not legitimate gossip, so
+  /// [`push_mem_ingress_capped`] rejects it at admission before it is
+  /// queued: bounding the shared ingress queue's total bytes to
+  /// `MAX_MEM_INGRESS_DATAGRAMS * max_gossip_datagram_bytes` regardless of
+  /// how many source addresses a flood rotates through.
+  pub(crate) fn max_gossip_datagram_bytes(&self) -> usize {
+    self
+      .gossip_mtu()
+      .saturating_add(ENCRYPTED_WRAPPER_OVERHEAD)
+      .saturating_add(CHECKSUMED_WRAPPER_OVERHEAD)
   }
 
   /// The largest UDP datagram this QUIC endpoint can receive: quinn's advertised
@@ -2670,11 +2743,15 @@ impl<I, R> QuicEndpoint<I, R> {
     // fallback flood cannot bypass the per-peer or node-global cap, drive
     // `mem_ingress_per_peer` past the bound the QUIC drain checks, or push the
     // global count over the hard memory limit.
+    let max_datagram_bytes = self.max_gossip_datagram_bytes();
     push_mem_ingress_capped(
       &mut self.mem_ingress,
       &mut self.mem_ingress_per_peer,
       &mut self.datagram_ingress_dropped,
+      &mut self.oversized_datagram_dropped,
       from,
+      max_datagram_bytes,
+      datagram.len(),
       || Bytes::copy_from_slice(datagram),
     );
   }
@@ -3050,6 +3127,14 @@ impl<I, R> QuicEndpoint<I, R> {
   #[cfg(test)]
   pub(crate) fn datagram_ingress_dropped(&self) -> u64 {
     self.datagram_ingress_dropped
+  }
+
+  /// Count of inbound `Class::Memberlist` datagrams rejected at admission
+  /// because they exceeded [`Self::max_gossip_datagram_bytes`] (best-effort
+  /// accounting; never a membership signal).
+  #[cfg(test)]
+  pub(crate) fn oversized_datagram_dropped(&self) -> u64 {
+    self.oversized_datagram_dropped
   }
 
   /// Count of inbound application datagrams dropped by the receive drain
@@ -5819,6 +5904,11 @@ where
   /// dials; they cannot be acted on in place because the parked-dial servicing
   /// re-borrows `self.conns` through `get_or_dial`.
   fn service_one_conn(&mut self, ch: ConnectionHandle, now: Instant) -> ServiceMarks {
+    // Sampled before `e` takes its exclusive borrow of `self.conns` below: the
+    // inbound-datagram drain further down needs the endpoint's per-datagram
+    // size cap, but `self.max_gossip_datagram_bytes()` reads `self.ep` via a
+    // `&self` method call, which cannot run while `e` holds `&mut self.conns`.
+    let max_gossip_datagram_bytes = self.max_gossip_datagram_bytes();
     // Both the inbound-accept and the inbound-datagram drains below attribute
     // work to this connection's membership address (`e.peer()`), which must be
     // the key its route is filed under. Asserted once here — the whole pass
@@ -6094,17 +6184,22 @@ where
       // each popped payload is gated.
       if established {
         // Pop quinn to empty so a zero-length-frame flood cannot accumulate
-        // inside quinn; admission (per-peer + global caps, dropped+counted past
-        // either bound so one flooding peer cannot fill the shared queue and
-        // starve another peer's probe Ack) is enforced by the shared helper —
-        // the SAME bound `handle_memberlist_udp` applies, so neither source can
-        // exceed it. The three `&mut self.<field>` args are disjoint from the
+        // inside quinn; admission (per-datagram size cap + per-peer + global
+        // count caps, dropped+counted past whichever bound so one flooding
+        // peer cannot fill the shared queue and starve another peer's probe
+        // Ack) is enforced by the shared helper — the SAME bound
+        // `handle_memberlist_udp` applies, so neither source can exceed it.
+        // The four `&mut self.<field>` args are disjoint from the
         // `self.conns` borrow `e` holds.
+        let payload_len = payload.len();
         push_mem_ingress_capped(
           &mut self.mem_ingress,
           &mut self.mem_ingress_per_peer,
           &mut self.datagram_ingress_dropped,
+          &mut self.oversized_datagram_dropped,
           peer,
+          max_gossip_datagram_bytes,
+          payload_len,
           move || payload,
         );
       } else {

--- a/memberlist-proto/src/quic/tests.rs
+++ b/memberlist-proto/src/quic/tests.rs
@@ -14024,3 +14024,286 @@ fn half_open_budget_bounds_aggregate_and_spares_outbound() {
     );
   }
 }
+
+/// A `Class::Memberlist` datagram larger than the endpoint's own configured
+/// [`super::QuicEndpoint::max_gossip_datagram_bytes`] is not legitimate
+/// gossip and must be rejected at admission — before it can grow the shared
+/// `mem_ingress` queue — rather than merely load-shed once the count cap is
+/// reached. A datagram at exactly the cap is still admitted (the cap rejects
+/// what is OVER it, not what is AT it).
+///
+/// Mutation-anchor: remove the `datagram_len > max_datagram_bytes` guard from
+/// `push_mem_ingress_capped` and this test fails — the oversized datagram is
+/// queued into `mem_ingress` instead of rejected.
+#[test]
+fn oversized_memberlist_datagram_rejected_at_ingress() {
+  let a_addr: SocketAddr = "127.0.0.1:7994".parse().unwrap();
+  let from: SocketAddr = "127.0.0.1:7995".parse().unwrap();
+  let now = Instant::now();
+  let mut a = make_endpoint("a", a_addr, now);
+
+  let cap = a.max_gossip_datagram_bytes();
+  let dropped_before = a.oversized_datagram_dropped();
+  let queue_len_before = a.mem_ingress.len();
+
+  // Leading byte 0x01 classifies as Class::Memberlist (frame tag range
+  // 1..=15) via the plain-UDP path (`handle_udp`).
+  let oversized = vec![0x01u8; cap + 1];
+  a.handle_udp(from, &oversized, now);
+
+  assert_eq!(
+    a.mem_ingress.len(),
+    queue_len_before,
+    "an oversized Class::Memberlist datagram must not be queued into mem_ingress"
+  );
+  assert_eq!(
+    a.oversized_datagram_dropped(),
+    dropped_before + 1,
+    "the oversized datagram must be dropped and counted on the distinct oversized metric"
+  );
+  assert_eq!(
+    a.datagram_ingress_dropped(),
+    0,
+    "an oversized rejection is a size drop, not a count-cap drop"
+  );
+
+  // Control: a datagram AT exactly the cap is legitimate and must be admitted.
+  let at_cap = vec![0x01u8; cap];
+  a.handle_udp(from, &at_cap, now);
+  assert_eq!(
+    a.mem_ingress.len(),
+    queue_len_before + 1,
+    "a datagram exactly at the cap must be admitted"
+  );
+  assert_eq!(
+    a.oversized_datagram_dropped(),
+    dropped_before + 1,
+    "the at-cap datagram must not be counted as oversized"
+  );
+}
+
+/// Same rejection as [`oversized_memberlist_datagram_rejected_at_ingress`],
+/// but via the QUIC datagram drain (`service_one_conn`'s
+/// `datagrams().recv()` loop) rather than the plain-UDP path: an inbound QUIC
+/// application datagram larger than the RECEIVING endpoint's own
+/// `max_gossip_datagram_bytes` is rejected at admission, never reaching
+/// `mem_ingress`, regardless of which transport carried it.
+///
+/// A's `gossip_mtu` is configured small so its cap is small while the
+/// oversized payload stays comfortably under quinn's own per-connection
+/// datagram size ceiling — the sender B need not (and, via
+/// `queue_unreliable_datagram`'s own `TooLarge` guard, could not) exceed
+/// quinn's limit to prove this endpoint-level gate.
+#[test]
+fn oversized_quic_datagram_rejected_at_ingress() {
+  let a_addr: SocketAddr = "127.0.0.1:7996".parse().unwrap();
+  let b_addr: SocketAddr = "127.0.0.1:7997".parse().unwrap();
+  let now = Instant::now();
+  let cfg_a = EndpointOptions::new(SmolStr::new("a"), a_addr).with_gossip_mtu(512);
+  let mut ep_a: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg_a);
+  ep_a.start_scheduling(now);
+  let mut seed = [0u8; 32];
+  seed[..2].copy_from_slice(&a_addr.port().to_le_bytes());
+  let mut a = QuicEndpoint::<SmolStr>::with_quinn_rng_seed(ep_a, test_config(), Some(seed));
+  let mut b = make_endpoint("b", b_addr, now);
+
+  let cap = a.max_gossip_datagram_bytes();
+  let oversized_len = cap + 50;
+
+  // Drive the A<->B push/pull handshake until A holds an Established
+  // connection to B (the proven ferry pattern).
+  // Ignoring StreamId return: the test asserts on the drop counters, not the
+  // handle.
+  let _ = a
+    .endpoint_mut()
+    .start_push_pull(b_addr, PushPullKind::Join, now);
+  for _ in 0..200 {
+    let mut moved = false;
+    while let Some((to, bytes)) = a.poll_transmit() {
+      if to == b_addr {
+        b.handle_udp(a_addr, &bytes, now);
+        moved = true;
+      }
+    }
+    while let Some((to, bytes)) = b.poll_transmit() {
+      if to == a_addr {
+        a.handle_udp(b_addr, &bytes, now);
+        moved = true;
+      }
+    }
+    a.handle_timeout(now);
+    b.handle_timeout(now);
+    if a.live_bridge_count() >= 1
+      && a.counters.endpoint_events_processed > 0
+      && b.counters.endpoint_events_processed > 0
+    {
+      break;
+    }
+    if !moved
+      && a.counters.endpoint_events_processed > 0
+      && b.counters.endpoint_events_processed > 0
+    {
+      break;
+    }
+  }
+  assert!(
+    a.live_connections_to(b_addr) >= 1,
+    "test precondition: A must hold a live connection to B"
+  );
+
+  let dropped_before = a.oversized_datagram_dropped();
+  let ingress_dropped_before = a.datagram_ingress_dropped();
+  let queue_len_before = a.mem_ingress.len();
+
+  let payload = Bytes::from(vec![0x01u8; oversized_len]);
+  assert_eq!(
+    b.queue_unreliable_datagram(a_addr, payload, now),
+    super::DatagramSendStatus::Queued,
+    "test precondition: the payload must be well within quinn's own datagram \
+       size ceiling so this proves the endpoint-level cap, not quinn's"
+  );
+
+  for _ in 0..50 {
+    b.handle_timeout(now);
+    while let Some((to, bytes)) = b.poll_transmit() {
+      if to == a_addr {
+        a.handle_udp(b_addr, &bytes, now);
+      }
+    }
+    a.handle_timeout(now);
+    if a.oversized_datagram_dropped() > dropped_before {
+      break;
+    }
+    while let Some((to, bytes)) = a.poll_transmit() {
+      if to == b_addr {
+        b.handle_udp(a_addr, &bytes, now);
+      }
+    }
+  }
+
+  assert_eq!(
+    a.oversized_datagram_dropped(),
+    dropped_before + 1,
+    "the oversized QUIC datagram must be dropped and counted at the drain"
+  );
+  assert_eq!(
+    a.datagram_ingress_dropped(),
+    ingress_dropped_before,
+    "an oversized rejection is a size drop, not a count-cap drop"
+  );
+  assert_eq!(
+    a.mem_ingress.len(),
+    queue_len_before,
+    "the oversized QUIC datagram must never reach mem_ingress"
+  );
+}
+
+/// Control for [`oversized_memberlist_datagram_rejected_at_ingress`]: a
+/// `Class::Memberlist` datagram AT or under `max_gossip_datagram_bytes()` is
+/// ordinary legitimate gossip and must be queued normally — the cap must
+/// never reject anything a real gossip sender would produce.
+#[test]
+fn legit_gossip_datagram_within_cap_admitted() {
+  let a_addr: SocketAddr = "127.0.0.1:7998".parse().unwrap();
+  let from: SocketAddr = "127.0.0.1:7999".parse().unwrap();
+  let now = Instant::now();
+  let mut a = make_endpoint("a", a_addr, now);
+
+  let cap = a.max_gossip_datagram_bytes();
+
+  let at_cap = vec![0x01u8; cap];
+  a.handle_memberlist_udp(from, &at_cap);
+  assert_eq!(
+    a.mem_ingress.len(),
+    1,
+    "a datagram at exactly the cap must be queued normally"
+  );
+  assert_eq!(
+    a.oversized_datagram_dropped(),
+    0,
+    "a within-cap datagram must not be counted as oversized"
+  );
+
+  let under_len = if cap > 1 { cap - 1 } else { 1 };
+  let under = vec![0x01u8; under_len];
+  a.handle_memberlist_udp(from, &under);
+  assert_eq!(
+    a.mem_ingress.len(),
+    2,
+    "a datagram under the cap must also be queued normally"
+  );
+  assert_eq!(a.oversized_datagram_dropped(), 0);
+}
+
+/// The F5 scenario: a source-rotating flood of oversized `Class::Memberlist`
+/// datagrams cannot fill the shared `mem_ingress` queue with attacker-
+/// controlled bytes — each oversized datagram is rejected at admission
+/// regardless of source, so rotating the source address (to dodge the
+/// per-peer cap) buys the attacker nothing. Legitimate at-cap datagrams from
+/// many distinct sources are still admitted up to the node-global COUNT cap,
+/// bounding the queue's total bytes to
+/// `MAX_MEM_INGRESS_DATAGRAMS * max_gossip_datagram_bytes` — tied to the
+/// operator's own `gossip_mtu`, never an attacker-chosen datagram size.
+#[test]
+fn ingress_bytes_bounded_under_source_rotation() {
+  let a_addr: SocketAddr = "127.0.0.1:8000".parse().unwrap();
+  let now = Instant::now();
+  let mut a = make_endpoint("a", a_addr, now);
+  let cap = a.max_gossip_datagram_bytes();
+
+  // Phase 1: a source-rotating flood of OVERSIZED datagrams — one distinct
+  // source per datagram, well past the node-global count cap's own entry
+  // budget, so rotating the source (to dodge the per-peer cap) is the only
+  // thing left for the attacker to try.
+  let flood_count = super::MAX_MEM_INGRESS_DATAGRAMS + 500;
+  let oversized = vec![0x01u8; cap + 1];
+  for i in 0..flood_count {
+    let src: SocketAddr = format!(
+      "10.{}.{}.{}:9000",
+      (i >> 16) & 0xFF,
+      (i >> 8) & 0xFF,
+      i & 0xFF
+    )
+    .parse()
+    .unwrap();
+    a.handle_memberlist_udp(src, &oversized);
+  }
+  assert_eq!(
+    a.mem_ingress.len(),
+    0,
+    "an all-oversized source-rotating flood must queue NOTHING"
+  );
+  assert_eq!(
+    a.oversized_datagram_dropped() as usize,
+    flood_count,
+    "every oversized datagram must be dropped and counted regardless of source"
+  );
+
+  // Phase 2: legitimate AT-cap datagrams, still source-rotating (far more
+  // sources than MAX_MEM_INGRESS_DATAGRAMS, so the node-global count cap —
+  // not any single peer's per-peer share — is what bounds the queue).
+  let at_cap = vec![0x01u8; cap];
+  let legit_count = super::MAX_MEM_INGRESS_DATAGRAMS + 500;
+  for i in 0..legit_count {
+    let src: SocketAddr = format!(
+      "11.{}.{}.{}:9000",
+      (i >> 16) & 0xFF,
+      (i >> 8) & 0xFF,
+      i & 0xFF
+    )
+    .parse()
+    .unwrap();
+    a.handle_memberlist_udp(src, &at_cap);
+  }
+  assert!(
+    a.mem_ingress.len() <= super::MAX_MEM_INGRESS_DATAGRAMS,
+    "the node-global count cap must still bound the queue's entry count"
+  );
+  let total_bytes: usize = a.mem_ingress.iter().map(|(_, b)| b.len()).sum();
+  let byte_bound = super::MAX_MEM_INGRESS_DATAGRAMS * cap;
+  assert!(
+    total_bytes <= byte_bound,
+    "queued bytes must stay within MAX_MEM_INGRESS_DATAGRAMS * max_gossip_datagram_bytes \
+       ({total_bytes} > {byte_bound})"
+  );
+}

--- a/memberlist-proto/src/quic/tests.rs
+++ b/memberlist-proto/src/quic/tests.rs
@@ -14307,3 +14307,133 @@ fn ingress_bytes_bounded_under_source_rotation() {
        ({total_bytes} > {byte_bound})"
   );
 }
+
+/// The PUBLIC [`crate::metrics::Metrics::gossip_ingress_oversized`] snapshot,
+/// read via [`super::QuicEndpoint::metrics`], must reflect an oversized-
+/// datagram drop exactly like the internal `oversized_datagram_dropped`
+/// counter it folds — driven through BOTH ingress paths: the plain-UDP
+/// `handle_udp` path (as in
+/// [`oversized_memberlist_datagram_rejected_at_ingress`]) and the QUIC
+/// datagram drain (as in [`oversized_quic_datagram_rejected_at_ingress`]).
+/// Before this fix, `oversized_datagram_dropped` was only readable through a
+/// `#[cfg(test)]` accessor, so a production driver reading
+/// `QuicEndpoint::metrics()` during an external oversized-datagram flood saw
+/// no distinct signal for it.
+///
+/// Mutation-anchor: remove the `gossip_ingress_oversized` fold from
+/// `QuicEndpoint::metrics` and this test fails — the public snapshot stays
+/// at `0` while the internal counter advances.
+#[test]
+fn public_metrics_snapshot_reflects_oversized_ingress_drops() {
+  let a_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
+  let b_addr: SocketAddr = "127.0.0.1:8002".parse().unwrap();
+  let plain_udp_from: SocketAddr = "127.0.0.1:8003".parse().unwrap();
+  let now = Instant::now();
+  let cfg_a = EndpointOptions::new(SmolStr::new("a"), a_addr).with_gossip_mtu(512);
+  let mut ep_a: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg_a);
+  ep_a.start_scheduling(now);
+  let mut seed = [0u8; 32];
+  seed[..2].copy_from_slice(&a_addr.port().to_le_bytes());
+  let mut a = QuicEndpoint::<SmolStr>::with_quinn_rng_seed(ep_a, test_config(), Some(seed));
+  let mut b = make_endpoint("b", b_addr, now);
+
+  let cap = a.max_gossip_datagram_bytes();
+  assert_eq!(
+    a.metrics().gossip_ingress_oversized,
+    0,
+    "no oversized drops yet"
+  );
+
+  // Path 1: the plain-UDP `handle_udp` path, from a source A holds no
+  // connection to.
+  let oversized = vec![0x01u8; cap + 1];
+  a.handle_udp(plain_udp_from, &oversized, now);
+  assert_eq!(
+    a.metrics().gossip_ingress_oversized,
+    1,
+    "the plain-UDP oversized drop must surface on the public metric"
+  );
+  assert_eq!(
+    a.metrics().gossip_ingress_oversized,
+    a.oversized_datagram_dropped(),
+    "the public metric must track the internal counter exactly"
+  );
+
+  // Path 2: the QUIC datagram drain, driven over a live A<->B connection —
+  // the proven ferry pattern from `oversized_quic_datagram_rejected_at_ingress`.
+  let _ = a
+    .endpoint_mut()
+    .start_push_pull(b_addr, PushPullKind::Join, now);
+  for _ in 0..200 {
+    let mut moved = false;
+    while let Some((to, bytes)) = a.poll_transmit() {
+      if to == b_addr {
+        b.handle_udp(a_addr, &bytes, now);
+        moved = true;
+      }
+    }
+    while let Some((to, bytes)) = b.poll_transmit() {
+      if to == a_addr {
+        a.handle_udp(b_addr, &bytes, now);
+        moved = true;
+      }
+    }
+    a.handle_timeout(now);
+    b.handle_timeout(now);
+    if a.live_bridge_count() >= 1
+      && a.counters.endpoint_events_processed > 0
+      && b.counters.endpoint_events_processed > 0
+    {
+      break;
+    }
+    if !moved
+      && a.counters.endpoint_events_processed > 0
+      && b.counters.endpoint_events_processed > 0
+    {
+      break;
+    }
+  }
+  assert!(
+    a.live_connections_to(b_addr) >= 1,
+    "test precondition: A must hold a live connection to B"
+  );
+
+  let before = a.metrics().gossip_ingress_oversized;
+  let oversized_len = cap + 50;
+  let payload = Bytes::from(vec![0x01u8; oversized_len]);
+  assert_eq!(
+    b.queue_unreliable_datagram(a_addr, payload, now),
+    super::DatagramSendStatus::Queued,
+    "test precondition: the payload must be well within quinn's own datagram \
+       size ceiling so this proves the endpoint-level cap, not quinn's"
+  );
+
+  for _ in 0..50 {
+    b.handle_timeout(now);
+    while let Some((to, bytes)) = b.poll_transmit() {
+      if to == a_addr {
+        a.handle_udp(b_addr, &bytes, now);
+      }
+    }
+    a.handle_timeout(now);
+    if a.metrics().gossip_ingress_oversized > before {
+      break;
+    }
+    while let Some((to, bytes)) = a.poll_transmit() {
+      if to == b_addr {
+        b.handle_udp(a_addr, &bytes, now);
+      }
+    }
+  }
+
+  assert_eq!(
+    a.metrics().gossip_ingress_oversized,
+    before + 1,
+    "the QUIC-datagram-drain oversized drop must also surface on the public metric"
+  );
+  assert_eq!(
+    a.metrics().gossip_ingress_oversized,
+    a.oversized_datagram_dropped(),
+    "the public metric must track the internal counter exactly, across both ingress paths"
+  );
+}


### PR DESCRIPTION
Addresses #158 finding **F5** (Medium) — count-only QUIC/UDP ingress limits permit ~512 MiB of queued payload.

## The bug (external pre-trust DoS)

`push_mem_ingress_capped` bounded the shared `mem_ingress` queue by entry **count** only (8192 global, 1024 per-source). `Class::Memberlist` datagrams are classified by their leading byte and queued as raw `Bytes` **before** any decode/decrypt, so no cluster key is needed. An external attacker rotating source `SocketAddr` (staying under the 1024 per-source count) while emitting ~65507-byte datagrams could fill the 8192-entry global cap at **~512 MiB** of attacker-controlled memory.

## The fix

A **per-datagram wire-size cap** = the endpoint's own maximum legitimate gossip datagram size (`gossip_mtu() + ENCRYPTED_WRAPPER_OVERHEAD + CHECKSUMED_WRAPPER_OVERHEAD`, the same formula the driver uses to size its receive buffer). A `Class::Memberlist` datagram larger than that is not legitimate gossip; it is rejected at admission — **before** the payload is materialized (preserving the no-alloc-on-drop property) and before the count checks. Both ingress callers (the plain-UDP path and the QUIC datagram drain) pass the cap. This bounds the queued bytes to `MAX_MEM_INGRESS_DATAGRAMS × max_gossip_datagram_bytes` — ≈12 MiB at a default gossip MTU, and to the operator's own configured budget at a large MTU (their choice, not an attacker's). The count caps are unchanged.

A global byte budget was deliberately **not** added — it would reject legitimate large-gossip-MTU bursts, and the per-datagram cap already bounds total memory to the operator's configured budget.

A distinct public metric, `Metrics::gossip_ingress_oversized` (the size-rejection counterpart to `gossip_ingress_dropped`, the count-cap drop), makes an oversized-datagram flood observable in production.
