### PR TITLE
fix(proto): apply a same-tick-settled handshake refutation before membership timers (#158 F4)

### DIFF
--- a/memberlist-proto/src/endpoint/tests.rs
+++ b/memberlist-proto/src/endpoint/tests.rs
@@ -4999,6 +4999,78 @@ fn reliable_ping_ack_drives_probe_success() {
   );
 }
 
+/// The reliable-ping-ack success path is anchored by an ABSOLUTE cutoff, not by
+/// when in a coordinator tick the ack is applied: a `ReliablePingAcked` reaching
+/// `handle_stream_event` at `now >= failure_deadline` routes the probe to
+/// FAILURE (suspect the target), never rescues it. This is the invariant that
+/// makes the stream coordinator's per-tick order independent for the probe
+/// class — replaying a buffered ack earlier in the tick (before the membership
+/// timers) cannot resurrect a probe whose budget has already elapsed.
+#[test]
+fn reliable_ping_ack_after_failure_deadline_fails_probe() {
+  use EndpointEvent;
+
+  use crate::event::ReliablePingAcked;
+
+  let mut e: Endpoint<SmolStr, SocketAddr> = Endpoint::new_seeded(cfg());
+  process_alive_auto(&mut e, alive("bob", 7001, 1), false, Instant::now());
+  while e.poll_event().is_some() {}
+  while e.poll_transmit().is_some() {}
+
+  let probe_seq = 55u32;
+  let bob = e.member(&SmolStr::new("bob")).unwrap().clone();
+  let bob_incarnation = e.node_incarnation(&SmolStr::new("bob")).unwrap();
+  let bob_generation = e.members.get(&SmolStr::new("bob")).unwrap().generation();
+  let now = Instant::now();
+  let deadline = now + Duration::from_secs(5);
+
+  let stream_id = StreamId::from_raw(999);
+  e.probes.insert(
+    probe_seq,
+    Probe {
+      target: bob,
+      target_incarnation: bob_incarnation,
+      target_generation: bob_generation,
+      sent_at: now,
+      kind: ProbeKind::Detection,
+      dispatched: true,
+      failure_deadline: deadline,
+      phase: ProbePhase::AwaitingIndirect(AwaitingIndirect {
+        expected_nacks: 2,
+        indirect_peers: SmallVec::new(),
+        nacked_by: SmallVec::new(),
+        reliable_stream_id: Some(stream_id),
+        deadline,
+      }),
+    },
+  );
+
+  let initial_score = e.health_score();
+  // The ack arrives AT/AFTER the failure deadline — too late to rescue.
+  e.handle_stream_event(
+    EndpointEvent::ReliablePingAcked(ReliablePingAcked::new(probe_seq, deadline)),
+    deadline,
+  );
+
+  assert!(
+    !e.probes.contains_key(&probe_seq),
+    "the probe is terminated by the past-deadline ack",
+  );
+  assert_eq!(
+    e.member_liveness(&SmolStr::new("bob")),
+    Some(State::Suspect),
+    "a past-deadline ack fails the probe: the target is suspected, not proven alive",
+  );
+  assert!(
+    e.health_score() >= initial_score,
+    "a probe failure does not tick awareness down (it records a failure)",
+  );
+  assert!(
+    !core::iter::from_fn(|| e.poll_event()).any(|ev| matches!(ev, Event::PingCompleted(..))),
+    "no PingCompleted is emitted for a past-deadline reliable-ping ack",
+  );
+}
+
 // ─────────────── Reliable user messages ──────────────────────────────────
 
 #[test]

--- a/memberlist-proto/src/streams/mod.rs
+++ b/memberlist-proto/src/streams/mod.rs
@@ -19,9 +19,14 @@
 //! stream ([`StreamEndpoint::poll_memberlist_transmit`]).
 //!
 //! The fixed per-tick step order keeps the load-bearing invariant — the
