### PR TITLE
fix: canonicalize IPv4-mapped IPv6 advertise addresses and CIDR checks to one identity (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ wire with the legacy `0.x` hand-rolled codec below.
   shutdown. `Event` is deliberately exhaustive and gains variants in `0.x`
   minor releases; match it exhaustively.
 
+### Behavior changes
+
+- IPv4-mapped IPv6 advertise addresses (`::ffff:a.b.c.d`) are now canonicalized
+  to their IPv4 form before the socket bind, so a node has a single identity
+  across both address families. Previously such a configuration split the node
+  into two membership entries (the same host keyed under both spellings) and let
+  a `CidrPolicy` written in one family silently miss the other. `CidrPolicy`
+  matching is likewise canonical-only: a checked IP is normalized with
+  `to_canonical()` before every containment test, so a policy net must be written
+  in its address's canonical family (a net inside the mapped range `::ffff:0:0/96`
+  never matches). A deployment that advertised a mapped address now announces its
+  IPv4 form — restart / rejoin such a node into this version rather than rolling
+  it, as its published identity changes to the canonical spelling.
+
 ## 0.6.0
 
 ### Features

--- a/memberlist-compio/src/memberlist/mod.rs
+++ b/memberlist-compio/src/memberlist/mod.rs
@@ -1192,14 +1192,22 @@ where
 {
   let mut addrs: Vec<SocketAddr> = Vec::new();
   for seed in seeds {
+    // Canonicalize each seed the same way the local advertise address is
+    // canonicalized: an IPv4-mapped IPv6 seed spelling is dialed as its IPv4
+    // form, matching the peer's now-canonical identity and avoiding a
+    // family-mismatched gossip `send_to` from a V4-bound socket.
     match seed {
-      MaybeResolved::Resolved(s) => addrs.push(*s),
+      MaybeResolved::Resolved(s) => addrs.push(crate::options::canonical_advertise(*s)),
       MaybeResolved::Unresolved(a) => {
         let resolved = resolver
           .resolve(a)
           .await
           .map_err(|e| MemberlistError::Resolve(std::io::Error::other(e.to_string())))?;
-        addrs.extend(resolved);
+        addrs.extend(
+          resolved
+            .into_iter()
+            .map(crate::options::canonical_advertise),
+        );
       }
     }
   }

--- a/memberlist-compio/src/options/mod.rs
+++ b/memberlist-compio/src/options/mod.rs
@@ -751,6 +751,34 @@ pub(crate) fn validate_driver_options(opts: &RuntimeOptions) -> Result<(), Membe
   Ok(())
 }
 
+/// Canonicalize a resolved advertise address so an IPv4-mapped IPv6 form
+/// (`::ffff:a.b.c.d`) becomes its plain IPv4 form, giving the node ONE identity.
+///
+/// The advertise address is the node's published identity — every peer keys the
+/// node by it and every CIDR check matches against it. A mapped IPv6 address and
+/// its IPv4 spelling reach the same host but are two distinct wire values, so
+/// left unresolved they split the node into two members and let a CIDR policy
+/// written in one family miss the other. Applied to the RESOLVED advertise
+/// address BEFORE the socket bind (bind follows identity), so the bind,
+/// `local_addr()` readback, validation, and machine identity all see the single
+/// canonical form; a mapped config then binds an `AF_INET` socket, which is the
+/// only family that address actually carries traffic on anyway.
+///
+/// Only the mapped case is rewritten, via [`Ipv6Addr::to_ipv4_mapped`] (which
+/// maps exactly `::ffff:0:0/96`, not the deprecated V4-compatible range). A
+/// genuine `SocketAddrV6` is returned bit-for-bit — `to_canonical` is NOT used
+/// here because it drops the `scope_id`/`flowinfo` a scoped address needs.
+pub(crate) fn canonical_advertise(addr: SocketAddr) -> SocketAddr {
+  match addr {
+    SocketAddr::V6(v6) => match v6.ip().to_ipv4_mapped() {
+      Some(v4) => SocketAddr::new(std::net::IpAddr::V4(v4), v6.port()),
+      // Genuine IPv6: preserve scope_id/flowinfo — SocketAddr::new would drop them.
+      None => addr,
+    },
+    v4 => v4,
+  }
+}
+
 /// Validate that the resolved advertise address is a USABLE UNICAST CONTACT —
 /// an address peers can actually route membership traffic to.
 ///
@@ -791,6 +819,25 @@ pub(crate) fn validate_advertise_addr(advertise_addr: &SocketAddr) -> Result<(),
       InvalidAdvertiseAddr::new(*advertise_addr, reason.to_string()),
     ))
   };
+
+  // A still-mapped IPv4-mapped IPv6 advertise address (`::ffff:a.b.c.d`) is a
+  // split identity: the same host is reachable — and CIDR-matched — under both
+  // its IPv4 and its mapped IPv6 spellings, so peers key it as two members and a
+  // CIDR policy written in one family silently misses the other. The standard
+  // backends canonicalize the resolved advertise address to its IPv4 form BEFORE
+  // binding (see `canonical_advertise`), so this never fires for them; it is a
+  // backstop enforcing the "identity is canonical" invariant against a custom
+  // `Transport` whose stored advertise address this post-construction validator
+  // cannot mutate.
+  if let SocketAddr::V6(v6) = advertise_addr
+    && v6.ip().to_ipv4_mapped().is_some()
+  {
+    return reject(
+      "an IPv4-mapped IPv6 advertise address (::ffff:a.b.c.d) splits node identity across two \
+       address families — canonicalize it to its IPv4 form before binding (the standard \
+       backends do this via canonical_advertise)",
+    );
+  }
 
   let ip = advertise_addr.ip();
   if ip.is_unspecified() {

--- a/memberlist-compio/src/options/tests.rs
+++ b/memberlist-compio/src/options/tests.rs
@@ -263,6 +263,66 @@ fn validate_advertise_addr_rejects_unroutable_contacts() {
   }
 }
 
