### PR TITLE
fix(memberlist): compile the tokio/smol facade without a transport; correct the compio constructor docs (#172 F1+F2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,12 @@ The minimum supported Rust version (MSRV) is **1.96.0** (edition 2024).
 ## Example
 
 Common types (`Options`, `MaybeResolved`, delegates, …) are re-exported from the per-runtime
-module; the runtime-pinned constructors (`tcp` / `tls` / `quic`) live there too
-(`memberlist::tokio`, `memberlist::smol`, `memberlist::compio`).
+module. `memberlist::tokio` and `memberlist::smol` also expose free, runtime-pinned constructor
+fns (`tcp` / `tls` / `quic`) so callers never name the driver's runtime generic. `memberlist::compio`
+is different: it re-exports [`memberlist-compio`]'s `Memberlist` type directly, whose constructor
+is the method-style `Memberlist::new::<T, D, RES, AR>(options, delegate, resolver,
+advertise_resolver)` — the transport is selected by the `T: Transport` type argument (and the
+`Options<T>` value) rather than by a free per-transport fn.
 
 ```rust,ignore
 use core::net::SocketAddr;

--- a/memberlist/src/smol.rs
+++ b/memberlist/src/smol.rs
@@ -4,6 +4,7 @@
 //! smol, so callers never name `R`. The full reactor surface is re-exported.
 pub use memberlist_reactor::*;
 
+#[cfg(any(feature = "tcp", feature = "tls", feature = "quic"))]
 use core::net::SocketAddr;
 
 /// The runtime these constructors bind.
@@ -12,6 +13,11 @@ pub type Runtime = agnostic::smol::SmolRuntime;
 /// A smol-backed memberlist handle — [`memberlist_reactor::Memberlist`] with its
 /// runtime pinned to smol, so callers never name `R`. The unpinned
 /// three-parameter handle stays available as [`crate::reactor::Memberlist`].
+#[cfg(any(feature = "tcp", feature = "tls", feature = "quic"))]
+#[cfg_attr(
+  docsrs,
+  doc(cfg(any(feature = "tcp", feature = "tls", feature = "quic")))
+)]
 pub type Memberlist<I, A> = memberlist_reactor::Memberlist<I, A, Runtime>;
 
 /// Build a QUIC-backed node on smol. See [`memberlist_reactor::Memberlist::quic`].

--- a/memberlist/src/tokio.rs
+++ b/memberlist/src/tokio.rs
@@ -4,6 +4,7 @@
 //! tokio, so callers never name `R`. The full reactor surface is re-exported.
 pub use memberlist_reactor::*;
 
+#[cfg(any(feature = "tcp", feature = "tls", feature = "quic"))]
 use core::net::SocketAddr;
 
 /// The runtime these constructors bind.
@@ -12,6 +13,11 @@ pub type Runtime = agnostic::tokio::TokioRuntime;
 /// A tokio-backed memberlist handle — [`memberlist_reactor::Memberlist`] with its
 /// runtime pinned to tokio, so callers never name `R`. The unpinned
 /// three-parameter handle stays available as [`crate::reactor::Memberlist`].
+#[cfg(any(feature = "tcp", feature = "tls", feature = "quic"))]
+#[cfg_attr(
+  docsrs,
+  doc(cfg(any(feature = "tcp", feature = "tls", feature = "quic")))
+)]
 pub type Memberlist<I, A> = memberlist_reactor::Memberlist<I, A, Runtime>;
 
 /// Build a QUIC-backed node on tokio. See [`memberlist_reactor::Memberlist::quic`].


### PR DESCRIPTION
## #172 F1+F2 — compile the tokio/smol facade without a transport; correct the compio constructor docs

Two facade findings from #172 (F3 Channel-grammar parity and F4 config-parity are separate follow-ups).

### F1 — `memberlist --features tokio` (or `smol`) fails to compile without a transport
The `tokio`/`smol` features enable the reactor driver but no transport, yet `memberlist/src/{tokio,smol}.rs` unconditionally aliased:
```rust
pub type Memberlist<I, A> = memberlist_reactor::Memberlist<I, A, Runtime>;
```
while `memberlist_reactor::Memberlist` is exported only under `#[cfg(any(feature = "quic", feature = "tcp", feature = "tls"))]`. Result: `cargo build -p memberlist --features tokio --no-default-features` → `error[E0425]: cannot find type Memberlist in crate memberlist_reactor` (and the same for `smol`), which also breaks `cargo hack --each-feature`.

Fixed by gating the `Memberlist` type alias (and the now-transport-only `use core::net::SocketAddr` import) in both files with `#[cfg(any(feature = "tcp", feature = "tls", feature = "quic"))]` plus the matching `doc(cfg(...))`, mirroring reactor's own gate. The per-transport constructor fns (`quic`/`tcp`/`tls`) were already individually gated and are unchanged. No Cargo feature definitions changed — `tokio`/`smol` deliberately do not pull a default transport; a live node uses e.g. `--features tokio,tcp`.

### F2 — README wrongly claimed Compio has free `tcp`/`tls`/`quic` constructors
`memberlist::compio` is `pub use memberlist_compio::*` and exposes no free per-transport constructor fns — its constructor is method-style `Memberlist::new::<T, D, RES, AR>(options, delegate, resolver, advertise_resolver)`, with the transport selected by the `T: Transport` type argument. The README prose was corrected to distinguish this from the tokio/smol free-fn constructors.
