### PR TITLE
fix(proto): retire a reaped exchange's pending Connect in reap_bridge (#158 F7)

### DIFF
--- a/memberlist-proto/src/streams/mod.rs
+++ b/memberlist-proto/src/streams/mod.rs
@@ -1784,6 +1784,12 @@ where
   /// [`StreamAction::Abort`], so the driver RSTs without putting stale bytes
   /// (including a TLS `close_notify`) on the wire.
   fn reap_bridge(&mut self, id: ExchangeId, br: &mut StreamBridge<I, A, R>, now: Instant) {
+    // Retire any still-queued `Connect` for this exchange: `poll_action` surfaces
+    // Connects before teardowns, so a reaped exchange whose `Connect` the driver
+    // had not yet drained would otherwise open a socket for an already-removed
+    // exchange before its `Abort`/`Close` arrives. Unconditional — the exchange is
+    // removed below on every reap, so no initiation action for it may remain.
+    self.purge_pending_connect_for(id);
     // Discipline the bridge's outbound bytes by terminal outcome BEFORE emitting
     // the teardown action below.
     //

--- a/memberlist-proto/src/streams/tests.rs
+++ b/memberlist-proto/src/streams/tests.rs
@@ -1029,7 +1029,7 @@ mod fallible {
 #[cfg(feature = "tls")]
 mod tls {
   use crate::Instant;
-  use core::net::SocketAddr;
+  use core::{net::SocketAddr, time::Duration};
 
   use smol_str::SmolStr;
   use std::sync::Arc;
@@ -1580,6 +1580,60 @@ mod tls {
       coord.live_bridge_count(),
       0,
       "no bridge is built while not running",
+    );
+  }
+
+  /// A reaped exchange's still-queued `Connect` must never surface:
+  /// `poll_action` orders every queued `Connect` before any teardown, so a
+  /// `Connect` left in `pending_connects` across a deadline reap would open a
+  /// transport socket for an exchange the coordinator has already removed,
+  /// before the `Abort` that tells the driver to tear the connection back
+  /// down.
+  ///
+  /// The TLS dialer stays `Handshaking` after `start_push_pull` (no server
+  /// response is fed), so the bridge is still unminted when its dial deadline
+  /// elapses. The `Connect` is deliberately left undrained — the driver has
+  /// not yet called `poll_action` when `handle_timeout` fires at the elapsed
+  /// deadline, which pumps the bridge, fails it on the handshake-deadline
+  /// guard, and reaps it through the GENERIC `reap_bridge` path (not the
+  /// dial-retired `dial_succeeded(None)` branch other tests cover).
+  #[test]
+  fn deadline_reaped_dial_surfaces_only_abort_no_stale_connect() {
+    let now = Instant::now();
+    let mut coord = tls_coord(7332);
+    let _sid = coord.start_push_pull(addr(7000), PushPullKind::Join, now);
+
+    assert_eq!(
+      coord.live_bridge_count(),
+      1,
+      "the dial built one handshaking bridge",
+    );
+
+    // Advance past the bridge's dial deadline (the default `stream_timeout`)
+    // WITHOUT ever draining the queued Connect via `poll_action`, then run
+    // the timer tick that reaps it.
+    let later = now + Duration::from_secs(30);
+    coord.handle_timeout(later);
+
+    assert_eq!(
+      coord.live_bridge_count(),
+      0,
+      "the deadline-elapsed bridge is reaped",
+    );
+
+    let mut saw_abort = false;
+    while let Some(action) = coord.poll_action() {
+      match action {
+        StreamAction::Connect(_) => {
+          panic!("a reaped exchange's stale Connect must never surface")
+        }
+        StreamAction::Abort(_) => saw_abort = true,
+        _ => {}
+      }
+    }
+    assert!(
+      saw_abort,
+      "the deadline-elapsed reap emits an Abort teardown",
     );
   }
 }


### PR DESCRIPTION
## #158 F7 — retire a reaped exchange's pending `Connect` in `reap_bridge`

### The bug
`poll_action` surfaces every queued `StreamAction::Connect` from `pending_connects` **before** any teardown (`Shutdown`/`Close`/`Abort`) — a documented self-ordering so a fresh dial's connection opens before a same-tick teardown targets an existing bridge. The two special terminal paths (the policy-change reap in `set_encryption_options`, and the `dial_succeeded(None)` failed-promotion branch) both pair `purge_transmit_for(id)` with `purge_pending_connect_for(id)`.

But the generic deadline-driven reap, `reap_bridge`, purged only the queued transmit bytes — it removed the exchange and pushed `Abort` but left the exchange's `Connect` in `pending_connects`. So an outbound bridge (e.g. a handshaking TLS dial) whose deadline elapses before the driver drains its `Connect`: `poll_action` surfaces the stale `Connect` (opening a transport socket for an already-removed exchange), and only afterward the `Abort`. Violated invariant: *once an exchange is terminal and removed, no initiation action for it should remain observable.*

### The fix
One unconditional `self.purge_pending_connect_for(id)` at the start of `reap_bridge` — centralizing initiation-action retirement in the one generic reap point, as the finding recommends. Unconditional is correct for both outcomes: `reap_bridge` removes the exchange from `self.exchanges` on every call, so any `Connect` for it is stale by definition; a clean (`BothClosed`) reap means the connection already completed its lifecycle and cannot have a legitimately-pending `Connect` (safe no-op there), and a failed reap is the trigger.

The two special-path purges are **left in place** — neither routes through `reap_bridge` (both remove the bridge inline), so their own purges are still required.