+// `canonical_advertise` rewrites ONLY an IPv4-mapped IPv6 address to its IPv4
+// form, preserving the port; a V4 address and a GENUINE V6 address (including
+// its scope_id / flowinfo) pass through bit-for-bit.
+#[test]
+fn canonical_advertise_maps_and_preserves() {
+  use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
+
+  // Mapped IPv6 → IPv4, port preserved.
+  let mapped: SocketAddr = "[::ffff:127.0.0.1]:7946".parse().unwrap();
+  assert_eq!(
+    canonical_advertise(mapped),
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 7946)),
+    "a mapped IPv6 advertise canonicalizes to its IPv4 form with the same port"
+  );
+
+  // Genuine V6 with a NONZERO scope_id must pass through bit-for-bit —
+  // `SocketAddr::new(ip.to_canonical(), port)` would silently drop the scope.
+  let scoped = SocketAddr::V6(SocketAddrV6::new(
+    Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1),
+    7946,
+    0x11,
+    42,
+  ));
+  assert_eq!(
+    canonical_advertise(scoped),
+    scoped,
+    "a genuine scoped IPv6 advertise is preserved bit-for-bit (scope_id + flowinfo)"
+  );
+
+  // A genuine non-scoped V6 (e.g. loopback) is also unchanged.
+  let v6_loop: SocketAddr = "[::1]:9000".parse().unwrap();
+  assert_eq!(canonical_advertise(v6_loop), v6_loop);
+
+  // A V4 address is unchanged.
+  let v4: SocketAddr = "10.0.0.5:1234".parse().unwrap();
+  assert_eq!(canonical_advertise(v4), v4);
+}
+
+// The reject-backstop: a still-mapped IPv4-mapped IPv6 advertise address that
+// reaches `validate_advertise_addr` (a custom `Transport` that did not
+// canonicalize) is rejected with `InvalidAdvertiseAddr`, while its canonical
+// IPv4 form is accepted.
+#[test]
+fn validate_advertise_addr_rejects_mapped() {
+  use MemberlistError::InvalidAdvertiseAddr;
+
+  let mapped: SocketAddr = "[::ffff:127.0.0.1]:7946".parse().unwrap();
+  assert!(
+    matches!(validate_advertise_addr(&mapped), Err(InvalidAdvertiseAddr(e)) if e.addr() == mapped),
+    "a still-mapped IPv6 advertise must be rejected"
+  );
+
+  // The canonical IPv4 form of the same host is a usable unicast contact.
+  let canonical: SocketAddr = "127.0.0.1:7946".parse().unwrap();
+  assert!(
+    validate_advertise_addr(&canonical).is_ok(),
+    "the canonical IPv4 form must be accepted"
+  );
+}
+
 #[test]
 fn validate_max_stream_frame_size_bounds() {
   // Unset is accepted (the machine default applies at `T::run`).

--- a/memberlist-compio/src/quic/mod.rs
+++ b/memberlist-compio/src/quic/mod.rs
@@ -207,6 +207,12 @@ where
       }
     };
 
+    // Canonicalize an IPv4-mapped IPv6 advertise (`::ffff:a.b.c.d`) to its IPv4
+    // form BEFORE binding, so the bind, `local_addr()` readback, and machine
+    // identity all see one canonical address — the node cannot split into two
+    // members (or dodge a family-specific CIDR policy) under two spellings.
+    let advertise_socket = crate::options::canonical_advertise(advertise_socket);
+
     let gossip_socket = UdpSocket::bind(advertise_socket)
       .await
       .map_err(MemberlistError::Io)?;

--- a/memberlist-compio/src/resolver/advertise/mod.rs
+++ b/memberlist-compio/src/resolver/advertise/mod.rs
@@ -46,7 +46,13 @@ impl AdvertiseAddrResolver for Ipv4PreferringResolver {
   type Error = AdvertiseResolutionError;
 
   fn pick(&self, candidates: Vec<SocketAddr>) -> Result<SocketAddr, Self::Error> {
-    let v4 = candidates.iter().find(|s| s.is_ipv4()).copied();
+    // Classify by the CANONICAL family so an IPv4-mapped IPv6 candidate
+    // (`::ffff:a.b.c.d`) counts as IPv4 — it names an IPv4 host and is
+    // canonicalized to its IPv4 form at the bind.
+    let v4 = candidates
+      .iter()
+      .find(|s| s.ip().to_canonical().is_ipv4())
+      .copied();
     if let Some(s) = v4 {
       return Ok(s);
     }
@@ -65,7 +71,13 @@ impl AdvertiseAddrResolver for Ipv6PreferringResolver {
   type Error = AdvertiseResolutionError;
 
   fn pick(&self, candidates: Vec<SocketAddr>) -> Result<SocketAddr, Self::Error> {
-    let v6 = candidates.iter().find(|s| s.is_ipv6()).copied();
+    // Classify by the CANONICAL family so an IPv4-mapped IPv6 candidate
+    // (`::ffff:a.b.c.d`) is treated as IPv4, NOT preferred here — it names an
+    // IPv4 host. Only a genuine IPv6 candidate is preferred.
+    let v6 = candidates
+      .iter()
+      .find(|s| s.ip().to_canonical().is_ipv6())
+      .copied();
     if let Some(s) = v6 {
       return Ok(s);
     }

--- a/memberlist-compio/src/resolver/advertise/tests.rs
+++ b/memberlist-compio/src/resolver/advertise/tests.rs
@@ -7,6 +7,14 @@ fn v4(port: u16) -> SocketAddr {
 fn v6(port: u16) -> SocketAddr {
   SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), port)
 }
+/// An IPv4-mapped IPv6 address (`::ffff:127.0.0.1`) — an IPv6 `SocketAddr` that
+/// names an IPv4 host.
+fn mapped(port: u16) -> SocketAddr {
+  SocketAddr::new(
+    IpAddr::V6(Ipv4Addr::new(127, 0, 0, 1).to_ipv6_mapped()),
+    port,
+  )
+}
 
 #[test]
 fn first_addr_returns_first() {
@@ -54,4 +62,30 @@ fn ipv6_preferring_falls_through_to_first_when_no_ipv6() {
   let r = Ipv6PreferringResolver;
   let picked = r.pick(vec![v4(1), v4(2)]).unwrap();
   assert_eq!(picked, v4(1));
+}
+
+// A mapped candidate is classified by its canonical family: IPv4-preferring
+// selects it (it names an IPv4 host), and IPv6-preferring skips it in favor of a
+// genuine IPv6 candidate.
+#[test]
+fn preferring_resolvers_classify_mapped_as_ipv4() {
+  let mapped_first = vec![mapped(1), v6(2)];
+  assert_eq!(
+    Ipv4PreferringResolver.pick(mapped_first.clone()).unwrap(),
+    mapped(1),
+    "IPv4-preferring must select a mapped candidate as IPv4"
+  );
+  assert_eq!(
+    Ipv6PreferringResolver.pick(mapped_first).unwrap(),
+    v6(2),
+    "IPv6-preferring must prefer the genuine IPv6 over a mapped (canonical-IPv4) candidate"
+  );
+
+  // With only a mapped candidate, IPv6-preferring falls through to it (first of
+  // any family), since no genuine IPv6 candidate is present.
+  assert_eq!(
+    Ipv6PreferringResolver.pick(vec![mapped(3)]).unwrap(),
+    mapped(3),
+    "with no genuine IPv6, IPv6-preferring falls through to the only candidate"
+  );
 }

--- a/memberlist-compio/src/tcp/mod.rs
+++ b/memberlist-compio/src/tcp/mod.rs
@@ -181,6 +181,12 @@ where
       }
     };
 
+    // Canonicalize an IPv4-mapped IPv6 advertise (`::ffff:a.b.c.d`) to its IPv4
+    // form BEFORE binding, so the bind, `local_addr()` readback, and machine
+    // identity all see one canonical address — the node cannot split into two
+    // members (or dodge a family-specific CIDR policy) under two spellings.
+    let advertise_socket = crate::options::canonical_advertise(advertise_socket);
+
     // memberlist reaches a node at ONE advertised address, so the UDP gossip
     // socket and the TCP reliable listener MUST share a port. Bind the listener
     // first to claim an OS-assigned free port, then bind the gossip socket to

--- a/memberlist-compio/src/tls/mod.rs
+++ b/memberlist-compio/src/tls/mod.rs
@@ -245,6 +245,12 @@ where
       }
     };
 
