### PR TITLE
fix: cap extreme durations so scheduler jitter and compio sleeps never wrap or panic (#171)

### DIFF
--- a/memberlist-compio/src/bridge/mod.rs
+++ b/memberlist-compio/src/bridge/mod.rs
@@ -126,6 +126,7 @@ use futures_util::{FutureExt, future::FusedFuture, pin_mut, select_biased};
 use lochan::mpsc::{Receiver, Sender};
 
 use crate::driver::{
+  options::capped_timer,
   shared::ExchangeId,
   stream::{BridgeBytes, BridgeEof, BridgeError, BridgeInbound, BridgeOut},
 };
@@ -478,7 +479,7 @@ where
     // Re-arm the deadline FRESH each iteration: progress (a non-empty partial
     // write) resets the clock, so this is an idle timeout, not a total-duration
     // cap. A slow-but-reading peer advances every chunk and never trips it.
-    let timeout_fut = compio::time::sleep(close_timeout).fuse();
+    let timeout_fut = compio::time::sleep(capped_timer(close_timeout)).fuse();
     pin_mut!(timeout_fut);
     let BufResult(res, slice) = select_biased! {
       // Explicit abort only (a disconnect was mapped to `pending()`). Listed

--- a/memberlist-compio/src/driver/options/mod.rs
+++ b/memberlist-compio/src/driver/options/mod.rs
@@ -12,6 +12,23 @@
 use crate::error::{InvalidOption, MemberlistError};
 use core::time::Duration;
 
+/// The largest duration passed to `compio::time::sleep`. `compio::time::sleep(d)`
+/// computes `Instant::now() + d`, which panics if it overflows the platform
+/// monotonic clock; capping here degrades an extreme or misconfigured timeout
+/// to a far-future deadline instead of panicking the detached task. The cap is
+/// far larger than any real close/dial/peek timeout and far below the overflow
+/// point, so `Instant::now() + MAX_TIMER_DURATION` can never overflow.
+pub(crate) const MAX_TIMER_DURATION: Duration = Duration::from_secs(10 * 365 * 24 * 60 * 60); // ~10 years
+
+/// Cap `d` at [`MAX_TIMER_DURATION`] before handing it to `compio::time::sleep`,
+/// so an operator-configured `close_timeout` / `dial_timeout` / `peek_budget`
+/// large enough to overflow `Instant::now() + d` degrades to a bounded
+/// far-future sleep instead of panicking the sleeping task.
+#[inline]
+pub(crate) fn capped_timer(d: Duration) -> Duration {
+  d.min(MAX_TIMER_DURATION)
+}
+
 /// Default per-call deadline for [`Memberlist::join`](crate::Memberlist::join).
 pub const DEFAULT_JOIN_DEADLINE: Duration = Duration::from_secs(10);
 

--- a/memberlist-compio/src/driver/options/tests.rs
+++ b/memberlist-compio/src/driver/options/tests.rs
@@ -296,3 +296,28 @@ fn stream_transport_options_validate() {
       .is_ok()
   );
 }
+
+// `capped_timer` caps an extreme duration at `MAX_TIMER_DURATION` and passes
+// a small one through unchanged; the cap is representable by
+// `Instant::now() + d` while the uncapped `Duration::MAX` is not, which is
+// exactly why `compio::time::sleep` needs the cap.
+#[test]
+fn capped_timer_caps_extreme_and_passes_through_small() {
+  assert_eq!(capped_timer(Duration::MAX), MAX_TIMER_DURATION);
+  assert_eq!(capped_timer(Duration::from_secs(5)), Duration::from_secs(5));
+
+  // The cap is representable, so `sleep(capped)` cannot overflow-panic.
+  assert!(
+    std::time::Instant::now()
+      .checked_add(MAX_TIMER_DURATION)
+      .is_some()
+  );
+  // Mutation-anchor: without the cap, the raw extreme duration overflows the
+  // monotonic clock's `checked_add` — this is the panic `capped_timer` exists
+  // to prevent.
+  assert!(
+    std::time::Instant::now()
+      .checked_add(Duration::MAX)
+      .is_none()
+  );
+}

--- a/memberlist-compio/src/driver/stream/mod.rs
+++ b/memberlist-compio/src/driver/stream/mod.rs
@@ -55,7 +55,7 @@ use crate::{
   command::{Command, JoinCmd, JoinKind, JoinReply, LeaveCmd, ShutdownCmd, UpdateNodeMetadataCmd},
   delegate::Delegate,
   driver::{
-    options::{RuntimeOptions, StreamTransportOptions},
+    options::{RuntimeOptions, StreamTransportOptions, capped_timer},
     shared::{
       ExchangeId, add_obs_payload, cidr_blocks, dispatch_event_delegate, join_reply,
       observation_payload_bytes, yield_once,
@@ -959,7 +959,7 @@ pub(crate) async fn stream_driver_loop<I, A, R, D, G>(
       // [`crate::DEFAULT_PEEK_BUDGET`].
       let peek_buf = vec![0u8; recv_buf_len];
       let peek_recv = gossip_socket.recv_from(peek_buf).fuse();
-      let peek_timer = compio::time::sleep(driver_opts.peek_budget()).fuse();
+      let peek_timer = compio::time::sleep(capped_timer(driver_opts.peek_budget())).fuse();
       pin_mut!(peek_recv, peek_timer);
       select_biased! {
         gossip = peek_recv => {
@@ -2222,7 +2222,7 @@ fn process_one_action(
         // runtime task and the `bridge_ready_tx` clone for the full
         // kernel timeout.
         let dial = TcpStream::connect(peer).fuse();
-        let timeout = compio::time::sleep(dial_timeout).fuse();
+        let timeout = compio::time::sleep(capped_timer(dial_timeout)).fuse();
         futures_util::pin_mut!(dial, timeout);
         let msg = futures_util::select_biased! {
           res = dial => match res {

--- a/memberlist-compio/src/quic/driver/mod.rs
+++ b/memberlist-compio/src/quic/driver/mod.rs
@@ -52,7 +52,7 @@ use crate::{
   command::{Command, JoinCmd, JoinKind, JoinReply, LeaveCmd, ShutdownCmd, UpdateNodeMetadataCmd},
   delegate::Delegate,
   driver::{
-    options::RuntimeOptions,
+    options::{RuntimeOptions, capped_timer},
     shared::{ExchangeId, cidr_blocks, dispatch_event_delegate, join_reply},
   },
   error::{JoinFailed, MemberlistError, Result, UserDialBacklogFull},
@@ -1467,7 +1467,7 @@ where
   {
     let peek_buf = vec![0u8; recv_buf_len];
     let peek_recv = state.udp_socket.recv_from(peek_buf).fuse();
-    let peek_timer = compio::time::sleep(state.driver_opts.peek_budget()).fuse();
+    let peek_timer = compio::time::sleep(capped_timer(state.driver_opts.peek_budget())).fuse();
     pin_mut!(peek_recv, peek_timer);
     select_biased! {
       gossip = peek_recv => {

--- a/memberlist-compio/src/resolver/dns/mod.rs
+++ b/memberlist-compio/src/resolver/dns/mod.rs
@@ -11,6 +11,7 @@
 
 use crate::{
   Address,
+  driver::options::capped_timer,
   resolver::{OsResolver, Resolver},
 };
 use compio::{
@@ -147,7 +148,7 @@ impl DnsResolver {
   /// path (see [`Resolver::resolve`] below).
   async fn tcp_query(&self, host: &str, port: u16) -> Result<Vec<SocketAddr>, DnsError> {
     let query = self.tcp_query_inner(host, port).fuse();
-    let timeout = compio::time::sleep(self.timeout).fuse();
+    let timeout = compio::time::sleep(capped_timer(self.timeout)).fuse();
     pin_mut!(query, timeout);
     select_biased! {
       res = query => res,

--- a/memberlist-proto/src/endpoint/mod.rs
+++ b/memberlist-proto/src/endpoint/mod.rs
@@ -5172,7 +5172,11 @@ where
   R: Rng,
 {
   use rand::RngExt;
-  let nanos = interval.as_nanos() as u64;
+  // `as_nanos()` is `u128`; `try_from` (rather than `as u64`) avoids truncating
+  // mod 2^64 for an interval whose total nanoseconds overflow `u64` (~584
+  // years) — an `as` cast would wrap to a small (even zero) value here and
+  // collapse the jitter into a thundering herd instead of degrading it.
+  let nanos = u64::try_from(interval.as_nanos()).unwrap_or(u64::MAX);
   if nanos == 0 {
     return Duration::ZERO;
   }

--- a/memberlist-proto/src/endpoint/tests.rs
+++ b/memberlist-proto/src/endpoint/tests.rs
@@ -12029,3 +12029,35 @@ fn oversized_pushpull_response_served_and_counted() {
     "a within-cap response is not counted"
   );
 }
+
+// `random_stagger` saturates its `u128 -> u64` nanosecond conversion instead
+// of truncating mod 2^64, so an interval whose total nanoseconds overflow
+// `u64` degrades to a huge non-empty stagger range instead of collapsing to
+// zero (which would fire every node's first tick simultaneously).
+#[test]
+fn random_stagger_saturates_on_overflow_interval() {
+  // Exactly 2^64 nanoseconds: `Duration::new(secs, nanos)` with
+  // `secs * 1_000_000_000 + nanos == 1u128 << 64`.
+  let interval = Duration::new(18_446_744_073, 709_551_616);
+  assert_eq!(interval.as_nanos(), 1u128 << 64);
+
+  let mut rng = test_seeded_rng();
+  let stagger = random_stagger(interval, &mut rng);
+  // Mutation-anchor: reverting to `as_nanos() as u64` truncates this
+  // interval's nanos to exactly 0, so `random_stagger` would return
+  // `Duration::ZERO` here — this assertion fails under that regression.
+  assert!(
+    stagger > Duration::ZERO,
+    "an overflow-large interval must not collapse the stagger to zero"
+  );
+  assert!(
+    stagger < interval,
+    "the stagger must stay a fraction of the (saturated) interval"
+  );
+
+  // Control: a normal interval still staggers within `[0, interval)`.
+  let normal = Duration::from_secs(1);
+  let mut rng2 = test_seeded_rng();
+  let normal_stagger = random_stagger(normal, &mut rng2);
+  assert!(normal_stagger < normal);
+}


### PR DESCRIPTION
## #171 — harden extreme-duration handling (scheduler jitter wrap + Compio sleep panic)

Two extreme-duration robustness bugs. Threat model is honest-config robustness (a panic is in scope regardless).

### F1 — `random_stagger` truncated the interval mod 2⁶⁴ ns
`random_stagger` (`memberlist-proto/src/endpoint/mod.rs`) computed `interval.as_nanos() as u64` — `as_nanos()` is `u128`, so the `as` cast wraps for an interval whose total nanoseconds exceed `u64` (~584 years). At exactly 2⁶⁴ ns it yields `0` → `Duration::ZERO` → the first-tick stagger **collapses to zero and every node fires simultaneously** (a thundering herd — the exact opposite of the helper's purpose).

Fixed by saturating the conversion:
```rust
let nanos = u64::try_from(interval.as_nanos()).unwrap_or(u64::MAX);
```
matching the sibling `scale` helper, which already degrades via `checked_mul(...).unwrap_or(interval)` rather than panicking.

### F2 — extreme timeouts panic detached Compio sleep tasks
`compio::time::sleep(d)` computes `Instant::now() + d` (confirmed in compio-runtime 0.12.3), and std `Instant + Duration` **panics on overflow**. So an operator-configured timeout large enough to overflow panics the **detached** dial/bridge/peek/dns task (a silent task death).

Fixed by capping the duration at a safe, representable maximum before sleeping — a `capped_timer(d) = d.min(MAX_TIMER_DURATION)` helper with `MAX_TIMER_DURATION ≈ 10 years`:
```rust
pub(crate) const MAX_TIMER_DURATION: Duration = Duration::from_secs(10 * 365 * 24 * 60 * 60);
```
`Instant::now() + 10y` cannot overflow a monotonic clock whose base is process/boot uptime, and ~10y is far above any real close/dial/peek/dns timeout, so the cap is **semantically transparent** for every legitimate config (a within-cap timeout is byte-identical behavior) — it degrades only absurd/misconfigured values, consistent with the codebase's degrade-don't-panic convention.

Applied at **all five** operator-configurable `compio::time::sleep` sites (the three initially identified plus two same-class sites found by enumerating the whole class):
- `close_timeout` — `bridge/mod.rs`
- `dial_timeout` — `driver/stream/mod.rs`
- `peek_budget` — `driver/stream/mod.rs` **and** `quic/driver/mod.rs`
- DNS query timeout — `resolver/dns/mod.rs`

No `validate()` rejection is added (degrade-gracefully is the chosen policy); no wire, option-default, or behavioral change for normal configs.