-//! stream-endpoint-event drain STRICTLY precedes `Endpoint::handle_timeout`
-//! (else a reliable-fallback ping ack that lands the same tick the probe
-//! cumulative deadline expires is lost and the peer is wrongly Suspected).
+//! stream-endpoint-event drain AND the promotion + replay of any handshake that
+//! settled on this tick's already-fed input STRICTLY precede
+//! `Endpoint::handle_timeout`. Two same-tick races depend on it: (a) a
+//! reliable-fallback ping ack that lands the same tick the probe cumulative
+//! deadline expires must be drained first, else it is lost and the peer is
+//! wrongly Suspected; (b) a buffered push/pull `Alive` refutation carried in a
+//! same-tick-settled handshake must cancel a same-tick suspicion expiry as a
+//! `Suspect -> Alive` cancel, not fire a spurious `Dead -> Alive` flap.
 //!
 //! # Transport half-close anchors
 //!
@@ -1927,8 +1932,8 @@ where
     }
   }
 
-  /// Step (4): for every exchange still awaiting its `Stream`, mint it once
-  /// the label / handshake step has settled.
+  /// Steps (2.5) and (5.5): for every exchange still awaiting its `Stream`,
+  /// mint it once the label / handshake step has settled.
   ///
   /// `is_handshaking()` is `false` once the record layer reports the label /
   /// handshake step done (the mint window) AND once the bridge is `Established`
@@ -2172,9 +2177,9 @@ where
   /// Step (5): drain the private `dial_pending` deque, surfacing one
   /// [`StreamAction::Connect`] and building one `Handshaking` client bridge per
   /// intent. Does NOT call `dial_succeeded` — the `Stream` is minted at the