+    // Canonicalize an IPv4-mapped IPv6 advertise (`::ffff:a.b.c.d`) to its IPv4
+    // form BEFORE binding, so the bind, `local_addr()` readback, and machine
+    // identity all see one canonical address — the node cannot split into two
+    // members (or dodge a family-specific CIDR policy) under two spellings.
+    let advertise_socket = crate::options::canonical_advertise(advertise_socket);
+
     // memberlist reaches a node at ONE advertised address, so the UDP gossip
     // socket and the TLS-over-TCP reliable listener MUST share a port. Bind the
     // listener first to claim an OS-assigned free port, then bind the gossip

--- a/memberlist-compio/tests/cidr.rs
+++ b/memberlist-compio/tests/cidr.rs
@@ -59,6 +59,24 @@ async fn make_tcp_cidr(id: &str, policy: CidrPolicy) -> Memberlist<SmolStr, Sock
   .expect("construct tcp memberlist")
 }
 
+/// Build a `Memberlist` advertising an explicit socket (used to hand in a mapped
+/// IPv6 advertise), with no admission policy.
+async fn make_tcp_advertise(id: &str, advertise: SocketAddr) -> Memberlist<SmolStr, SocketAddr> {
+  let opts = Options::<TcpTransport<SmolStr, SocketAddr>>::new(
+    TcpTransportOptions::<SmolStr, SocketAddr>::new()
+      .with_local_id(SmolStr::new(id))
+      .with_advertise_addr(MaybeResolved::Resolved(advertise)),
+  );
+  Memberlist::new(
+    opts,
+    VoidDelegate::default(),
+    &SocketAddrResolver,
+    &FirstAddrResolver,
+  )
+  .await
+  .expect("construct tcp memberlist")
+}
+
 async fn wait_until<F: FnMut() -> bool>(mut predicate: F, deadline: Duration) -> bool {
   let start = std::time::Instant::now();
   while start.elapsed() < deadline {
@@ -68,6 +86,49 @@ async fn wait_until<F: FnMut() -> bool>(mut predicate: F, deadline: Duration) ->
     compio::time::sleep(Duration::from_millis(20)).await;
   }
   predicate()
+}
+
+/// #170: a peer CONFIGURED with an IPv4-mapped IPv6 advertise is canonicalized to
+/// its IPv4 identity before binding, so a V4 CIDR allow-list admits it. Without
+/// canonicalization the mapped spelling would miss the V4 policy (family-strict
+/// containment) and be wrongly blocked — and, symmetrically, the policy's own
+/// `to_canonical` normalization guarantees a mapped check maps to the V4 net.
+#[compio::test]
+async fn v4_policy_admits_mapped_config_peer() {
+  // A admits 127.0.0.0/8 (a V4 net). B is configured with a mapped advertise.
+  let policy = CidrPolicy::try_from(["127.0.0.0/8"].as_slice()).expect("valid cidr");
+  let a = make_tcp("cidr-mapped-a", Some(policy)).await;
+  let b = make_tcp_advertise("cidr-mapped-b", "[::ffff:127.0.0.1]:0".parse().unwrap()).await;
+
+  // B's published identity is its canonical IPv4 form.
+  assert!(
+    b.advertise_address().is_ipv4(),
+    "a mapped advertise must canonicalize to IPv4, got {}",
+    b.advertise_address()
+  );
+
+  b.join(
+    &SocketAddrResolver,
+    &[MaybeResolved::Resolved(a.advertise_address())],
+  )
+  .await
+  .expect("join");
+
+  // A's V4 policy admits B's canonical V4 address, so both reach two members.
+  let converged = wait_until(
+    || a.member_count() == 2 && b.member_count() == 2,
+    Duration::from_secs(5),
+  )
+  .await;
+  assert!(
+    converged,
+    "a mapped-config peer must be admitted by a V4 policy: a={}, b={}",
+    a.member_count(),
+    b.member_count()
+  );
+
+  a.shutdown().await.expect("a shutdown");
+  b.shutdown().await.expect("b shutdown");
 }
 
 /// A node whose CIDR allow-list excludes the peer's network ignores the peer's

--- a/memberlist-compio/tests/quic_smoke.rs
+++ b/memberlist-compio/tests/quic_smoke.rs
@@ -51,6 +51,41 @@ async fn quic_memberlist_binds_and_shuts_down_cleanly() {
   timed.expect("shutdown Ok");
 }
 
+/// #170: a resolved IPv4-mapped IPv6 advertise (`::ffff:127.0.0.1`) is
+/// canonicalized to its IPv4 form BEFORE the UDP bind, so the QUIC node publishes
+/// a single IPv4 identity. Mirrors the TCP `mapped_advertise_canonicalized_to_v4`
+/// over the QUIC backend's `Transport::new`.
+#[compio::test]
+async fn quic_mapped_advertise_canonicalized_to_v4() {
+  let opts = Options::<QuicTransport<SmolStr, SocketAddr>>::new(
+    QuicTransportOptions::<SmolStr, SocketAddr>::new()
+      .with_local_id(SmolStr::new("quic-mapped-adv"))
+      .with_advertise_addr(MaybeResolved::Resolved(
+        "[::ffff:127.0.0.1]:0".parse().unwrap(),
+      ))
+      .with_quic_config(support::self_trusted_quic_config()),
+  );
+  let ml = Memberlist::new(
+    opts,
+    VoidDelegate::default(),
+    &SocketAddrResolver,
+    &FirstAddrResolver,
+  )
+  .await
+  .expect("a mapped advertise must canonicalize and construct over QUIC");
+  let advertise = ml.advertise_address();
+  assert!(
+    advertise.is_ipv4(),
+    "a mapped IPv6 advertise must publish as IPv4 over QUIC, got {advertise}"
+  );
+  assert_ne!(
+    advertise.port(),
+    0,
+    "ephemeral :0 must resolve to a concrete port"
+  );
+  ml.shutdown().await.expect("shutdown");
+}
+
 /// Two-node end-to-end smoke: A dispatch-joins B's listening port, the
 /// QUIC handshake + push/pull exchange completes inside the 5-second
 /// budget, and both nodes converge on `alive_count == 2`. Exercises

