### PR TITLE
fix(proto): preflight push/pull frames against max_stream_frame_size (#158 F6)

### DIFF
--- a/memberlist-proto/src/endpoint/mod.rs
+++ b/memberlist-proto/src/endpoint/mod.rs
@@ -26,9 +26,9 @@ use crate::{
   delegate::{AliveDelegate, MergeDelegate},
   error::{EndpointInitError, Error, GossipMtuBound, MetaTooLarge, SizeExceeded},
   event::{
-    CompoundTransmit, DialIntent, DialRequested, Event, ExchangeKind, NodeConflict, PacketTransmit,
-    PingCompleted, PingFailed, PingId, Reliability, RemoteStateReceived, SendPushPullResponse,
-    Transmit, UserPacket,
+    CompoundTransmit, DialAbortReason, DialIntent, DialRequested, Event, ExchangeKind,
+    NodeConflict, PacketTransmit, PingCompleted, PingFailed, PingId, Reliability,
+    RemoteStateReceived, SendPushPullResponse, Transmit, UserPacket,
   },
   members::{LocalNodeState, Member, Members},
   metrics::Metrics,
@@ -86,6 +86,14 @@ pub const META_MAX_SIZE: usize = 512;
 /// `PushNodeState` entries; an operator running BOTH a near-cap snapshot AND a
 /// cluster whose membership framing exceeds this reserve should raise
 /// `max_stream_frame_size` accordingly.
+///
+/// This reserve is a static construction/setter guard on the SNAPSHOT alone; it
+/// composes with — but does not replace — the dynamic gates that charge the FULL
+/// framed PushPull against the FULL `max_stream_frame_size` the receiver
+/// enforces. When membership framing pushes a request or response over that cap,
+/// the outbound request aborts as [`DialAbortReason::FrameExceedsCap`] (bumping
+/// `push_pull_requests_oversized`) and an over-cap served response bumps
+/// `push_pull_responses_oversized`.
 pub const LOCAL_STATE_FRAME_BUDGET: usize = 1024 * 1024;
 
 /// Validate a candidate local-state snapshot against the reliable-stream frame
@@ -280,6 +288,14 @@ pub struct Endpoint<I, A, R = SmallRng> {
   // encoding + compressing the frame per request. With compression disabled (or
   // no backend) this is the raw `encode_push_pull_response` frame verbatim.
   cached_pushpull_response: Bytes,
+  // Whether the plain (pre-compression) cached response frame exceeds
+  // `max_stream_frame_size` — the quantity an identically-configured peer's
+  // frame gate rejects before decoding. Recomputed on every cache rebuild in
+  // `build_pushpull_response_bytes`. The response is served anyway (refusing to
+  // answer diverges views); this flag drives the per-serve
+  // `push_pull_responses_oversized` counter so the doomed-but-served payload is
+  // observable.
+  cached_response_oversized: bool,
   // The `snapshot_version` the cached response was last built at. A tick rebuilds
   // the cache only when this differs from `snapshot_version` (which every
   // membership / incarnation / liveness / health change bumps), so a
@@ -1112,6 +1128,24 @@ where
       .collect();
     let framed =
       Self::encode_push_pull_response(&local_states, self.local_state_snapshot.clone(), false);
+    // Charge the PLAIN (pre-compression) frame against the cap the peer enforces
+    // before decoding — the receiver bounds the DECOMPRESSED plaintext by the
+    // same cap, so a well-compressing over-cap plain frame is still rejected;
+    // measuring `serve_ready` would undercount. The response is served anyway
+    // (refusing diverges views); the flag drives the per-serve counter.
+    let cap = self.cfg.max_stream_frame_size();
+    let oversized = framed.len() > cap;
+    #[cfg(feature = "tracing")]
+    if oversized && !self.cached_response_oversized {
+      // Edge-triggered: warn only on the false->true transition, not every
+      // rebuild, so a persistently over-cap cluster does not flood the log.
+      tracing::warn!(
+        framed_len = framed.len(),
+        cap,
+        "cached push/pull response frame exceeds max_stream_frame_size; peers with the same cap will reject it"
+      );
+    }
+    self.cached_response_oversized = oversized;
     // Fold the coordinator-uniform compression into the cache so it is paid once
     // per membership change, not once per inbound request. `compress_reliable_payload`
     // honors the don't-expand rule (a body that would not shrink is stored
@@ -1495,6 +1529,7 @@ where
       // Placeholder: the real self-only response is pre-built below (the forced
       // `cached_response_dirty` makes the first `refresh` build it).
       cached_pushpull_response: Bytes::new(),
+      cached_response_oversized: false,
       cached_response_version: 0,
       cached_response_dirty: true,
       #[cfg(compression)]
@@ -3229,10 +3264,18 @@ where
   /// `poll_event`. A driver that services its own dials in-band uses this to skip
   /// the drain-and-requeue of the whole application-event backlog per reliable send.
   ///
-  /// Returns `(id, None)` on the not-running inert-id path: a leaving/left node
-  /// registers no intent and emits no event, so there is no descriptor — the
-  /// returned id is inert, exactly as the event-emitting method leaves it.
-  /// Otherwise returns `(id, Some(intent))` with `intent.id() == id`.
+  /// Returns `(id, Ok(intent))` with `intent.id() == id` when the dial is
+  /// registered. Returns `(id, Err(reason))` with an inert id (no intent
+  /// registered, no event emitted) when the dial is retired before it starts:
+  ///
+  /// - [`DialAbortReason::NotRunning`] — a leaving/left node registers no intent
+  ///   and emits no event, so it advertises none of its pre-leave Alive state to
+  ///   a seed.
+  /// - [`DialAbortReason::FrameExceedsCap`] — the encoded PushPull frame exceeds
+  ///   `max_stream_frame_size`, so an identically-configured receiver's frame
+  ///   gate would reject it before decoding; dialing would burn a connection and
+  ///   handshake for a guaranteed remote decode error, so the send is aborted
+  ///   locally and `push_pull_requests_oversized` is bumped instead.
   ///
   /// `kind` should be `PushPullKind::Join` for initial join, `PushPullKind::Refresh`
   /// for periodic anti-entropy.
@@ -3241,14 +3284,14 @@ where
     peer: A,
     kind: PushPullKind,
     now: Instant,
-  ) -> (StreamId, Option<DialIntent<A>>) {
+  ) -> (StreamId, Result<DialIntent<A>, DialAbortReason>) {
     let id = self.allocate_stream_id();
     // A leaving/left node initiates no push/pull: it queues no dial intent and
     // emits no DialRequested, so it advertises none of its pre-leave Alive state
     // to a seed. The returned id is inert; the gated callers (join command
     // handlers and seed drains) never reach this once not Running.
     if !self.is_running() {
-      return (id, None);
+      return (id, Err(DialAbortReason::NotRunning));
     }
     let deadline = now + self.cfg.stream_timeout();
 
@@ -3285,6 +3328,37 @@ where
     let encoded = crate::wire::encode_message::<I, A>(&msg)
       .expect("PushPull encode cannot fail for well-formed data");
 
+    // Preflight the framed request against the same cap the receiver enforces
+    // before decoding: `encode_message` yields `[TAG:1][VARINT body_len][BODY]`,
+    // whose length equals the receiver's gated `total = 1 + varint_bytes +
+    // body_len` (`Stream::probe_frame`), byte-for-byte, both fed from
+    // `EndpointOptions::max_stream_frame_size`. Compression/encryption are
+    // neutral: the receiver bounds the DECOMPRESSED plaintext by the same cap on
+    // unwrap, so a well-compressing over-cap plain frame is still rejected. The
+    // comparison is therefore on the plain frame and STRICT — an exactly-at-cap
+    // frame passes both gates and must be sent. Aborting here (no dial, inert id)
+    // spares a doomed connection + handshake + full re-serialization every
+    // anti-entropy interval and surfaces the size locally instead of only as a
+    // remote decode error.
+    let cap = self.cfg.max_stream_frame_size();
+    if encoded.len() > cap {
+      self.metrics.push_pull_requests_oversized += 1;
+      #[cfg(feature = "tracing")]
+      tracing::debug!(
+        encoded_len = encoded.len(),
+        cap,
+        kind = ?kind,
+        "push/pull request frame exceeds max_stream_frame_size; not dialing"
+      );
+      return (
+        id,
+        Err(DialAbortReason::FrameExceedsCap(SizeExceeded::new(
+          encoded.len(),
+          cap,
+        ))),
+      );
+    }
+
     self.insert_intent(
       id,
       PendingStreamIntent {
@@ -3298,7 +3372,7 @@ where
 
     (
       id,
-      Some(DialIntent::new(id, peer, deadline, ExchangeKind::PushPull)),
+      Ok(DialIntent::new(id, peer, deadline, ExchangeKind::PushPull)),
     )
   }
 
@@ -3314,7 +3388,12 @@ where
   /// for periodic anti-entropy.
   pub fn start_push_pull(&mut self, peer: A, kind: PushPullKind, now: Instant) -> StreamId {
     let (id, intent) = self.start_push_pull_direct(peer, kind, now);
-    if let Some(intent) = intent {
+    // On `Err` (not running, or the frame exceeds `max_stream_frame_size`) no
+    // dial is queued — the metric and trace inside `start_push_pull_direct`
+    // carry the observability, and the returned id is inert, exactly as the
+    // not-running path has always behaved. The internal anti-entropy caller
+    // stays correct: an oversized tick dials nothing and still reschedules.
+    if let Ok(intent) = intent {
       let (id, peer, deadline, _kind) = intent.into_parts();
       self
         .pending_events
@@ -4973,6 +5052,15 @@ where
         // surface in the next tick's rebuild — at most one tick later.
         // `merge_state` above still applies the peer's push immediately; only
         // the reflected-back copy is tick-quantized.
+        //
+        // The response is served even when its plain frame exceeds
+        // `max_stream_frame_size`: refusing to answer would diverge the two
+        // nodes' views (a SWIM-semantic change), so the doomed-but-served
+        // payload is counted per serve instead. O(1) — the flag was computed on
+        // the last cache rebuild.
+        if self.cached_response_oversized {
+          self.metrics.push_pull_responses_oversized += 1;
+        }
         Some(StreamCommand::SendPushPullResponse(
           SendPushPullResponse::new(self.cached_pushpull_response.clone()),
         ))

--- a/memberlist-proto/src/endpoint/tests.rs
+++ b/memberlist-proto/src/endpoint/tests.rs
@@ -800,7 +800,7 @@ fn start_push_pull_direct_matches_event_emitting_surface() {
   // DIRECT method: same id / peer / deadline, and NO event.
   let mut e_new: Endpoint<SmolStr, SocketAddr> = Endpoint::new_at_seeded(cfg(), t0);
   let (id_new, intent) = e_new.start_push_pull_direct(peer, PushPullKind::Refresh, t0);
-  let intent = intent.expect("a running endpoint returns Some(DialIntent)");
+  let intent = intent.expect("a running endpoint returns Ok(DialIntent)");
   assert_eq!(
     id_new, id_old,
     "same id from the same fresh endpoint + args"
@@ -11707,5 +11707,325 @@ fn pushpull_response_cache_dirtied_by_set_local_state_snapshot() {
     after.as_ref(),
     b"app-state-v2",
     "the dirty flag makes the next tick rebuild the cache with the new snapshot"
+  );
+}
+
+// ── push/pull frame preflight against `max_stream_frame_size` ────────────────
+
+/// `meta_max_size` for the oversized-frame rigs: small enough that a single
+/// worst-case identity PushPull (the construction floor) fits under a modest
+/// `max_stream_frame_size`, while a SECOND member advertising a meta at this
+/// ceiling pushes the two-member frame over that cap.
+const OVERSIZED_META_MAX: usize = 256;
+
+/// A meta blob at exactly `OVERSIZED_META_MAX` — the largest a member may
+/// legally advertise under the rig config.
+fn near_max_meta() -> Meta {
+  Meta::try_from(Bytes::from(vec![0u8; OVERSIZED_META_MAX])).expect("meta at the ceiling is valid")
+}
+
+/// A second member carrying `near_max_meta`, admitted via a handled `Alive`.
+fn alive_near_max_meta(node_id: &str, port: u16, inc: u32) -> Alive<SmolStr, SocketAddr> {
+  Alive::new(inc, Node::new(SmolStr::new(node_id), sock(port)))
+    .with_meta(near_max_meta())
+    .with_protocol_version(ProtocolVersion::V1)
+    .with_delegate_version(DelegateVersion::V1)
+}
+
+/// The exact framed bytes of the two-member PushPull an endpoint holding
+/// `[local(empty meta), bob(near-max meta)]` with an empty local-state snapshot
+/// emits — the receiver-gated quantity. The local member reconstructs exactly
+/// (incarnation 1, empty initial meta, V1/V1 defaults) via `pns`; `bob` matches
+/// `alive_near_max_meta`. The `join` bool does not change the framed length.
+fn two_member_frame_bytes() -> Vec<u8> {
+  let local = pns("local", 7000, 1, State::Alive);
+  let bob = PushNodeState::new(1, SmolStr::new("bob"), sock(7001), State::Alive)
+    .with_meta(near_max_meta())
+    .with_protocol_version(ProtocolVersion::V1)
+    .with_delegate_version(DelegateVersion::V1);
+  Endpoint::<SmolStr, SocketAddr>::encode_push_pull_response(&[local, bob], Bytes::new(), false)
+}
+
+fn two_member_frame_len() -> usize {
+  two_member_frame_bytes().len()
+}
+
+/// A `max_stream_frame_size` one byte below the two-member frame: the single
+/// worst-case identity floor still fits (so construction succeeds), but a
+/// two-member PushPull is exactly one byte over.
+fn oversized_rig_cap() -> usize {
+  two_member_frame_len() - 1
+}
+
+/// A running two-member endpoint (local plus `bob` at near-max meta) built with
+/// the given frame cap. The two-member frame is `two_member_frame_len()`.
+fn two_member_endpoint(cap: usize, now: Instant) -> Endpoint<SmolStr, SocketAddr> {
+  let mut e = Endpoint::<SmolStr, SocketAddr>::try_new_at_seeded(
+    cfg()
+      .with_meta_max_size(OVERSIZED_META_MAX)
+      .with_max_stream_frame_size(cap),
+    now,
+  )
+  .expect("the single-identity floor fits under the cap, so construction succeeds");
+  while e.poll_event().is_some() {}
+  process_alive_auto(&mut e, alive_near_max_meta("bob", 7001, 1), false, now);
+  e
+}
+
+/// A running endpoint whose two-member PushPull frame overflows its
+/// `max_stream_frame_size` by one byte.
+fn oversized_two_member_endpoint(now: Instant) -> Endpoint<SmolStr, SocketAddr> {
+  two_member_endpoint(oversized_rig_cap(), now)
+}
+
+/// An oversized outbound push/pull request is aborted locally with the typed
+/// `FrameExceedsCap` reason: no intent is registered, no `DialRequested` is
+/// queued, the returned id is inert, and the request counter is bumped.
+#[test]
+fn start_push_pull_oversized_aborts_locally_with_typed_reason() {
+  let t0 = Instant::now();
+  let mut e = oversized_two_member_endpoint(t0);
+  let cap = oversized_rig_cap();
+  let peer = sock(7001);
+
+  let (id, res) = e.start_push_pull_direct(peer, PushPullKind::Refresh, t0);
+  let se = match res {
+    Err(DialAbortReason::FrameExceedsCap(se)) => se,
+    other => panic!("expected Err(FrameExceedsCap), got {other:?}"),
+  };
+  assert_eq!(se.limit(), cap, "the reported limit is the frame cap");
+  assert_eq!(
+    se.size(),
+    cap + 1,
+    "the reported size is the framed request length (one byte over the cap)"
+  );
+  assert!(
+    se.size() > se.limit(),
+    "an aborted frame is strictly over the cap"
+  );
+
+  // Inert id: no intent was registered, so a driver's dial-succeeded callback
+  // finds nothing to promote to a stream.
+  assert!(
+    e.dial_succeeded(id, t0).is_none(),
+    "an aborted request registers no intent"
+  );
+  // No dial was queued.
+  assert!(
+    !core::iter::from_fn(|| e.poll_event()).any(|ev| matches!(ev, Event::DialRequested(..))),
+    "an aborted request queues no DialRequested"
+  );
+  assert_eq!(
+    e.metrics().push_pull_requests_oversized,
+    1,
+    "the oversized-request counter is bumped exactly once"
+  );
+}
+
+/// Control: a within-cap push/pull still dials. A single-member endpoint sized
+/// with the same cap frames a request well under it, so the direct variant
+/// returns `Ok(intent)` and the event variant queues a `DialRequested`; neither
+/// bumps the oversized counter.
+#[test]
+fn start_push_pull_within_cap_still_dials() {
+  let t0 = Instant::now();
+  let cap = oversized_rig_cap();
+  let peer = sock(7001);
+
+  // Direct variant: Ok(intent) with a matching id, counter untouched.
+  let mut e_direct = Endpoint::<SmolStr, SocketAddr>::try_new_at_seeded(
+    cfg()
+      .with_meta_max_size(OVERSIZED_META_MAX)
+      .with_max_stream_frame_size(cap),
+    t0,
+  )
+  .expect("construction succeeds");
+  while e_direct.poll_event().is_some() {}
+  let (id, res) = e_direct.start_push_pull_direct(peer, PushPullKind::Refresh, t0);
+  let intent = res.expect("a within-cap single-member frame dials");
+  assert_eq!(intent.id(), id, "the intent carries the returned id");
+  assert_eq!(
+    e_direct.metrics().push_pull_requests_oversized,
+    0,
+    "a within-cap request bumps no counter"
+  );
+
+  // Event variant: a DialRequested is queued for the same within-cap frame.
+  let mut e_event = Endpoint::<SmolStr, SocketAddr>::try_new_at_seeded(
+    cfg()
+      .with_meta_max_size(OVERSIZED_META_MAX)
+      .with_max_stream_frame_size(cap),
+    t0,
+  )
+  .expect("construction succeeds");
+  while e_event.poll_event().is_some() {}
+  let ev_id = e_event.start_push_pull(peer, PushPullKind::Refresh, t0);
+  let dialed = core::iter::from_fn(|| e_event.poll_event()).any(|ev| match ev {
+    Event::DialRequested(d) => d.id() == ev_id,
+    _ => false,
+  });
+  assert!(dialed, "a within-cap request queues its DialRequested");
+  assert_eq!(
+    e_event.metrics().push_pull_requests_oversized,
+    0,
+    "a within-cap request bumps no counter"
+  );
+}
+
+/// The sender's preflight and the receiver's frame gate agree byte-for-byte and
+/// are both strict `>`: the very frame a sender aborts at `cap` is the frame a
+/// receiver rejects at `cap`, and the same frame at exactly its own length
+/// passes BOTH ends. Pins strict `>` on both sides against one identical frame.
+#[test]
+fn sender_preflight_matches_receiver_gate() {
+  use crate::error::StreamError;
+
+  let t0 = Instant::now();
+  let peer = sock(7001);
+
+  // The exact two-member frame both ends measure.
+  let frame = two_member_frame_bytes();
+  let l2 = frame.len();
+  let cap_below = l2 - 1; // frame is exactly one byte over
+  let cap_exact = l2; // frame is exactly at the cap
+
+  // ── Over the cap (`cap_below`) ──
+  // Sender: aborts locally with the exact framed size.
+  let mut e_send_over = two_member_endpoint(cap_below, t0);
+  let (_id, res) = e_send_over.start_push_pull_direct(peer, PushPullKind::Refresh, t0);
+  match res {
+    Err(DialAbortReason::FrameExceedsCap(se)) => {
+      assert_eq!(se.size(), l2, "the sender measures the exact frame length");
+      assert_eq!(se.limit(), cap_below);
+    }
+    other => panic!("expected the sender to abort over the cap, got {other:?}"),
+  }
+  // Receiver: rejects the same frame at the same cap before decoding.
+  let mut s_over = stream_in_receiving(cap_below);
+  let err = s_over
+    .handle_data(&frame, t0)
+    .expect_err("the receiver rejects a frame over its cap");
+  assert!(
+    matches!(err, StreamError::Decode(_)),
+    "an over-cap frame is a decode rejection, got {err:?}"
+  );
+
+  // ── Exactly at the cap (`cap_exact`) ──
+  // Sender: the same frame at a cap equal to its length is sent (strict `>`).
+  let mut e_send_exact = two_member_endpoint(cap_exact, t0);
+  let (_id, res) = e_send_exact.start_push_pull_direct(peer, PushPullKind::Refresh, t0);
+  assert!(
+    res.is_ok(),
+    "a frame at exactly the cap is sent (strict `>` gate), got {res:?}"
+  );
+  assert_eq!(e_send_exact.metrics().push_pull_requests_oversized, 0);
+  // Receiver: the same frame at the same cap is accepted and decodes.
+  let mut s_exact = stream_in_receiving(cap_exact);
+  s_exact
+    .handle_data(&frame, t0)
+    .expect("a frame at exactly the cap is accepted");
+  assert!(
+    matches!(
+      s_exact.poll_endpoint_event(),
+      Some(EndpointEvent::PushPullRequestReceived(..))
+    ),
+    "the exact-cap frame decodes into a push/pull request"
+  );
+}
+
+/// A `Stream` in `InboundAwaitingFirstMessage` configured with `cap` as its
+/// frame bound, built directly from the crate-visible fields.
+fn stream_in_receiving(cap: usize) -> crate::stream::Stream<SmolStr, SocketAddr> {
+  use crate::stream::{Stream, StreamPhase};
+  use std::collections::VecDeque;
+  Stream {
+    id: StreamId::from_raw(1),
+    peer: sock(7002),
+    local_id: SmolStr::new("local"),
+    max_frame_size: cap,
+    phase: StreamPhase::InboundAwaitingFirstMessage,
+    input_buf: bytes::BytesMut::new(),
+    output_buf: VecDeque::new(),
+    deadline: Some(Instant::now() + Duration::from_secs(30)),
+    endpoint_events: VecDeque::new(),
+    stream_events: VecDeque::new(),
+  }
+}
+
+/// A periodic anti-entropy tick over an oversized membership counts the aborted
+/// request and still reschedules: no `DialRequested` surfaces, the counter is
+/// bumped, and the scheduler is not wedged (a future push/pull deadline stays).
+#[test]
+fn anti_entropy_tick_oversized_counts_and_reschedules() {
+  let t0 = Instant::now();
+  let mut e = oversized_two_member_endpoint(t0);
+  e.start_scheduling(t0);
+  while e.poll_event().is_some() {}
+
+  // Advance well past the push/pull interval so the scheduler fires.
+  let later = t0 + e.cfg.push_pull_interval() + Duration::from_secs(120);
+  e.handle_timeout(later);
+
+  assert!(
+    e.metrics().push_pull_requests_oversized >= 1,
+    "the anti-entropy tick counted the oversized abort"
+  );
+  assert!(
+    !core::iter::from_fn(|| e.poll_event()).any(|ev| matches!(ev, Event::DialRequested(..))),
+    "the oversized anti-entropy tick queues no DialRequested"
+  );
+  assert!(
+    e.poll_timeout().is_some(),
+    "the scheduler reschedules rather than wedging on a doomed dial"
+  );
+}
+
+/// An oversized inbound push/pull response is served unchanged (refusing would
+/// diverge views) and counted per serve; a within-cap endpoint serves the same
+/// way with the counter flat.
+#[test]
+fn oversized_pushpull_response_served_and_counted() {
+  let t0 = Instant::now();
+  let mut e = oversized_two_member_endpoint(t0);
+  // Publish the two-member membership into the response cache (the tick is the
+  // only site that rebuilds it and re-evaluates the oversized flag).
+  e.handle_timeout(t0);
+  while e.poll_event().is_some() {}
+
+  let peer = sock(9500);
+  let cmd1 = e.handle_stream_event(inbound_pushpull_request(peer, vec![], 1), t0);
+  let cmd2 = e.handle_stream_event(inbound_pushpull_request(peer, vec![], 2), t0);
+  let bytes1 = pushpull_response_bytes(cmd1);
+  let bytes2 = pushpull_response_bytes(cmd2);
+  // Served UNCHANGED: byte-identical to the cache, and both requests share the
+  // one cached allocation.
+  assert_eq!(
+    bytes1,
+    e.cached_pushpull_response(),
+    "the oversized response is served verbatim from the cache"
+  );
+  assert_eq!(
+    bytes1.as_ptr(),
+    bytes2.as_ptr(),
+    "both serves share the cache"
+  );
+  assert_eq!(
+    e.metrics().push_pull_responses_oversized,
+    2,
+    "each serve of an oversized response is counted"
+  );
+
+  // Control: a within-cap endpoint serves with the counter flat.
+  let mut e_ok: Endpoint<SmolStr, SocketAddr> = Endpoint::new_at_seeded(cfg(), t0);
+  process_alive_auto(&mut e_ok, alive("known", 9001, 1), false, t0);
+  e_ok.handle_timeout(t0);
+  while e_ok.poll_event().is_some() {}
+  let _ = pushpull_response_bytes(
+    e_ok.handle_stream_event(inbound_pushpull_request(peer, vec![], 1), t0),
+  );
+  assert_eq!(
+    e_ok.metrics().push_pull_responses_oversized,
+    0,
+    "a within-cap response is not counted"
   );
 }

--- a/memberlist-proto/src/error/mod.rs
+++ b/memberlist-proto/src/error/mod.rs
@@ -122,7 +122,7 @@ pub enum Error {
 /// exceeded a limit in bytes. The variant names the specific size and limit
 /// (a per-endpoint cap, a gossip-packet budget, or a reliable-stream frame
 /// budget).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SizeExceeded(usize, usize);
 
 impl SizeExceeded {

--- a/memberlist-proto/src/event/mod.rs
+++ b/memberlist-proto/src/event/mod.rs
@@ -249,6 +249,10 @@ pub enum DialAbortReason {
   /// retires the id here. Distinct from [`Self::NotRunning`], which is a dial
   /// started while the endpoint was already leaving/left.
   Leaving,
+  /// The encoded push/pull request frame exceeds `max_stream_frame_size`, so an
+  /// identically-configured receiver's frame gate would reject it before
+  /// decoding. No dial was initiated. Carries the framed size and the cap.
+  FrameExceedsCap(crate::error::SizeExceeded),
 }
 
 /// Payload for [`Event::DialAborted`]: a [`StreamId`] returned by a `start_*`

--- a/memberlist-proto/src/metrics.rs
+++ b/memberlist-proto/src/metrics.rs
@@ -2,7 +2,8 @@
 //!
 //! [`Metrics`] is a snapshot of cumulative `u64` counters the single-owner
 //! machine bumps as it sheds load at its bounds — every count is a datagram,
-//! node, connection, or payload the machine deliberately dropped or withheld.
+//! node, connection, or payload the machine deliberately dropped, withheld, or
+//! served past a peer's frame gate.
 //! Because the machine is single-owner and synchronous, the counters are plain
 //! integers (no atomics); a driver reads a `Copy` snapshot via the endpoint and
 //! re-exports it on its handle, alongside the membership snapshot.
@@ -66,4 +67,10 @@ pub struct Metrics {
   /// keeps a plaintext forger from pinning a live id un-refutably. Locally
   /// synthesized failure detection is unaffected.
   pub unrefutable_failure_rejected: u64,
+  /// Outbound push/pull requests aborted locally because the encoded frame
+  /// exceeds `max_stream_frame_size` (join, seed drain, and periodic refresh alike).
+  pub push_pull_requests_oversized: u64,
+  /// Inbound push/pull responses served whose plain frame exceeds
+  /// `max_stream_frame_size` (the identically-configured peer will reject it; counted per serve).
+  pub push_pull_responses_oversized: u64,
 }

--- a/memberlist-proto/src/quic/mod.rs
+++ b/memberlist-proto/src/quic/mod.rs
@@ -5207,11 +5207,18 @@ where
   /// never scans the whole dial / bridge / connection tables and does zero
   /// event-queue work.
   ///
-  /// On the not-running inert-id path the descriptor is `None`: the endpoint
-  /// registered no intent and queued no event, so NO `pending_outbound_*` entry is
-  /// inserted (inserting one would leak — no bridge is ever created for this id to
-  /// reap it) and a synchronous `Failed` [`Event::ExchangeCompleted`] is emitted for
-  /// the returned id so a join waiter parked on it resolves immediately.
+  /// On an `Err` inert-id path the endpoint registered no intent and queued no
+  /// event, so NO `pending_outbound_*` entry is inserted (inserting one would
+  /// leak — no bridge is ever created for this id to reap it) and a synchronous
+  /// `Failed` [`Event::ExchangeCompleted`] is emitted for the returned id so a
+  /// join waiter parked on it resolves immediately. This covers both
+  /// [`DialAbortReason::NotRunning`](crate::event::DialAbortReason::NotRunning)
+  /// (the endpoint is leaving/left) and
+  /// [`DialAbortReason::FrameExceedsCap`](crate::event::DialAbortReason::FrameExceedsCap)
+  /// (the framed request exceeds `max_stream_frame_size`, so an
+  /// identically-configured receiver would reject it before decoding). The abort
+  /// reason is carried by `push_pull_requests_oversized` and the trace, not by
+  /// `ExchangeCompleted` (which has no reason field).
   pub fn start_push_pull(
     &mut self,
     peer: SocketAddr,
@@ -5221,7 +5228,7 @@ where
     self.last_now = Some(now);
     let (id, intent) = self.ep.start_push_pull_direct(peer, kind, now);
     match intent {
-      Some(intent) => {
+      Ok(intent) => {
         // `attempted = true`: this entry never entered `dial_pending`, so it was
         // never counted in `unattempted_dial_count`; constructing it attempted
         // keeps `process_dial_entry` from decrementing a count it never bumped, so
@@ -5241,7 +5248,7 @@ where
         self.pending_outbound_peers.insert(id, peer);
         self.service_started_exchange(entry, now);
       }
-      None => self.emit_inert_dial_failed(id, peer, ExchangeKind::PushPull),
+      Err(_reason) => self.emit_inert_dial_failed(id, peer, ExchangeKind::PushPull),
     }
     id
   }

--- a/memberlist-proto/src/quic/tests.rs
+++ b/memberlist-proto/src/quic/tests.rs
@@ -2129,6 +2129,88 @@ fn expired_push_pull_dial_emits_failed_exchange_completed() {
   );
 }
 
+/// A QUIC `start_push_pull` whose framed request exceeds `max_stream_frame_size`
+/// completes synchronously as a `Failed` `Event::ExchangeCompleted` keyed
+/// `ExchangeId::from(StreamId)` — the same terminal a QUIC join waiter parks on,
+/// so an oversized seed resolves immediately rather than hanging. No connection
+/// is dialed (no `dial_parked` entry) and no `pending_outbound_*` entry leaks.
+#[test]
+fn quic_start_push_pull_oversized_completes_failed() {
+  use crate::{
+    endpoint::Endpoint as CoreEndpoint,
+    event::{ExchangeId, ExchangeKind, ExchangeStatus},
+    node::Node,
+    typed::{Alive, DelegateVersion, Meta, ProtocolVersion, PushNodeState},
+  };
+
+  const META_MAX: usize = 256;
+  let big_meta = Meta::try_from(Bytes::from(vec![0u8; META_MAX])).expect("meta at the ceiling");
+
+  let a_addr: SocketAddr = "127.0.0.1:7983".parse().unwrap();
+  let bob_addr: SocketAddr = "127.0.0.1:7984".parse().unwrap();
+  let now = Instant::now();
+
+  // The exact two-member frame the endpoint (local "a" + bob near-max meta)
+  // would emit, and a cap one byte below it.
+  let local_pns = PushNodeState::new(1, SmolStr::new("a"), a_addr, State::Alive)
+    .with_meta(Meta::empty())
+    .with_protocol_version(ProtocolVersion::V1)
+    .with_delegate_version(DelegateVersion::V1);
+  let bob_pns = PushNodeState::new(1, SmolStr::new("bob"), bob_addr, State::Alive)
+    .with_meta(big_meta.clone())
+    .with_protocol_version(ProtocolVersion::V1)
+    .with_delegate_version(DelegateVersion::V1);
+  let l2 = CoreEndpoint::<SmolStr, SocketAddr>::encode_push_pull_response(
+    &[local_pns, bob_pns],
+    Bytes::new(),
+    false,
+  )
+  .len();
+
+  let cfg = EndpointOptions::new(SmolStr::new("a"), a_addr)
+    .with_meta_max_size(META_MAX)
+    .with_max_stream_frame_size(l2 - 1);
+  let mut a = make_endpoint_full(cfg, test_config(), a_addr, now);
+  a.endpoint_mut().process_alive(
+    Alive::new(1, Node::new(SmolStr::new("bob"), bob_addr))
+      .with_meta(big_meta)
+      .with_protocol_version(ProtocolVersion::V1)
+      .with_delegate_version(DelegateVersion::V1),
+    false,
+    now,
+  );
+
+  let id = a.start_push_pull(bob_addr, PushPullKind::Refresh, now);
+  let expected_eid = ExchangeId::from(id);
+
+  let mut found = None;
+  while let Some(ev) = a.poll_event() {
+    if let Event::ExchangeCompleted(payload) = ev
+      && payload.eid() == expected_eid
+    {
+      found = Some(payload);
+      break;
+    }
+  }
+  let payload = found.expect(
+    "an oversized push/pull request completes synchronously as a Failed \
+       ExchangeCompleted keyed ExchangeId::from(StreamId)",
+  );
+  assert_eq!(payload.kind(), ExchangeKind::PushPull);
+  assert_eq!(payload.outcome(), ExchangeStatus::Failed);
+  assert_eq!(payload.peer(), &bob_addr);
+
+  // No connection was dialed and nothing leaked.
+  assert_eq!(
+    a.dial_parked.get(&bob_addr).map(|b| b.len()).unwrap_or(0),
+    0,
+    "an oversized request parks no dial",
+  );
+  assert!(!a.pending_outbound_kinds.contains_key(&id));
+  assert!(!a.pending_outbound_peers.contains_key(&id));
+  assert_eq!(a.live_bridge_count(), 0, "no bridge was built");
+}
+
 /// Strict-poll self-sufficiency: a bridge inserted into `self.bridges`
 /// by `service_quinn`'s `accept(Dir::Bi)` loop (step 4) or
 /// `service_dials`'s `streams().open(Dir::Bi)` (step 5) MUST be pumped

--- a/memberlist-proto/src/streams/mod.rs
+++ b/memberlist-proto/src/streams/mod.rs
@@ -106,8 +106,8 @@ use crate::{
   endpoint::Endpoint,
   error::{Error, StreamError},
   event::{
-    DialAbortReason, DialAborted, Event, ExchangeCompleted, ExchangeKind, ExchangeStatus,
-    PushPullKind, StreamId, Transmit,
+    DialAbortReason, DialAborted, DialRequested, Event, ExchangeCompleted, ExchangeKind,
+    ExchangeStatus, PushPullKind, StreamId, Transmit,
   },
 };
 use bridge::StreamBridge;
@@ -2587,22 +2587,35 @@ where
   /// `handle_timeout` pre-pump.
   pub fn start_push_pull(&mut self, peer: A, kind: PushPullKind, now: Instant) -> StreamId {
     self.last_now = Some(now);
-    // The inner endpoint returns an inert id (no `DialRequested` enqueued) when
-    // leaving/left. Clone the address up front so the not-running branch can
-    // terminate that id with a `DialAborted` without staging it — staging would
-    // leave a `pending_outbound_kinds` entry that `service_dials` never drains
-    // while not running.
+    // Use the direct variant so the abort reason is in-band. On `Err` the inner
+    // endpoint registered no intent and queued no `DialRequested`, so the id is
+    // inert: terminate it with a single `DialAborted` and do NOT stage its kind —
+    // staging without a dial would leave a `pending_outbound_kinds` entry that
+    // `service_dials` never drains. Both `NotRunning` (leaving/left) and
+    // `FrameExceedsCap` (the framed request exceeds `max_stream_frame_size`, so
+    // an identically-configured receiver would reject it before decoding) flow
+    // through this arm.
     let peer_a = crate::CheapClone::cheap_clone(&peer);
-    let id = self.ep.start_push_pull(peer, kind, now);
-    if !self.ep.is_running() {
-      self.ep.emit_event(Event::DialAborted(DialAborted::new(
-        id,
-        peer_a,
-        ExchangeKind::PushPull,
-        DialAbortReason::NotRunning,
-      )));
-      return id;
-    }
+    let (id, intent) = self.ep.start_push_pull_direct(peer, kind, now);
+    let intent = match intent {
+      Ok(intent) => intent,
+      Err(reason) => {
+        self.ep.emit_event(Event::DialAborted(DialAborted::new(
+          id,
+          peer_a,
+          ExchangeKind::PushPull,
+          reason,
+        )));
+        return id;
+      }
+    };
+    // Mirror what the event variant would have queued: surface the dial request
+    // so `service_dials` sieves and attempts it in-band (byte-identical to the
+    // event-emitting path for a within-cap frame).
+    let (rid, rpeer, deadline, _kind) = intent.into_parts();
+    self.ep.emit_event(Event::DialRequested(DialRequested::new(
+      rid, rpeer, deadline,
+    )));
     self
       .pending_outbound_kinds
       .insert(id, ExchangeKind::PushPull);

--- a/memberlist-proto/src/streams/tests.rs
+++ b/memberlist-proto/src/streams/tests.rs
@@ -1169,6 +1169,127 @@ mod tcp {
       "Dead(M) is broadcast: the stale Alive did not suppress the suspicion",
     );
   }
+
+  /// A meta blob at exactly `META_MAX` — the largest a member may advertise
+  /// under the oversized rig config.
+  const META_MAX: usize = 256;
+
+  fn near_max_meta() -> crate::typed::Meta {
+    crate::typed::Meta::try_from(Bytes::from(vec![0u8; META_MAX])).expect("meta at the ceiling")
+  }
+
+  /// The exact framed length of the two-member PushPull request an endpoint
+  /// holding `[local(empty meta), bob(near-max meta)]` emits (empty snapshot).
+  fn two_member_frame_len(local_id: &str, local: SocketAddr, bob: SocketAddr) -> usize {
+    use crate::{
+      endpoint::Endpoint,
+      typed::{DelegateVersion, ProtocolVersion, PushNodeState, State},
+    };
+    let local_pns = PushNodeState::new(1, SmolStr::new(local_id), local, State::Alive)
+      .with_meta(crate::typed::Meta::empty())
+      .with_protocol_version(ProtocolVersion::V1)
+      .with_delegate_version(DelegateVersion::V1);
+    let bob_pns = PushNodeState::new(1, SmolStr::new("bob"), bob, State::Alive)
+      .with_meta(near_max_meta())
+      .with_protocol_version(ProtocolVersion::V1)
+      .with_delegate_version(DelegateVersion::V1);
+    Endpoint::<SmolStr, SocketAddr>::encode_push_pull_response(
+      &[local_pns, bob_pns],
+      Bytes::new(),
+      false,
+    )
+    .len()
+  }
+
+  /// A running plain-TCP coordinator over a two-member endpoint (local + `bob`
+  /// at near-max meta) built with the given frame cap.
+  fn two_member_coord(
+    local_port: u16,
+    cap: usize,
+    now: Instant,
+  ) -> StreamEndpoint<SmolStr, SocketAddr, RawRecords> {
+    use crate::{
+      config::EndpointOptions,
+      endpoint::Endpoint,
+      node::Node,
+      typed::{Alive, DelegateVersion, ProtocolVersion},
+    };
+    let local_id = format!("n-{local_port}");
+    let mut ep = Endpoint::<SmolStr, SocketAddr>::try_new_at_seeded(
+      EndpointOptions::new(SmolStr::new(local_id), addr(local_port))
+        .with_meta_max_size(META_MAX)
+        .with_max_stream_frame_size(cap),
+      now,
+    )
+    .expect("the single-identity floor fits under the cap");
+    ep.process_alive(
+      Alive::new(1, Node::new(SmolStr::new("bob"), addr(7002)))
+        .with_meta(near_max_meta())
+        .with_protocol_version(ProtocolVersion::V1)
+        .with_delegate_version(DelegateVersion::V1),
+      false,
+      now,
+    );
+    let cfg = LabelOptions::new_in(Some(b"cluster-x".to_vec()), ());
+    StreamEndpoint::new(ep, cfg, test_sni_provider(), test_peer_to_socket())
+  }
+
+  /// A coordinator `start_push_pull` whose framed request exceeds
+  /// `max_stream_frame_size` surfaces exactly one `DialAborted{PushPull,
+  /// FrameExceedsCap}` keyed by the returned id, opens NO connection, and leaves
+  /// no staged `pending_outbound_kinds` entry to wedge later servicing. The
+  /// control (a raised cap) dials as usual.
+  #[test]
+  fn streams_start_push_pull_oversized_emits_dial_aborted() {
+    let now = Instant::now();
+    let local_port = 7150;
+    let l2 = two_member_frame_len(&format!("n-{local_port}"), addr(local_port), addr(7002));
+
+    // Oversized: cap one byte below the two-member frame.
+    let mut coord = two_member_coord(local_port, l2 - 1, now);
+    let sid = coord.start_push_pull(addr(7002), PushPullKind::Join, now);
+
+    assert!(
+      coord.poll_action().is_none(),
+      "no Connect surfaces for an oversized push/pull request",
+    );
+    assert!(
+      coord.poll_transport_transmit().is_none(),
+      "no bytes transmit for an aborted dial",
+    );
+    let mut aborts = Vec::new();
+    while let Some(ev) = coord.poll_event() {
+      if let Event::DialAborted(a) = ev {
+        aborts.push((a.stream_id(), a.kind(), a.reason()));
+      }
+    }
+    assert_eq!(aborts.len(), 1, "exactly one DialAborted surfaces");
+    let (aid, akind, areason) = aborts[0];
+    assert_eq!(aid, sid, "the abort is keyed by the returned StreamId");
+    assert_eq!(akind, ExchangeKind::PushPull);
+    assert!(
+      matches!(areason, DialAbortReason::FrameExceedsCap(_)),
+      "the reason is FrameExceedsCap, got {areason:?}",
+    );
+    assert_eq!(
+      coord.pending_outbound_kinds_len(),
+      0,
+      "an aborted dial stages no pending_outbound_kinds entry",
+    );
+    // No wedge: servicing again surfaces nothing further.
+    assert!(coord.poll_action().is_none());
+    assert_eq!(coord.live_bridge_count(), 0, "no bridge was built");
+
+    // Control: a raised cap dials through the coordinator as usual.
+    let mut ok = two_member_coord(local_port, l2 + 4096, now);
+    let ok_sid = ok.start_push_pull(addr(7002), PushPullKind::Join, now);
+    let connected = core::iter::from_fn(|| ok.poll_action())
+      .any(|a| matches!(a, StreamAction::Connect(c) if c.stream_id() == ok_sid));
+    assert!(connected, "a within-cap request surfaces a Connect");
+    let no_abort =
+      !core::iter::from_fn(|| ok.poll_event()).any(|ev| matches!(ev, Event::DialAborted(_)));
+    assert!(no_abort, "a within-cap request is not aborted");
+  }
 }
 
 /// STR-A001 test 3: a record layer whose `dialer` constructor fails drives the


### PR DESCRIPTION
## #158 F6 — couple push/pull output sizing to `max_stream_frame_size`

The final #158 adversarial-review survivor (order F1 → F5 → F4 → F7 → **F6**).

### The bug
Both push/pull **sender** paths — the outbound request (`start_push_pull_direct`) and the inbound response cache (`build_pushpull_response_bytes`) — fold the **full** membership into a `PushPull` frame and encode with **no** check against `max_stream_frame_size`, while the **receiver** (`Stream::probe_frame`) rejects any frame whose total exceeds that cap *before* decoding. So once membership framing grows past the cap, join and periodic anti-entropy fail **repeatedly**, surfacing only as an opaque **remote** decode error — with the anti-entropy scheduler re-burning a doomed dial + handshake + full serialization every interval, and the diagnosis on the wrong node.

Honest-scaling correctness bug (CST threat model — no attacker).

### The fix — sender-side preflight + typed abort + observability
- **Outbound request:** a strict preflight (`encoded.len() > max_stream_frame_size`) after encode, before registering the intent. On overflow: no dial, the `StreamId` is inert, and the abort travels on the existing terminal surface as a new typed `DialAbortReason::FrameExceedsCap(SizeExceeded)`, bumping a new `push_pull_requests_oversized` counter. The streams coordinator emits one `DialAborted` (without staging `pending_outbound_kinds` — that would leak); the QUIC coordinator emits its synchronous `Failed` `ExchangeCompleted` via `emit_inert_dial_failed`, so a join waiter resolves immediately. The event-variant `start_push_pull` stays infallible — an oversized anti-entropy tick bumps the counter, dials nothing, and still reschedules (no wedge).
- **Inbound response:** served **unchanged** (byte-identical) — refusing would only turn a fast remote decode error into a slower timeout while dropping the request→us merge that still converges one direction — but counted per serve via `push_pull_responses_oversized`, flagged (edge-triggered warn) on the **plain pre-compression** frame (the receiver bounds *decompressed* plaintext by the same cap, so compression cannot mask an over-cap frame).

**Byte-for-byte sender/receiver agreement:** `encode_message(msg).len()` == the receiver's gated `total = 1 + varint_bytes + body_len`, both strict against the same `max_stream_frame_size`, so an exactly-at-cap frame is sent *and* accepted. Pinned by `sender_preflight_matches_receiver_gate`, which drives one identical two-member frame through both the sender abort and the receiver `Stream` at `cap−1` (both reject) and at `cap` (both accept).

**Out of scope (noted as future work):** PushPull fragmentation/chunking, and coupling `max_members` admission to frame budget (membership is gossip-driven — refusing admission on frame size would diverge views, a SWIM-semantic change).

`LOCAL_STATE_FRAME_BUDGET` is unchanged: it stays the static construction/setter guard on the snapshot alone; the new checks are the dynamic exact gate on the full frame against the full cap. No API break downstream (serf calls only the coordinator wrappers); the driver crates don't match `DialAbortReason` exhaustively, so the new variant needs no driver arm.