-  /// label / handshake-settled step (step 4) across a later tick (or this same
-  /// tick when invoked from a `start_*` flush, since a no-handshake dialer's
-  /// label step settles at construction).
+  /// label / handshake-settled step (step 5.5 this same tick, since a
+  /// no-handshake dialer's label step settles at construction; or a later tick
+  /// otherwise) or by a `start_*` flush's `service_handshake_completions`.
   pub(crate) fn service_dials(&mut self, now: Instant) {
     // A leaving/left node initiates no dial: skip sieving and draining so no
     // bridge is built or Connect surfaced after leave. Defensive — the start_*
@@ -2671,28 +2676,43 @@ where
   /// The fixed per-tick step order (load-bearing — see module docs).
   ///
   /// Step (2) (pump every bridge + drain each non-terminal stream's
-  /// endpoint-events into the `Endpoint`) MUST strictly precede step (3)
-  /// (`ep.handle_timeout`): a reliable-fallback ping ack delivered on the same
-  /// tick the probe cumulative deadline expires is carried by the stream's
-  /// last `poll_endpoint_event`; draining it after the probe timeout would
-  /// lose it and wrongly Suspect a live peer. Do not reorder.
+  /// endpoint-events into the `Endpoint`), step (2.5) (label / handshake-settled
+  /// mint), and step (2.6) (pump the just-minted bridges) MUST all strictly
+  /// precede step (3) (`ep.handle_timeout`). Two refutable-class deadlines
+  /// depend on this inbound-first ordering:
   ///
-  /// Step (4) (label / handshake-settled mint) mints the `Stream` for any
-  /// bridge whose label / handshake step settled since the last tick and
-  /// promotes it; a freshly-promoted OUTBOUND bridge carries its request bytes
-  /// in the minted `Stream`'s output buffer. Step (5) (`service_dials`) inserts
-  /// new `Handshaking` outbound bridges. A dialer record layer with no
-  /// handshake (its inbound label is validated in-line on the established
-  /// intake) is never handshaking, so step (5.5) — a second
-  /// `service_handshake_completions` — promotes those freshly-inserted dial
-  /// bridges in the SAME tick, before step (5.6)'s `pump_bridges` pumps their
-  /// request bytes out. Without the step (5.5) extra promote, a
+  /// - A reliable-fallback ping ack delivered on the same tick the probe
+  ///   cumulative deadline expires is carried by the stream's last
+  ///   `poll_endpoint_event`; draining it after the probe timeout would lose it
+  ///   and wrongly Suspect a live peer.
+  /// - A push/pull `Alive` refutation carried in a handshake that settles on
+  ///   this tick's already-fed input must cancel a same-tick suspicion expiry
+  ///   as a `Suspect -> Alive` — not fire a spurious `Dead -> Alive` flap. The
+  ///   handshake settles only on the byte feed the caller already performed, so
+  ///   step (2.5)'s mint and step (2.6)'s replay of the buffered plaintext apply
+  ///   the refutation before `handle_timeout` synthesizes a Dead.
+  ///
+  /// The probe class itself is ordering-INDEPENDENT: `complete_probe_success`
+  /// routes any ack at/after the probe's absolute `failure_deadline` to failure,
+  /// so replaying a past-deadline ack earlier (in step (2.6) rather than after
+  /// the timers) cannot resurrect a probe that has already lost its budget.
+  ///
+  /// Step (5) (`service_dials`) inserts new `Handshaking` outbound bridges
+  /// emitted by step (3). A dialer record layer with no handshake (its inbound
+  /// label is validated in-line on the established intake) is never handshaking,
+  /// so step (5.5) — a second `service_handshake_completions` — promotes those
+  /// freshly-inserted dial bridges in the SAME tick, before step (5.6)'s
+  /// `pump_bridges` pumps their request bytes out. A step-(5) dial's `Stream` is
+  /// minted by `dial_succeeded`, whose own `now >= deadline` check retires an
+  /// already-expired intent; that makes minting here order-equivalent to minting
+  /// after `fire_expired_stream_intents`, so moving the earlier mint (2.5) ahead
+  /// of the timers is safe. Without the step (5.5) extra promote, a
   /// reliable-fallback ping bridge created by step (3) would have its `Stream`
-  /// minted only on the NEXT coordinator wake — under a strict-poll driver
-  /// that wakes only at [`Self::poll_timeout`], that next wake is the bridge's
+  /// minted only on the NEXT coordinator wake — under a strict-poll driver that
+  /// wakes only at [`Self::poll_timeout`], that next wake is the bridge's
   /// exchange deadline itself, at which point
-  /// [`crate::stream::Stream::handle_data`] would reject the buffered request
-  /// as timed out. `pump_bridges` and `service_handshake_completions` are both
+  /// [`crate::stream::Stream::handle_data`] would reject the buffered request as
+  /// timed out. `pump_bridges` and `service_handshake_completions` are both
   /// idempotent on already-handled bridges, so the duplicated calls are no-ops
   /// on bridges already serviced upstream. There is NO connection drained-reap
   /// step (connection-per-exchange — a reaped bridge frees its own connection
@@ -2701,20 +2721,25 @@ where
     // (1) inbound feed already done by the caller (`handle_transport_data`).
     // (2) pump bridges + drain stream endpoint-events into the Endpoint.
     self.pump_bridges(now);
+    // (2.5) mint the Stream for any bridge whose label / handshake step settled
+    // on this tick's already-fed input, so its buffered refutation is applied
+    // BEFORE the membership timers below.
+    self.service_handshake_completions(now);
+    // (2.6) pump the just-minted bridges: replay their buffered plaintext and
+    // drain the decoded state into the Endpoint (a same-tick Alive refutation
+    // must cancel a suspicion expiry as a Suspect -> Alive, not fire
+    // Dead -> Alive).
+    self.pump_bridges(now);
     // (3) THEN membership timers (probe cumulative-deadline, suspicion).
     self.ep.handle_timeout(now);
-    // (4) mint the Stream for any bridge whose label / handshake step just
-    // settled.
-    self.service_handshake_completions(now);
     // (5) dial requests emitted by (3).
     self.service_dials(now);
     // (5.5) promote any dial bridge whose records are not handshaking from
     // the moment of construction (the dialer's role) so step (5.6)'s pump
     // can transmit the request bytes this same tick. Idempotent on bridges
-    // already promoted by step (4).
+    // already promoted by step (2.5).
     self.service_handshake_completions(now);
-    // (5.6) pump bridges promoted/inserted by (4), (5), and (5.5) this same
-    // tick.
+    // (5.6) pump bridges promoted/inserted by (5) and (5.5) this same tick.
     self.pump_bridges(now);
     self.finalize_tick(now);
     // Clear the policy-change reap latch: a bridge failed by

--- a/memberlist-proto/src/streams/tests.rs
+++ b/memberlist-proto/src/streams/tests.rs
@@ -914,6 +914,261 @@ mod tcp {
       "exactly one machine terminal per kind-bearing StreamId",
     );
   }