--- a/memberlist-compio/tests/tcp_join.rs
+++ b/memberlist-compio/tests/tcp_join.rs
@@ -616,3 +616,66 @@ async fn join_with_against_banner_tcp_service_surfaces_join_failed() {
 
   joiner.shutdown().await.expect("joiner shutdown");
 }
+
+/// #170: a node CONFIGURED with an IPv4-mapped IPv6 advertise (`::ffff:127.0.0.1`)
+/// is canonicalized to its IPv4 identity before binding, so it and a plain-IPv4
+/// peer converge to ONE membership entry — no split identity, no duplicate keyed
+/// at a second address spelling. B (mapped config) joins A (plain V4); both settle
+/// at exactly 2 members and A keys B at a V4 address.
+#[compio::test]
+async fn mapped_and_v4_spellings_converge_to_one_peer() {
+  let a = make_tcp("mapped-a", loopback_addr(0), b"mapped-cluster").await;
+  // B is configured with a mapped IPv6 advertise; canonicalization rewrites it to
+  // 127.0.0.1 before the bind.
+  let b_mapped: SocketAddr = "[::ffff:127.0.0.1]:0".parse().unwrap();
+  let b = make_tcp("mapped-b", b_mapped, b"mapped-cluster").await;
+
+  // B's published identity is its canonical IPv4 form.
+  assert!(
+    b.advertise_address().is_ipv4(),
+    "a mapped advertise must canonicalize to IPv4, got {}",
+    b.advertise_address()
+  );
+
+  b.dispatch_join(
+    &SocketAddrResolver,
+    &[MaybeResolved::Resolved(a.advertise_address())],
+  )
+  .await
+  .expect("dispatch_join");
+
+  let converged = wait_until(
+    || a.member_count() == 2 && b.member_count() == 2,
+    Duration::from_secs(5),
+  )
+  .await;
+  assert!(
+    converged,
+    "cluster did not converge: a={} b={}",
+    a.member_count(),
+    b.member_count()
+  );
+
+  // Exactly 2 — no duplicate entry from a second address spelling.
+  assert_eq!(
+    a.member_count(),
+    2,
+    "A must key B once, not once per spelling"
+  );
+
+  // A keys B at a V4 address (B's canonical identity), never a mapped IPv6.
+  let b_id = b.local_node().id_ref().clone();
+  let b_in_a = a
+    .members()
+    .into_iter()
+    .find(|n| *n.id_ref() == b_id)
+    .expect("A must know B");
+  assert!(
+    b_in_a.address_ref().is_ipv4(),
+    "A must key B at its canonical IPv4 address, got {}",
+    b_in_a.address_ref()
+  );
+
+  a.shutdown().await.expect("a shutdown");
+  b.shutdown().await.expect("b shutdown");
+}

--- a/memberlist-compio/tests/transport_new.rs
+++ b/memberlist-compio/tests/transport_new.rs
@@ -521,3 +521,39 @@ async fn transport_new_rejects_unspecified_advertise() {
   .expect("a concrete loopback advertise must construct");
   m.shutdown().await.expect("shutdown");
 }
+
+/// #170: a resolved IPv4-mapped IPv6 advertise (`::ffff:127.0.0.1`) is
+/// canonicalized to its IPv4 form BEFORE the bind, so the node's single published
+/// identity is IPv4 — no split identity across two address families. The bound
+/// ephemeral port resolves to a concrete value. Exercised on TCP; the same
+/// `canonical_advertise` runs in every backend's `Transport::new`.
+#[compio::test]
+async fn mapped_advertise_canonicalized_to_v4() {
+  let opts = Options::<TcpTransport<SmolStr, SocketAddr>>::new(
+    TcpTransportOptions::<SmolStr, SocketAddr>::new()
+      .with_local_id(SmolStr::new("mapped-adv"))
+      .with_advertise_addr(MaybeResolved::Resolved(
+        "[::ffff:127.0.0.1]:0".parse().unwrap(),
+      )),
+  );
+  let m = Memberlist::new(
+    opts,
+    VoidDelegate::default(),
+    &SocketAddrResolver,
+    &FirstAddrResolver,
+  )
+  .await
+  .expect("a mapped advertise must canonicalize and construct");
+  let advertise = m.advertise_address();
+  assert!(
+    advertise.is_ipv4(),
+    "a mapped IPv6 advertise must publish as IPv4, got {advertise}"
+  );
+  assert_eq!(advertise.ip(), std::net::Ipv4Addr::LOCALHOST);
+  assert_ne!(
+    advertise.port(),
+    0,
+    "ephemeral :0 must resolve to a concrete port"
+  );
+  m.shutdown().await.expect("shutdown");
+}

--- a/memberlist-proto/src/cidr/mod.rs
+++ b/memberlist-proto/src/cidr/mod.rs
@@ -26,6 +26,23 @@
 //! completes its exchange and counts that seed as contacted, while the seed is
 //! not admitted to membership. The join "contacted" count reflects completed
 //! exchanges, not admission — inspect membership to confirm a peer was admitted.
