### PR TITLE
test: non-vacuous sim/conformance oracles + VOPR-on-main gate, and realign the sim tests stranded by #200 (#169 findings 1-3)

### DIFF
--- a/.github/workflows/vopr.yml
+++ b/.github/workflows/vopr.yml
@@ -26,6 +26,7 @@ on:
     - cron: "0 4 * * *"
   push:
     branches:
+      - main
       - refactor/sansio
       - vopr
     paths:

--- a/tests/memberlist-simulation/tests/legacy_dead.rs
+++ b/tests/memberlist-simulation/tests/legacy_dead.rs
@@ -49,24 +49,37 @@ fn dead_node_no_node() {
 
 // ── 2. `dead_node_left` (legacy line 1734) ────────────────────────────────────
 
-/// Dead where `node == from` marks the peer as Left (voluntary departure).
+/// A remote self-marked Dead (`node == from`) records reclaim-protected
+/// `State::Dead`, never `State::Left`.
 ///
-/// When `target_id == from_id` the Dead message signals that the peer
-/// announced its own departure, which maps to `State::Left` not `State::Dead`.
+/// A self-leave is unattributable in plaintext gossip: SWIM relays the
+/// departing node's own `Dead{X, from: X}` through arbitrary peers, so a peer
+/// cannot tell a genuine self-leave from a forged one. Granting `State::Left` —
+/// which is immediately address-reclaimable and exempt from the
+/// incarnation-staleness guard — off such a payload would let a forger redirect
+/// a live id to an attacker-chosen address. So the target is recorded as
+/// `State::Dead`, reclaim-protected by `dead_node_reclaim_time`; `State::Left`
+/// is reserved for the local node's view of ITSELF leaving.
 ///
-/// After marking Left, a fresh Alive with a higher incarnation at a new address
-/// must be accepted and move the peer back to Alive.
+/// A departed node still returns legitimately: once `dead_node_reclaim_time`
+/// has elapsed, a fresh Alive at a new address is adopted. The address-change
+/// reclaim is a new membership instance, exempt from the incarnation gate.
 ///
 /// Asserts:
-/// - After Dead(from=peer): `State::Left`.
+/// - After Dead(node==from): `State::Dead` (not Left).
 /// - Dead broadcast is queued.
-/// - After Alive(inc=3, new addr): `State::Alive`, meta and address updated.
+/// - Past the reclaim window, an Alive at a new address is adopted:
+///   `State::Alive`, with the address and meta updated.
 ///
-/// Ported from `memberlist-core/src/state/tests.rs:1734 dead_node_left`.
+/// Ported from `memberlist-core/src/state/tests.rs:1734 dead_node_left`,
+/// realigned to the self-leave-takeover hardening.
 #[test]
-fn dead_node_left_semantics() {
+fn dead_node_self_marked_marks_dead_not_left() {
+  let reclaim = Duration::from_millis(10);
   let mut c = Cluster::new();
-  let m1 = c.add_node(SmolStr::new("m1"), addr(23011));
+  let m1 = c.add_node_with(SmolStr::new("m1"), addr(23011), |cfg| {
+    cfg.with_dead_node_reclaim_time(reclaim)
+  });
 
   let peer_id = SmolStr::new("test_node");
   let peer_addr1 = addr(23091);
@@ -81,14 +94,14 @@ fn dead_node_left_semantics() {
   // Drain join event.
   while c.poll_event(m1).is_some() {}
 
-  // Dead with node == from → Left.
+  // Dead with node == from → reclaim-protected Dead (NOT Left).
   let d = Dead::new(1, peer_id.clone(), peer_id.clone());
   c.dead_node(m1, d);
 
   assert_eq!(
     c.get_node_state(m1, &peer_id),
-    Some(State::Left),
-    "peer with Dead(node==from) should be Left"
+    Some(State::Dead),
+    "peer with Dead(node==from) must record reclaim-protected Dead, never Left"
   );
 
   // Dead broadcast must be queued.
@@ -101,8 +114,12 @@ fn dead_node_left_semantics() {
   // Drain leave event.
   while c.poll_event(m1).is_some() {}
 
-  // Rejoin at new address with higher incarnation (Left state allows address
-  // reclaim without waiting for dead_node_reclaim_time).
+  // Age the Dead entry past `dead_node_reclaim_time` so its address becomes
+  // reclaimable, then rejoin at a NEW address with a higher incarnation. The
+  // address-change reclaim adopts the new address and is exempt from the
+  // incarnation gate, so the fresh Alive re-alives the peer — the legitimate
+  // return path a plain reclaim-protected Dead still allows.
+  c.age_node(m1, &peer_id, reclaim + Duration::from_millis(1));
   use memberlist_simulation::Meta;
   let foo_meta: Meta = "foo".try_into().unwrap();
   c.alive_node(
@@ -114,12 +131,22 @@ fn dead_node_left_semantics() {
   assert_eq!(
     c.get_node_state(m1, &peer_id),
     Some(State::Alive),
-    "peer should be Alive again after fresh Alive post-Left"
+    "peer should be Alive again after a reclaim-window rejoin at a new address"
   );
   assert_eq!(
     c.get_node_incarnation(m1, &peer_id),
     Some(3),
     "incarnation should be 3 after rejoin"
+  );
+  assert_eq!(
+    c.member(m1, &peer_id).map(|ns| *ns.address_ref()),
+    Some(peer_addr2),
+    "address must be updated to the rejoin address after reclaim"
+  );
+  assert_eq!(
+    c.member_meta(m1, &peer_id).map(|(meta, _, _)| meta),
+    Some(b"foo".to_vec()),
+    "meta must be updated after reclaim"
   );
 }
 
@@ -393,8 +420,10 @@ fn dead_node_refute() {
 //   higher incarnation; the simulation passes `Dead::new(2, ...)` directly.
 //   The end invariant is the same: `State::Dead` guards prevent re-transition.
 //
-// **dead_node_left — Left vs Dead distinction**:
-//   `Dead::new(inc, peer_id, peer_id)` (node == from) → `State::Left`.
+// **dead_node_self_marked — a self-marked Dead records reclaim-protected Dead**:
+//   `Dead::new(inc, peer_id, peer_id)` (node == from) → `State::Dead`,
+//   reclaim-protected by `dead_node_reclaim_time`.
 //   `Dead::new(inc, peer_id, other_id)` (node != from) → `State::Dead`.
-//   This matches the simulation `process_dead` `self_marked` sentinel at
-//   `memberlist-proto/src/endpoint.rs:724`.
+//   A remote self-marked departure is unattributable in plaintext gossip, so it
+//   is never granted the immediately-reclaimable `State::Left`; `Left` is
+//   reserved for the local node's view of itself leaving.

--- a/tests/memberlist-simulation/tests/property.rs
+++ b/tests/memberlist-simulation/tests/property.rs
@@ -4,6 +4,7 @@
 //! latency (0–100 ms), every Alive node eventually appears in every
 //! other node's member view after sufficient simulation steps."
 
+use memberlist_proto::typed::State;
 use memberlist_simulation::Cluster;
 use proptest::prelude::*;
 use smol_str::{SmolStr, format_smolstr};
@@ -57,16 +58,21 @@ proptest! {
       c.step();
     }
 
-    // Assert: every node knows every other node.
+    // Assert: every node knows every other node as Alive. `member` only
+    // reflects the wire-protocol state fixed at insertion, so a peer that
+    // arrived and was later Suspected/Dead/Left would still satisfy
+    // `is_some()`; `member_liveness` tracks the gossip state machine's
+    // current view and is the accessor the "every node knows every other
+    // node" property actually means.
     for (i, &host_addr) in addrs.iter().enumerate() {
       for (j, peer_id) in ids.iter().enumerate() {
         if i == j {
           continue;
         }
-        let found = c.member(host_addr, peer_id).is_some();
+        let state = c.member_liveness(host_addr, peer_id);
         prop_assert!(
-          found,
-          "node{i} should know {peer_id} (latency={latency_ms}ms, n={n})"
+          state == Some(State::Alive),
+          "node{i} should know {peer_id} as Alive (latency={latency_ms}ms, n={n}), got {state:?}"
         );
       }
     }

--- a/tests/memberlist-simulation/tests/tcp_conformance.rs
+++ b/tests/memberlist-simulation/tests/tcp_conformance.rs
@@ -115,6 +115,17 @@ fn push_pull_convergence_over_tcp() {
   assert!(c.sees_alive(b, &id("a")));
 }
 
+/// Reliable-fallback invariant: a single triggered failure-detection probe
+/// whose direct + indirect UDP path is blocked must complete via the TCP
+/// reliable-ping fallback on the warm connection, and the healthy peer must
+/// NOT be falsely Suspected.
+///
+/// Mirrors the QUIC harness's `reliable_fallback_rescues_udp_blocked_probe_no_false_suspect`
+/// (`quic_conformance.rs`): the warm-up MUST reach mutual Alive (a hard
+/// assert, not a soft loop-break), `trigger_probe` MUST report it actually
+/// armed a probe, and the test tracks the fallback bridge's full open→reap
+/// cycle so a run where the fallback path is never exercised (or stalls) is
+/// caught rather than silently passing on the absence of a false Suspect.
 #[test]
 fn reliable_fallback_rescues_udp_blocked_probe_no_false_suspect() {
   let a = "127.0.0.1:9021".parse().unwrap();
@@ -127,18 +138,66 @@ fn reliable_fallback_rescues_udp_blocked_probe_no_false_suspect() {
     }
     c.step();
   }
+  assert!(
+    c.sees_alive(a, &id("b")) && c.sees_alive(b, &id("a")),
+    "precondition: warm-up join must reach mutual Alive before blocking UDP probes"
+  );
+  assert_eq!(
+    c.live_bridge_count(a),
+    0,
+    "warm-up join must have fully settled (no leftover bridge)"
+  );
+
   c.drop_all_udp_probes_between(a, b);
-  c.trigger_probe(a);
+  assert!(
+    c.trigger_probe(a),
+    "trigger_probe must actually arm a probe on a"
+  );
+
+  // Drive the triggered probe's lifetime and watch the fallback bridge's
+  // full open→reap cycle: the direct ping times out, the probe escalates and
+  // opens the TCP reliable-ping fallback bridge, the fallback Ping↔Ack
+  // completes, and the bridge is reaped. A run where the fallback never
+  // opens (or opens but never reaps) is caught here instead of silently
+  // passing on `!ever_suspected` alone.
+  let mut fallback_bridge_opened = false;
+  let mut fallback_bridge_reaped = false;
   for _ in 0..20_000 {
-    if !c.step() {
+    let progressed = c.step();
+    let live = c.live_bridge_count(a);
+    if live > 0 {
+      fallback_bridge_opened = true;
+    } else if fallback_bridge_opened {
+      // The bridge opened and is now gone → the reliable-ping exchange
+      // finished and its bridge was reaped.
+      fallback_bridge_reaped = true;
+      break;
+    }
+    if !progressed {
       break;
     }
   }
+
+  assert!(
+    fallback_bridge_opened,
+    "the UDP-blocked probe must escalate and open a TCP reliable-ping \
+     fallback bridge (the fallback path was genuinely exercised)"
+  );
+  assert!(
+    fallback_bridge_reaped,
+    "the reliable-ping fallback bridge must complete its Ping↔Ack and be \
+     reaped (the fallback exchange actually finished — no stall, no leak)"
+  );
   assert!(
     !c.ever_suspected(a, &id("b")),
     "fallback ack absorbed in step (2) before probe handle_timeout — no false Suspect"
   );
   assert_eq!(c.live_bridge_count(a), 0, "fallback bridge reaped");
+  assert!(
+    c.sees_alive(a, &id("b")),
+    "b must remain Alive: with the UDP probe path blocked, only the \
+     completed TCP reliable-ping fallback can keep b from being Suspected"
+  );
 }
 
 #[test]

--- a/tests/memberlist-simulation/tests/tls_conformance.rs
+++ b/tests/memberlist-simulation/tests/tls_conformance.rs
@@ -97,6 +97,17 @@ fn push_pull_convergence_over_tls() {
   assert!(c.sees_alive(b, &id("a")));
 }
 
+/// Reliable-fallback invariant: a single triggered failure-detection probe
+/// whose direct + indirect UDP path is blocked must complete via the TLS
+/// reliable-ping fallback on the warm connection, and the healthy peer must
+/// NOT be falsely Suspected.
+///
+/// Mirrors the QUIC harness's `reliable_fallback_rescues_udp_blocked_probe_no_false_suspect`
+/// (`quic_conformance.rs`): the warm-up MUST reach mutual Alive (a hard
+/// assert, not a soft loop-break), `trigger_probe` MUST report it actually
+/// armed a probe, and the test tracks the fallback bridge's full open→reap
+/// cycle so a run where the fallback path is never exercised (or stalls) is
+/// caught rather than silently passing on the absence of a false Suspect.
 #[test]
 fn reliable_fallback_rescues_udp_blocked_probe_no_false_suspect() {
   let a = "127.0.0.1:8021".parse().unwrap();
@@ -109,18 +120,66 @@ fn reliable_fallback_rescues_udp_blocked_probe_no_false_suspect() {
     }
     c.step();
   }
+  assert!(
+    c.sees_alive(a, &id("b")) && c.sees_alive(b, &id("a")),
+    "precondition: warm-up join must reach mutual Alive before blocking UDP probes"
+  );
+  assert_eq!(
+    c.live_bridge_count(a),
+    0,
+    "warm-up join must have fully settled (no leftover bridge)"
+  );
+
   c.drop_all_udp_probes_between(a, b);
-  c.trigger_probe(a);
+  assert!(
+    c.trigger_probe(a),
+    "trigger_probe must actually arm a probe on a"
+  );
+
+  // Drive the triggered probe's lifetime and watch the fallback bridge's
+  // full open→reap cycle: the direct ping times out, the probe escalates and
+  // opens the TLS reliable-ping fallback bridge, the fallback Ping↔Ack
+  // completes, and the bridge is reaped. A run where the fallback never
+  // opens (or opens but never reaps) is caught here instead of silently
+  // passing on `!ever_suspected` alone.
+  let mut fallback_bridge_opened = false;
+  let mut fallback_bridge_reaped = false;
   for _ in 0..20_000 {
-    if !c.step() {
+    let progressed = c.step();
+    let live = c.live_bridge_count(a);
+    if live > 0 {
+      fallback_bridge_opened = true;
+    } else if fallback_bridge_opened {
+      // The bridge opened and is now gone → the reliable-ping exchange
+      // finished and its bridge was reaped.
+      fallback_bridge_reaped = true;
+      break;
+    }
+    if !progressed {
       break;
     }
   }
+
+  assert!(
+    fallback_bridge_opened,
+    "the UDP-blocked probe must escalate and open a TLS reliable-ping \
+     fallback bridge (the fallback path was genuinely exercised)"
+  );
+  assert!(
+    fallback_bridge_reaped,
+    "the reliable-ping fallback bridge must complete its Ping↔Ack and be \
+     reaped (the fallback exchange actually finished — no stall, no leak)"
+  );
   assert!(
     !c.ever_suspected(a, &id("b")),
     "fallback ack absorbed in step (2) before probe handle_timeout — no false Suspect"
   );
   assert_eq!(c.live_bridge_count(a), 0, "fallback bridge reaped");
+  assert!(
+    c.sees_alive(a, &id("b")),
+    "b must remain Alive: with the UDP probe path blocked, only the \
+     completed TLS reliable-ping fallback can keep b from being Suspected"
+  );
 }
 
 #[test]

--- a/tests/memberlist-simulation/tests/vopr.rs
+++ b/tests/memberlist-simulation/tests/vopr.rs
@@ -91,7 +91,10 @@ fn safety_seed_sweep() {
     "a live peer must observe Suspect: {totals:?}"
   );
   assert!(totals.dead > 0, "a live peer must observe Dead: {totals:?}");
-  assert!(totals.left > 0, "a live peer must observe Left: {totals:?}");
+  assert_eq!(
+    totals.left, 0,
+    "post self-leave hardening, a live PEER never observes a remote node as Left — a self-marked departure is recorded as reclaim-protected Dead; Left is local-self-view-only and excluded from peer samples: {totals:?}"
+  );
   assert!(
     totals.calm_ticks > 0,
     "the calm/quiesce phase must run: {totals:?}"
@@ -130,8 +133,12 @@ fn full_campaign() {
   );
   assert!(totals.leaves > 0, "leaves must fire: {totals:?}");
   assert!(
-    totals.suspect > 0 && totals.dead > 0 && totals.left > 0,
-    "a live peer must observe Suspect, Dead, and Left: {totals:?}"
+    totals.suspect > 0 && totals.dead > 0,
+    "a live peer must observe Suspect and Dead: {totals:?}"
+  );
+  assert_eq!(
+    totals.left, 0,
+    "post self-leave hardening, a live PEER never observes a remote node as Left — a self-marked departure is recorded as reclaim-protected Dead; Left is local-self-view-only and excluded from peer samples: {totals:?}"
   );
   assert!(
     totals.seeds_with_calm_window > 0,

--- a/tests/memberlist-simulation/tests/vopr_self_test.rs
+++ b/tests/memberlist-simulation/tests/vopr_self_test.rs
@@ -551,13 +551,19 @@ fn no_resurrection_checker_retains_baseline_through_unpruned_absence() {
 fn convergence_checker_bites_on_wrong_address_binding() {
   use memberlist_proto::typed::Dead;
   use memberlist_simulation::{Cluster, checker::ConvergenceChecker};
-  use std::collections::HashSet;
+  use std::{collections::HashSet, time::Duration};
   let a0 = addr(34400);
   let a1 = addr(34401);
   let a2 = addr(34402);
   let a_wrong = addr(34999); // not a registered node address
+  let reclaim = Duration::from_millis(10);
   let mut c = Cluster::new();
-  c.add_node("n0".into(), a0);
+  // a0 needs a non-zero reclaim window: post self-leave hardening, a self-marked
+  // Dead records reclaim-protected Dead, and only an elapsed reclaim window
+  // re-opens its address for adoption at a new binding.
+  c.add_node_with("n0".into(), a0, |cfg| {
+    cfg.with_dead_node_reclaim_time(reclaim)
+  });
   c.add_node("n1".into(), a1);
   c.add_node("n2".into(), a2);
   c.inject_alive(a0, "n1".into(), a1, 1);
@@ -570,20 +576,22 @@ fn convergence_checker_bites_on_wrong_address_binding() {
     c.step();
   }
 
-  // Drive a0's view of n1 to State::Left via a self-marked Dead (node == from),
-  // at the same incarnation the cluster holds (1). A Left entry is immediately
-  // address-reclaimable, so the next Alive at a wrong address is ADOPTED rather
-  // than rejected as a NodeConflict.
+  // Drive a0's view of n1 to State::Dead via a self-marked Dead (node == from),
+  // at the same incarnation the cluster holds (1). Post self-leave hardening a
+  // self-marked departure records reclaim-protected Dead (never the
+  // immediately-reclaimable Left), so age the entry past a0's reclaim window to
+  // re-open its address for adoption at a new binding.
   c.dead_node(a0, Dead::new(1, "n1".into(), "n1".into()));
   assert_eq!(
     c.member_liveness(a0, &"n1".into()),
-    Some(memberlist_proto::typed::State::Left),
-    "the self-marked Dead must drive n1 to Left at a0"
+    Some(memberlist_proto::typed::State::Dead),
+    "the self-marked Dead must drive n1 to reclaim-protected Dead at a0"
   );
-  // Inject Alive@1 for n1 at the WRONG address. Adopting the address skips the
-  // incarnation gate, so the applied incarnation stays 1 — every observer still
-  // agrees n1 is Alive@1, isolating the address-binding check from the
-  // incarnation-agreement check.
+  c.age_node(a0, &"n1".into(), reclaim + Duration::from_millis(1));
+  // Inject Alive@1 for n1 at the WRONG address. The post-window address-change
+  // reclaim adopts the new binding and is exempt from the incarnation gate, so
+  // the applied incarnation stays 1 — every observer still agrees n1 is Alive@1,
+  // isolating the address-binding check from the incarnation-agreement check.
   c.inject_alive(a0, "n1".into(), a_wrong, 1);
   assert_eq!(
     c.member_liveness(a0, &"n1".into()),


### PR DESCRIPTION
## #169 (findings 1–3) — non-vacuous sim/conformance oracles + run VOPR on `main`, plus the sim tests stranded by #200

Two parts. Test/CI only — no production code changes.

### Part A — findings 1/2/3
- **Finding 1 (property test):** the simulation property test asserted a peer `is_some()` (merely known) — strengthened to assert `member_liveness == Some(State::Alive)` (the *current* gossip view), so a peer that has drifted to Suspect/Dead/Left no longer satisfies "every node knows every other node."
- **Finding 2 (reliable-fallback oracle):** the TCP **and** TLS reliable-fallback conformance tests could pass without ever exercising the fallback (soft warm-up, ignored `trigger_probe` return, no positive oracle). Ported the QUIC positive-control oracle to both: a hard warm-up `Alive` assert, an assert that `trigger_probe` armed, and tracking that the reliable-fallback bridge actually **opened and then reaped**. Mutation-anchor: disabling the UDP-probe block (so the fallback never runs) now fails the new oracle — proving it is non-vacuous (the old `!ever_suspected` + `live_bridge_count == 0` assertions passed vacuously).
- **Finding 3 (VOPR regression gate):** `.github/workflows/vopr.yml` did not run on pushes to the default branch; added `main` to `on.push.branches`.

### Part B — realign three sim tests stranded by #200 (prerequisite for finding 3)
PR #200 hardened a self-leave takeover so a **remote** self-marked `Dead` (`node == from`) now records reclaim-protected `State::Dead`, never `State::Left` (`Left` is now local-self-leave-only). #200 updated the `memberlist-proto` tests but did not sweep the separate `tests/memberlist-simulation` crate, leaving three tests asserting the old `Left` semantics — red on `main`, and (since Part B's finding 3 enables the VOPR gate on `main`) a blocker for a green gate:
- `legacy_dead::dead_node_left_semantics` → renamed `dead_node_self_marked_marks_dead_not_left`; asserts `Dead`, and reaches the rejoin-at-new-address case legitimately via `dead_node_reclaim_time` + aging past the window (mirrors the proto `remote_self_leave_reclaimable_after_window`).
- `vopr_self_test::convergence_checker_bites_on_wrong_address_binding` → the wrong-address binding is now set up via `Dead` + reclaim-window at **equal incarnation** (the `ConvergenceChecker` evaluates incarnation agreement *before* the address check, so isolating the address violation requires equal inc); the checker still fires the `binds`/`n1` address reason.
- `vopr::safety_seed_sweep` **and** `full_campaign` (the latter is what the VOPR CI gate actually runs): `assert!(totals.left > 0)` → `assert_eq!(totals.left, 0, …)`. `total_left_samples` counts only live-**peer** observations of a non-self subject as `Left`; post-#200 a peer records a departure as `Dead`, so peer-observed-`Left` is structurally zero — the assertion is now a **positive regression guard** for #200. Leave coverage is preserved by the `leaves` (action) and `dead` (peer-observation) assertions.