+
+  /// Build a coordinator whose inner endpoint holds `m_id` in `State::Suspect`
+  /// at incarnation `inc`, armed with the suspicion's own deadline. The setup
+  /// events (the `NodeJoined(m_id)` from seeding it Alive, the `Suspect`
+  /// broadcast) are drained so the caller observes only what the tick under
+  /// test produces.
+  fn coord_with_suspect_member(
+    coord_port: u16,
+    m_id: &SmolStr,
+    m_addr: SocketAddr,
+    inc: u32,
+    now: Instant,
+  ) -> StreamEndpoint<SmolStr, SocketAddr, RawRecords> {
+    use crate::typed::{Alive, Suspect};
+    let mut coord = coord(coord_port);
+    coord.handle_alive(
+      m_addr,
+      Alive::new(inc, crate::Node::new(m_id.clone(), m_addr)),
+      now,
+    );
+    coord.handle_suspect(
+      m_addr,
+      Suspect::new(inc, m_id.clone(), SmolStr::new("accuser")),
+      now,
+    );
+    while coord.poll_event().is_some() {}
+    let _ = coord.endpoint_mut().drain_broadcasts();
+    coord
+  }
+
+  /// A real dialer's coalesced `[label || push/pull request]` bytes, where the
+  /// push advertises `m_id` at `m_inc` as `State::Alive`. The dialer's
+  /// membership is seeded so its push/pull request carries that exact record —
+  /// the refutation (or, for a stale incarnation, non-refutation) the acceptor
+  /// merges when its handshake settles.
+  fn dialer_push_pull_advertising_alive(
+    dialer_port: u16,
+    m_id: &SmolStr,
+    m_addr: SocketAddr,
+    m_inc: u32,
+    coord_addr: SocketAddr,
+    now: Instant,
+  ) -> Vec<u8> {
+    use crate::typed::Alive;
+    let cfg = LabelOptions::new_in(Some(b"cluster-x".to_vec()), ());
+    let mut dialer: StreamEndpoint<SmolStr, SocketAddr, RawRecords> = StreamEndpoint::new(
+      endpoint(dialer_port),
+      cfg,
+      test_sni_provider(),
+      test_peer_to_socket(),
+    );
+    dialer.handle_alive(
+      m_addr,
+      Alive::new(m_inc, crate::Node::new(m_id.clone(), m_addr)),
+      now,
+    );
+    let _ = dialer.start_push_pull(coord_addr, PushPullKind::Join, now);
+    let _ = dialer.poll_action();
+    let mut bytes = Vec::new();
+    while let Some((_id, _peer, chunk)) = dialer.poll_transport_transmit() {
+      bytes.extend_from_slice(&chunk);
+    }
+    bytes
+  }
+
+  /// A same-tick-settled handshake carrying a superseding `Alive` cancels a
+  /// suspicion whose deadline expires on that same tick as a silent
+  /// `Suspect -> Alive` — not a spurious `Dead -> Alive` flap. The buffered
+  /// refutation is applied (mint + replay) BEFORE `Endpoint::handle_timeout`
+  /// fires the suspicion, so no `NodeLeft`/`Dead` is ever synthesized.
+  #[test]
+  fn same_tick_refutation_cancels_suspicion_no_flap() {
+    use crate::{
+      event::Event,
+      typed::{Message, State},
+    };
+    let now = Instant::now();
+    let m = SmolStr::new("m-node");
+    let m_addr = addr(7303);
+    let inc = 5u32;
+    let coord_addr = addr(7300);
+
+    let mut coord = coord_with_suspect_member(7300, &m, m_addr, inc, now);
+    assert_eq!(
+      coord.endpoint_ref().member_liveness(&m),
+      Some(State::Suspect),
+      "M starts Suspect",
+    );
+
+    // The suspicion is armed at `now`; its deadline is well within this margin
+    // (the small cluster gives `k == 0`, so the timer is fixed at the sub-minute
+    // `min`). The connection arrives fresh on the wake at `t >= deadline`: the
+    // peer's push/pull request coalesced with its handshake tail, delivered on a
+    // driver wake at or after the suspicion deadline — ordinary scheduling.
+    let t = now + Duration::from_secs(30);
+    let blob = dialer_push_pull_advertising_alive(7304, &m, m_addr, inc + 1, coord_addr, t);
+    let exchange = coord
+      .accept_connection(m_addr, t)
+      .expect("connection admitted while running");
+    coord.handle_transport_data(exchange, &blob, true, t);
+
+    assert_eq!(
+      coord.endpoint_ref().member_liveness(&m),
+      Some(State::Alive),
+      "M ends Alive: the refutation cancelled the suspicion",
+    );
+    assert_eq!(
+      coord.endpoint_ref().node_incarnation(&m),
+      Some(inc + 1),
+      "M carries the refuting incarnation",
+    );
+
+    let mut node_left_m = false;
+    let mut node_joined_m = false;
+    while let Some(ev) = coord.poll_event() {
+      match ev {
+        Event::NodeLeft(ns) if ns.id_ref() == &m => node_left_m = true,
+        Event::NodeJoined(ns) if ns.id_ref() == &m => node_joined_m = true,
+        _ => {}
+      }
+    }
+    assert!(
+      !node_left_m,
+      "no NodeLeft(M): the suspicion was cancelled, never fired",
+    );
+    assert!(
+      !node_joined_m,
+      "no NodeJoined(M): a Suspect -> Alive cancel is not a rejoin",
+    );
+
+    let broadcasts = coord.endpoint_mut().drain_broadcasts();
+    assert!(
+      broadcasts.iter().any(|msg| matches!(
+        msg,
+        Message::Alive(a) if a.node_ref().id_ref() == &m && a.incarnation() == inc + 1
+      )),
+      "the refutation Alive(M, inc+1) is broadcast",
+    );
+    assert!(
+      !broadcasts
+        .iter()
+        .any(|msg| matches!(msg, Message::Dead(d) if d.node_ref() == &m)),
+      "no Dead(M) is broadcast",
+    );
+  }
+
+  /// Liveness control: with no refutation on the wire, a suspicion still fires
+  /// `Dead` on the tick its deadline expires — the reorder does not suppress a
+  /// genuine failure. Same setup as the flap-cancel test, minus the inbound.
+  #[test]
+  fn suspicion_still_fires_without_refutation() {
+    use crate::{
+      event::Event,
+      typed::{Message, State},
+    };
+    let now = Instant::now();
+    let m = SmolStr::new("m-node");
+    let m_addr = addr(7303);
+    let inc = 5u32;
+
+    let mut coord = coord_with_suspect_member(7310, &m, m_addr, inc, now);
+    assert_eq!(
+      coord.endpoint_ref().member_liveness(&m),
+      Some(State::Suspect),
+      "M starts Suspect",
+    );
+
+    // The same wake time the refutation tests use; here nothing refutes, so the
+    // suspicion deadline (well within this margin) fires on the tick.
+    let t = now + Duration::from_secs(30);
+    coord.handle_timeout(t);
+
+    assert_eq!(
+      coord.endpoint_ref().member_liveness(&m),
+      Some(State::Dead),
+      "M transitions Dead once the suspicion deadline elapses",
+    );
+
+    let mut node_left_m = false;
+    while let Some(ev) = coord.poll_event() {
+      if let Event::NodeLeft(ns) = ev
+        && ns.id_ref() == &m
+      {
+        node_left_m = true;
+      }
+    }
+    assert!(
+      node_left_m,
+      "NodeLeft(M) is emitted on the suspicion expiry"
+    );
+
+    let broadcasts = coord.endpoint_mut().drain_broadcasts();
+    assert!(
+      broadcasts
+        .iter()
+        .any(|msg| matches!(msg, Message::Dead(d) if d.node_ref() == &m)),
+      "Dead(M) is broadcast on the suspicion expiry",
+    );
+  }
+
+  /// Control: a stale/equal-incarnation `Alive` carried in the same-tick
+  /// handshake does NOT refute the suspicion — the older/equal-incarnation
+  /// guard rejects it — so the suspicion survives the mint + replay and still
+  /// fires `Dead` when `handle_timeout` runs later in the same tick.
+  #[test]
+  fn stale_refutation_does_not_suppress_suspicion() {
+    use crate::{
+      event::Event,
+      typed::{Message, State},
+    };
+    let now = Instant::now();
+    let m = SmolStr::new("m-node");
+    let m_addr = addr(7303);
+    let inc = 5u32;
+    let coord_addr = addr(7320);
+
+    let mut coord = coord_with_suspect_member(7320, &m, m_addr, inc, now);
+
+    // The handshake carries Alive(M, inc) — equal to the suspicion incarnation,
+    // so the merge's `<= local_incarnation` guard drops it. The connection
+    // arrives fresh on the wake at `t >= deadline`.
+    let t = now + Duration::from_secs(30);
+    let blob = dialer_push_pull_advertising_alive(7321, &m, m_addr, inc, coord_addr, t);
+    let exchange = coord
+      .accept_connection(m_addr, t)
+      .expect("connection admitted while running");
+    coord.handle_transport_data(exchange, &blob, true, t);
+
+    assert_eq!(
+      coord.endpoint_ref().member_liveness(&m),
+      Some(State::Dead),
+      "the stale Alive does not refute; the suspicion still fires Dead",
+    );
+
+    let mut node_left_m = false;
+    while let Some(ev) = coord.poll_event() {
+      if let Event::NodeLeft(ns) = ev
+        && ns.id_ref() == &m
+      {
+        node_left_m = true;
+      }
+    }
+    assert!(
+      node_left_m,
+      "NodeLeft(M) is emitted: the suspicion survived"
+    );
+
+    let broadcasts = coord.endpoint_mut().drain_broadcasts();
+    assert!(
+      broadcasts
+        .iter()
+        .any(|msg| matches!(msg, Message::Dead(d) if d.node_ref() == &m)),
+      "Dead(M) is broadcast: the stale Alive did not suppress the suspicion",
+    );
+  }
 }
 
 /// STR-A001 test 3: a record layer whose `dialer` constructor fails drives the