+//!
+//! # Canonical-family matching
+//!
+//! An address is matched in its **canonical** family: the checked IP is passed
+//! through [`IpAddr::to_canonical`] before any network containment test, so an
+//! IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) and its plain IPv4 spelling
+//! (`a.b.c.d`) always yield the SAME verdict. The invariant is
+//! `is_allowed(ip) == is_allowed(ip.to_canonical())` — a host reachable under
+//! two spellings can never be admitted under one and denied under the other.
+//!
+//! The configured networks are NOT canonicalized, so **a policy net must be
+//! written in its address's canonical family**. A net inside the mapped range
+//! `::ffff:0:0/96` (e.g. `::ffff:10.0.0.0/104`) is dead config: no checked
+//! address ever reaches it, because every mapped IP is canonicalized to IPv4
+//! before the test. Write `10.0.0.0/8`, not its mapped form. Same-family
+//! matching is byte-identical to no canonicalization (`to_canonical` is a no-op
+//! for a non-mapped address).
 
 use core::{
   net::{IpAddr, SocketAddr},
@@ -112,8 +129,13 @@ impl CidrPolicy {
   /// leaves a block-all policy; call [`allow_all`](Self::allow_all) to lift the
   /// restriction entirely.
   pub fn remove_by_ip(&mut self, ip: &IpAddr) {
+    // Canonicalize the probe IP for the same reason `is_allowed` does: an
+    // IPv4-mapped IPv6 address must match the same nets its IPv4 spelling would,
+    // so both spellings remove the same networks. `to_canonical` is a no-op for
+    // a non-mapped address.
+    let ip = ip.to_canonical();
     if let Some(allowed) = self.allowed_cidrs.as_mut() {
-      allowed.retain(|net| !net.contains(ip));
+      allowed.retain(|net| !net.contains(&ip));
     }
   }
 
@@ -133,11 +155,19 @@ impl CidrPolicy {
   }
 
   /// Whether `ip` is allowed (allow-all admits every address).
+  ///
+  /// The IP is matched in its canonical family: an IPv4-mapped IPv6 address is
+  /// canonicalized to IPv4 before the containment test, so it and its plain IPv4
+  /// spelling always share a verdict (see the module docs — a net must be written
+  /// in the canonical family; a `::ffff:0:0/96` net is dead config).
   pub fn is_allowed(&self, ip: &IpAddr) -> bool {
+    // Canonicalize first so both spellings of a host give the same verdict; a
+    // no-op for a non-mapped address, so same-family matching is unchanged.
+    let ip = ip.to_canonical();
     self
       .allowed_cidrs
       .as_ref()
-      .is_none_or(|nets| nets.iter().any(|net| net.contains(ip)))
+      .is_none_or(|nets| nets.iter().any(|net| net.contains(&ip)))
   }
 
   /// Whether `ip` is blocked.

--- a/memberlist-proto/src/cidr/tests.rs
+++ b/memberlist-proto/src/cidr/tests.rs
@@ -68,6 +68,165 @@ fn try_from_cidr_strings_round_trips() {
   assert!(CidrPolicy::try_from(["not-a-cidr"].as_slice()).is_err());
 }
 
+// An IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) is matched in its canonical
+// IPv4 family: it shares a verdict with its plain IPv4 spelling. A policy over
+// `10.0.0.0/8` admits `::ffff:10.1.2.3` and blocks `::ffff:11.0.0.1`, exactly
+// as it does the IPv4 forms — so a host reachable under both spellings can never
+// be admitted under one and denied under the other.
+#[test]
+fn mapped_v6_checked_as_v4() {
+  let policy = CidrPolicy::try_from(["10.0.0.0/8"].as_slice()).expect("valid cidr");
+
+  let mapped_in: IpAddr = "::ffff:10.1.2.3".parse().unwrap();
+  let mapped_out: IpAddr = "::ffff:11.0.0.1".parse().unwrap();
+  assert!(
+    policy.is_allowed(&mapped_in),
+    "a mapped in-policy address is admitted as its IPv4 form"
+  );
+  assert!(
+    policy.is_blocked(&mapped_out),
+    "a mapped out-of-policy address is blocked as its IPv4 form"
+  );
+
+  // The invariant: both spellings of a host give the SAME verdict.
+  for probe in [
+    "10.1.2.3",
+    "11.0.0.1",
+    "10.255.255.255",
+    "9.255.255.255",
+    "::ffff:10.1.2.3",
+    "::ffff:11.0.0.1",
+    "::ffff:10.255.255.255",
+    "::ffff:9.255.255.255",
+  ] {
+    let ip: IpAddr = probe.parse().unwrap();
+    assert_eq!(
+      policy.is_allowed(&ip),
+      policy.is_allowed(&ip.to_canonical()),
+      "is_allowed({ip}) must equal is_allowed(canonical)"
+    );
+  }
+}
+
+// Canonicalization is a NO-OP for a genuine (non-mapped) IPv6 address: an
+// `fd00::/8` policy admits `fd00::1` and blocks `2001:db8::1`, and both keep
+// their IPv6 family through the check (a genuine V6 has no IPv4 canonical form).
+#[test]
+fn genuine_v6_canonicalization_noop() {
+  let policy = CidrPolicy::try_from(["fd00::/8"].as_slice()).expect("valid cidr");
+
+  let inside: IpAddr = "fd00::1".parse().unwrap();
+  let outside: IpAddr = "2001:db8::1".parse().unwrap();
+  assert!(
+    policy.is_allowed(&inside),
+    "an in-policy genuine V6 is admitted"
+  );
+  assert!(
+    policy.is_blocked(&outside),
+    "an out-of-policy genuine V6 is blocked"
+  );
+
+  // A genuine V6 canonicalizes to itself, so the invariant holds trivially.
+  for probe in ["fd00::1", "2001:db8::1", "fdff:ffff::ffff"] {
+    let ip: IpAddr = probe.parse().unwrap();
+    assert_eq!(
+      ip,
+      ip.to_canonical(),
+      "a genuine V6 is its own canonical form"
+    );
+    assert_eq!(
+      policy.is_allowed(&ip),
+      policy.is_allowed(&ip.to_canonical())
+    );
+  }
+}
+
+// Regression control: for same-family (V4-net/V4-ip and V6-net/V6-ip) matching,
+// canonicalization changes NOTHING — the verdict truth table is byte-identical
+// to the pre-change behavior (`to_canonical` is a no-op for a non-mapped
+// address). This is the proof the fix does not perturb the common case.
+#[test]
+fn same_family_control() {
+  // IPv4 net, IPv4 probes.
+  let v4 = CidrPolicy::try_from(["192.168.0.0/16", "10.0.0.0/8"].as_slice()).expect("valid cidr");
+  let v4_truth = [
+    ("192.168.1.1", true),
+    ("192.168.255.255", true),
+    ("10.9.9.9", true),
+    ("10.255.255.255", true),
+    ("192.167.0.1", false),
+    ("11.0.0.1", false),
+    ("172.16.0.1", false),
+    ("203.0.113.7", false),
+  ];
+  for (probe, expected) in v4_truth {
+    let ip: IpAddr = probe.parse().unwrap();
+    assert_eq!(v4.is_allowed(&ip), expected, "v4/v4 verdict for {probe}");
+  }
+
+  // IPv6 net, IPv6 probes (genuine, non-mapped).
+  let v6 = CidrPolicy::try_from(["fd00::/8", "2001:db8::/32"].as_slice()).expect("valid cidr");
+  let v6_truth = [
+    ("fd00::1", true),
+    ("fdff:ffff::1", true),
+    ("2001:db8::1", true),
+    ("2001:db8:ffff::ffff", true),
+    ("fc00::1", false),
+    ("2001:db9::1", false),
+    ("::1", false),
+    ("2606:4700::1", false),
+  ];
+  for (probe, expected) in v6_truth {
+    let ip: IpAddr = probe.parse().unwrap();
+    assert_eq!(v6.is_allowed(&ip), expected, "v6/v6 verdict for {probe}");
+  }
+}
+
+// A policy net written INSIDE the mapped range `::ffff:0:0/96` is dead config:
+// every checked address is canonicalized before the containment test, so no
+// address — neither the IPv4 spelling nor the mapped IPv6 spelling — ever
+// reaches it. Operators must write nets in the canonical family (`10.0.0.0/8`,
+// not its mapped form).
+#[test]
+fn mapped_range_v6_net_is_dead_config() {
+  let policy = CidrPolicy::try_from(["::ffff:10.0.0.0/104"].as_slice()).expect("valid cidr");
+
+  // The IPv4 spelling canonicalizes to IPv4 and never enters the V6 mapped net.
+  let v4: IpAddr = "10.1.2.3".parse().unwrap();
+  assert!(
+    policy.is_blocked(&v4),
+    "the mapped-range net matches no IPv4 address"
+  );
+
+  // The mapped IPv6 spelling ALSO canonicalizes to IPv4 before the test, so it
+  // never matches the V6 net either — the net is unreachable both ways.
+  let mapped: IpAddr = "::ffff:10.1.2.3".parse().unwrap();
+  assert!(
+    policy.is_blocked(&mapped),
+    "a mapped address is canonicalized to IPv4, so it never reaches the mapped-range V6 net"
+  );
+}
+
+// `remove_by_ip` canonicalizes its probe the same way `is_allowed` does: the
+// mapped IPv6 spelling of a host removes the same IPv4 net its plain spelling
+// would.
+#[test]
+fn remove_by_ip_uses_canonical() {
+  let mut policy = CidrPolicy::try_from(["10.0.0.0/8"].as_slice()).expect("valid cidr");
+  assert!(policy.is_allowed(&"10.1.2.3".parse().unwrap()));
+
+  // Remove by the MAPPED spelling; it must strip the covering IPv4 net.
+  policy.remove_by_ip(&"::ffff:10.1.2.3".parse().unwrap());
+  assert!(
+    policy.is_blocked(&"10.1.2.3".parse().unwrap()),
+    "removing by the mapped spelling strips the covering IPv4 net"
+  );
+  assert!(
+    policy.is_block_all(),
+    "the last net removed leaves a block-all policy"
+  );
+}
+
 #[test]
 fn notify_alive_decides_on_the_self_advertised_address() {
   use crate::typed::State;

--- a/memberlist-reactor/src/error.rs
+++ b/memberlist-reactor/src/error.rs
@@ -156,6 +156,17 @@ pub enum Error {
   #[error("invalid advertise address {0}: must be a concrete unicast address")]
   InvalidAdvertise(SocketAddr),
 
+  /// The resolved advertise address is an IPv4-mapped IPv6 address
+  /// (`::ffff:a.b.c.d`). It reaches the same host as its IPv4 spelling but is a
+  /// distinct wire value, so leaving it as identity would split the node into two
+  /// members and let a family-specific CIDR policy miss one form. The standard
+  /// backends canonicalize it to IPv4 before binding; this backstop rejects a
+  /// custom stream transport whose stored advertise address stays mapped.
+  #[error(
+    "IPv4-mapped IPv6 advertise address {0} splits node identity across two address families: canonicalize it to its IPv4 form before binding"
+  )]
+  MappedAdvertise(SocketAddr),
+
   /// The configured `close_timeout` is zero. The stream driver bounds each
   /// per-bridge graceful-close drain `write` with this timeout; a zero timeout
   /// fires immediately, so a graceful close abandons (RSTs) its queued push/pull

--- a/memberlist-reactor/src/memberlist.rs
+++ b/memberlist-reactor/src/memberlist.rs
@@ -356,10 +356,14 @@ impl<I, A, R> Memberlist<I, A, R> {
     }
     let mut addrs = Vec::with_capacity(seeds.len());
     for seed in seeds {
+      // Canonicalize each seed the same way the local advertise address is
+      // canonicalized: an IPv4-mapped IPv6 seed spelling is dialed as its IPv4
+      // form, matching the peer's now-canonical identity and avoiding a
+      // family-mismatched gossip `send_to` from a V4-bound socket.
       match seed {
-        MaybeResolved::Resolved(s) => addrs.push(*s),
+        MaybeResolved::Resolved(s) => addrs.push(canonical_advertise(*s)),
         MaybeResolved::Unresolved(a) => match resolver.resolve(a).await {
-          Ok(resolved) => addrs.extend(resolved),
+          Ok(resolved) => addrs.extend(resolved.into_iter().map(canonical_advertise)),
           Err(e) => return Err((SmallVec::new(), Error::Resolve(Box::new(e)))),
         },
       }

--- a/memberlist-reactor/src/memberlist.rs
+++ b/memberlist-reactor/src/memberlist.rs
@@ -754,7 +754,10 @@ where
     D: Delegate<Id = I, Address = SocketAddr>,
     G: rand::Rng + Send + Unpin + 'static,
   {
-    let advertise_socket = resolve_one(resolver, advertise).await?;
+    // Canonicalize an IPv4-mapped IPv6 advertise to its IPv4 form before binding,
+    // so bind, `local_addr()` readback, and machine identity all see one address
+    // (a node cannot split into two members under two spellings).
+    let advertise_socket = canonical_advertise(resolve_one(resolver, advertise).await?);
     let socket = <R::Net as Net>::UdpSocket::bind(advertise_socket)
       .await
       .map_err(Error::Io)?;
@@ -1099,7 +1102,10 @@ where
     T::Options: Send + Unpin,
     G: rand::Rng + Send + Unpin + 'static,
   {
-    let advertise_socket = resolve_one(resolver, advertise).await?;
+    // Canonicalize an IPv4-mapped IPv6 advertise to its IPv4 form before binding,
+    // so bind, `local_addr()` readback, and machine identity all see one address
+    // (a node cannot split into two members under two spellings).
+    let advertise_socket = canonical_advertise(resolve_one(resolver, advertise).await?);
     // Bind the TCP listener first to claim an OS-assigned free port, then bind
     // the gossip UDP socket to that same port. Binding UDP first and reusing its
     // port for TCP races: an ephemeral UDP port can land on a TCP port still in
@@ -1569,9 +1575,40 @@ where
   Ok(())
 }
 
+/// Canonicalize a resolved advertise address so an IPv4-mapped IPv6 form
+/// (`::ffff:a.b.c.d`) becomes its plain IPv4 form, giving the node ONE identity.
+/// Mirrors compio's `canonical_advertise`: the advertise address is the node's
+/// published identity and its CIDR-match key, so a mapped IPv6 spelling and its
+/// IPv4 spelling would otherwise split the node into two members and dodge a
+/// family-specific CIDR policy. Applied to the RESOLVED address BEFORE the bind,
+/// so bind, `local_addr()` readback, and machine identity all see one form.
+///
+/// Only the mapped case is rewritten, via `Ipv6Addr::to_ipv4_mapped` (exactly
+/// `::ffff:0:0/96`). A genuine `SocketAddrV6` passes through bit-for-bit —
+/// `to_canonical` is NOT used here because it drops the `scope_id`/`flowinfo` a
+/// scoped address needs.
+fn canonical_advertise(addr: SocketAddr) -> SocketAddr {
+  match addr {
+    SocketAddr::V6(v6) => match v6.ip().to_ipv4_mapped() {
+      Some(v4) => SocketAddr::new(std::net::IpAddr::V4(v4), v6.port()),
+      // Genuine IPv6: preserve scope_id/flowinfo — SocketAddr::new would drop them.
+      None => addr,
+    },
+    v4 => v4,
+  }
+}
+
 /// Rejects an advertise address peers could not dial: unspecified, multicast,
-/// or broadcast. The port is already concrete (read back post-bind).
+/// or broadcast. The port is already concrete (read back post-bind). Also rejects
+/// a still-mapped IPv4-mapped IPv6 address as a backstop for a custom stream
+/// transport — the standard backends canonicalize it before binding, so this
+/// never fires for them, but it enforces the "identity is canonical" invariant.
 fn validate_advertise(addr: SocketAddr) -> Result<(), Error> {
+  if let SocketAddr::V6(v6) = addr
+    && v6.ip().to_ipv4_mapped().is_some()
+  {
+    return Err(Error::MappedAdvertise(addr));
+  }
   let ip = addr.ip();
   let bad = ip.is_unspecified()
     || ip.is_multicast()

--- a/memberlist-reactor/tests/advertise_canonical.rs
+++ b/memberlist-reactor/tests/advertise_canonical.rs
@@ -1,0 +1,116 @@
+//! #170: IPv4-mapped IPv6 advertise canonicalization over the reactor TCP driver.
+//!
+//! A resolved `::ffff:a.b.c.d` advertise is rewritten to its plain IPv4 form
+//! BEFORE the bind, so the node has ONE published identity (no split across two
+//! address families) and a mapped-config peer converges with a plain-IPv4 peer to
+//! a single membership entry. Mirrors the compio `mapped_advertise_canonicalized_to_v4`
+//! and `mapped_and_v4_spellings_converge_to_one_peer` tests.
+
+#![cfg(feature = "tcp")]
+
+use std::{net::SocketAddr, time::Duration};
+
+use agnostic::tokio::TokioRuntime;
+use memberlist_reactor::{MaybeResolved, Memberlist, Options, SocketAddrResolver, VoidDelegate};
+use smol_str::SmolStr;
+
+/// Build a reactor TCP node advertising `advertise` (used to hand in a mapped
+/// IPv6 advertise). The constructor canonicalizes and reads the bound address
+/// back.
+async fn make(id: &str, advertise: SocketAddr) -> Memberlist<SmolStr, SocketAddr, TokioRuntime> {
+  Memberlist::<SmolStr, _, TokioRuntime>::tcp(
+    &SocketAddrResolver,
+    SmolStr::new(id),
+    MaybeResolved::Resolved(advertise),
+    Options::new(),
+    VoidDelegate::<SmolStr, SocketAddr>::new(),
+  )
+  .await
+  .expect("bind tcp memberlist")
+}
+
+async fn wait_until<F: FnMut() -> bool>(mut predicate: F, deadline: Duration) -> bool {
+  tokio::time::timeout(deadline, async {
+    loop {
+      if predicate() {
+        return;
+      }
+      tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+  })
+  .await
+  .is_ok()
+}
+
+/// A resolved mapped IPv6 advertise is canonicalized to IPv4 before binding, so
+/// the node publishes a single IPv4 identity with a concrete resolved port.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mapped_advertise_canonicalized_to_v4() {
+  let m = make("mapped-adv", "[::ffff:127.0.0.1]:0".parse().unwrap()).await;
+  let advertise = m.advertise_address();
+  assert!(
+    advertise.is_ipv4(),
+    "a mapped IPv6 advertise must publish as IPv4, got {advertise}"
+  );
+  assert_eq!(advertise.ip(), std::net::Ipv4Addr::LOCALHOST);
+  assert_ne!(
+    advertise.port(),
+    0,
+    "ephemeral :0 must resolve to a concrete port"
+  );
+  let _ = m.shutdown().await;
+}
+
+/// A mapped-config node and a plain-IPv4 node converge to ONE membership entry —
+/// no split identity, no duplicate keyed at a second spelling. B (mapped config)
+/// joins A (plain V4); both settle at exactly 2 members and A keys B at V4.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn mapped_and_v4_spellings_converge_to_one_peer() {
+  let a = make("mapped-a", "127.0.0.1:0".parse().unwrap()).await;
+  let b = make("mapped-b", "[::ffff:127.0.0.1]:0".parse().unwrap()).await;
+
+  assert!(
+    b.advertise_address().is_ipv4(),
+    "a mapped advertise must canonicalize to IPv4, got {}",
+    b.advertise_address()
+  );
+
+  let a_addr = a.advertise_address();
+  b.join(&SocketAddrResolver, &[MaybeResolved::Resolved(a_addr)])
+    .await
+    .expect("join");
+
+  let converged = wait_until(
+    || a.num_members() == 2 && b.num_members() == 2,
+    Duration::from_secs(8),
+  )
+  .await;
+  assert!(
+    converged,
+    "cluster did not converge: a={} b={}",
+    a.num_members(),
+    b.num_members()
+  );
+
+  assert_eq!(
+    a.num_members(),
+    2,
+    "A must key B once, not once per spelling"
+  );
+
+  // A keys B at a V4 address (B's canonical identity), never a mapped IPv6.
+  let b_id = b.local().id_ref().clone();
+  let b_in_a = a
+    .members()
+    .into_iter()
+    .find(|n| *n.id_ref() == b_id)
+    .expect("A must know B");
+  assert!(
+    b_in_a.address_ref().is_ipv4(),
+    "A must key B at its canonical IPv4 address, got {}",
+    b_in_a.address_ref()
+  );
+
+  let _ = a.shutdown().await;
+  let _ = b.shutdown().await;
+}

--- a/memberlist-reactor/tests/cidr.rs
+++ b/memberlist-reactor/tests/cidr.rs
@@ -70,6 +70,64 @@ async fn wait_until<F: FnMut() -> bool>(mut predicate: F, deadline: Duration) ->
   .is_ok()
 }
 
+/// Build a reactor TCP node advertising `advertise` (used to hand in a mapped
+/// IPv6 advertise), with no admission policy.
+async fn make_advertise(
+  id: &str,
+  advertise: SocketAddr,
+) -> Memberlist<SmolStr, SocketAddr, TokioRuntime> {
+  Memberlist::<SmolStr, _, TokioRuntime>::tcp(
+    &SocketAddrResolver,
+    SmolStr::new(id),
+    MaybeResolved::Resolved(advertise),
+    Options::<SmolStr>::new(),
+    VoidDelegate::<SmolStr, SocketAddr>::new(),
+  )
+  .await
+  .expect("bind tcp memberlist")
+}
+
+/// #170: a peer CONFIGURED with an IPv4-mapped IPv6 advertise is canonicalized to
+/// its IPv4 identity before binding, so a V4 driver-level CIDR policy admits it at
+/// BOTH the reliable transport boundary (the recv-source / accept `cidr_blocks`
+/// path on the canonical bind) and membership admission. Without canonicalization
+/// the mapped spelling would miss the V4 net and be wrongly blocked.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn v4_policy_admits_mapped_config_peer() {
+  // A enforces a driver-level 127.0.0.0/8 policy (gates the transport boundary
+  // too); B is configured with a mapped advertise → canonical 127.0.0.1.
+  let policy = CidrPolicy::try_from(["127.0.0.0/8"].as_slice()).expect("valid cidr");
+  let a = make_cidr("cidr-mapped-a", policy).await;
+  let b = make_advertise("cidr-mapped-b", "[::ffff:127.0.0.1]:0".parse().unwrap()).await;
+
+  assert!(
+    b.advertise_address().is_ipv4(),
+    "a mapped advertise must canonicalize to IPv4, got {}",
+    b.advertise_address()
+  );
+
+  let a_addr = a.advertise_address();
+  b.join(&SocketAddrResolver, &[MaybeResolved::Resolved(a_addr)])
+    .await
+    .expect("join");
+
+  let converged = wait_until(
+    || a.num_members() == 2 && b.num_members() == 2,
+    Duration::from_secs(8),
+  )
+  .await;
+  assert!(
+    converged,
+    "a mapped-config peer must be admitted by a V4 policy at the boundary and in \
+     membership: a={}, b={}",
+    a.num_members(),
+    b.num_members()
+  );
+
+  a.shutdown().await.ok();
+  b.shutdown().await.ok();
+}
+
 /// A node whose CIDR allow-list excludes the peer's network ignores the peer's
 /// Alive, so the peer never enters its membership table — even though the join
 /// exchange itself completes. B reaching two members proves the exchange worked,


### PR DESCRIPTION
## #170 F1 — canonicalize IPv4-mapped IPv6 at the advertise boundary and in `CidrPolicy`

An IPv4-mapped IPv6 advertise address (e.g. `::ffff:127.0.0.1`) passed the standard drivers' advertise validation and became the node's announced identity **without** canonicalization, splitting identity/admission: the same host reachable as `127.0.0.1` and `::ffff:127.0.0.1` was keyed as two different peers, and a `CidrPolicy` expressed in one family silently failed to match the other (a family-strict `net.contains`). Threat model: CST honest-config + external pre-trust admission.

### Fix — canonicalize (not reject), before bind; canonical-only CIDR matching
- **`canonical_advertise` helper** (compio `options/mod.rs`, mirrored private in reactor `memberlist.rs`): rewrites an IPv4-mapped V6 `SocketAddr` to its V4 form and passes a **genuine** `SocketAddrV6` through bit-for-bit. It uses `to_ipv4_mapped()`, **not** `to_canonical()` — `SocketAddr::new(ip.to_canonical(), port)` would silently drop `scope_id`/`flowinfo` from a scoped V6 (pinned by `canonical_advertise_maps_and_preserves`).
- **Applied before bind** at every advertise site — compio `tcp`/`tls`/`quic` `Transport::new`, reactor `quic_with_rng` + `build_stream_backend` — so bind, `local_addr()` readback, validation, and machine identity all see one canonical form. Bind follows identity (a mapped config's socket family becomes AF_INET, which is the only traffic such a socket could carry anyway, and fixes Windows `V6ONLY` flakiness).
- **`CidrPolicy` canonical-only matching**: `is_allowed` and `remove_by_ip` canonicalize the checked IP via `to_canonical()` before containment (canonical-only, establishing `is_allowed(ip) == is_allowed(ip.to_canonical())`). This fixes **all** consumers at once (AliveDelegate admission + the reactor/compio/embedded recv-source `cidr_blocks` guards, all funnel through `is_allowed`). Documented consequence: a mapped-range V6 net (`::ffff:0:0/96`) is dead config; configured nets are **not** canonicalized at insertion (iter/PartialEq/remove semantics preserved).
- **Reject-backstop** for custom `Transport` impls that bypass the driver canonicalization: `validate_advertise_addr` (compio) and `validate_advertise` (reactor, new `Error::MappedAdvertise`) reject a still-mapped advertise. Unreachable for the standard backends (they canonicalize first).
- **Secondary** (commit `5185dbc`): canonicalize resolved join-seed addresses (a mapped seed otherwise fails the family-mismatched `sendto` from a V4-bound socket); `Ipv4/Ipv6PreferringResolver` classify candidates by canonical family.

`getifs`/auto-advertise resolvers are untouched (kernel enumeration cannot yield a mapped address).

### Compat
No wire-**format** change — only the announced *value* changes, and only for a mapped-advertise config, which was itself the defect (split identity + CIDR mismatch). New↔new clusters with clean configs see zero byte difference. `CHANGELOG.md` notes that a mapped-advertise deployment should be restarted/rejoined (not rolled) — it now behaves as its V4 form.

### Out of scope (noted as #170 follow-up)
The machine does not canonicalize a **remote** peer's advertised address (a non-standard sender could still key a membership entry at a mapped address) — a frozen-FSM change requiring its own review.