### PR DESCRIPTION
## #158 F4 — apply a same-tick-settled handshake refutation before membership timers

Third of the #158 adversarial-review survivors (order F1 → F5 → **F4** → F6 → F7).

### The bug
The stream coordinator fuses inbound feed with time advance: `handle_transport_data` feeds bytes into a bridge, marks it dirty, then runs the **full** `run_tick(now)`, which advances membership time. Unlike the QUIC coordinator — whose datagram ingress does **not** advance time (it splits ingress from the timer at the entry point) — the stream coordinator therefore applied a refutation that settles a handshake on *this tick's already-fed input* only **after** `ep.handle_timeout` had already fired.

Concretely: member `M` is `Suspect` with deadline `t`. A peer's delivery `[TLS Finished ‖ label ‖ push/pull carrying Alive(M, inc+1) ‖ FIN]` arrives coalesced in one `handle_transport_data` on a driver wake at `now ≥ t` (ordinary scheduling). Old step order fired the suspicion first → synthesized `Dead(M)` → `NodeLeft` + cluster-wide `Dead` broadcast; then minted/replayed the handshake and merged the newer `Alive` → `NodeJoined` + `Alive` broadcast. Net: a spurious **Dead → Alive flap** gossiped cluster-wide, where the correct outcome is the silent **Suspect → Alive** cancel (snapshot bump only, no join/leave event).

Honest-scheduling correctness bug (CST threat model — no attacker required).

### The fix
Give the stream coordinator the QUIC ingress-before-time invariant **inside** `run_tick` (the only place it can, since ingress and time are fused there): mint and replay any handshake that settled on this tick's fed input (new steps **2.5** + **2.6**) **before** the membership timers (step 3), and delete the now-redundant post-timeout mint (old step 4).

- Extends the load-bearing drain-before-timeout invariant in the **same** direction — never weakens it. The reliable-fallback ping-ack drain-first rule is unchanged.
- **REFUTABLE-class** ordering (suspicion expiry vs a buffered `Alive` with no cutoff → apply-inbound-first is correct).
- The **PROBE class stays ordering-independent**: `complete_probe_success` routes any ack at/after the absolute `failure_deadline` to failure, so replaying a past-deadline reliable-ping ack earlier cannot resurrect a probe.
- No promotion coverage dropped: every dial `service_dials` inserts is added to `unminted` + `dirty`, and step 5.5's `service_handshake_completions` scans `unminted`, so it still promotes every bridge the deleted step 4 did. Nothing settles a handshake between step 2.6 and step 5 (settlement happens only on byte feed; `handle_timeout` feeds none).
- Cannot be flooded: the pre-timer work is a strict subset of the tick's existing work, one-shot mint per bridge, no new external input read between step 2 and step 3.
