### PR TITLE
fix(driver): unify the observation-channel string grammar across reactor and compio (#172 F3)

### DIFF
--- a/memberlist-compio/src/driver/options/mod.rs
+++ b/memberlist-compio/src/driver/options/mod.rs
@@ -148,7 +148,9 @@ impl core::str::FromStr for Channel {
     if s.eq_ignore_ascii_case("unbounded") {
       return Ok(Self::Unbounded);
     }
-    let cap = s.strip_prefix("bounded:").or_else(|| s.strip_prefix("bounded="));
+    let cap = s
+      .strip_prefix("bounded:")
+      .or_else(|| s.strip_prefix("bounded="));
     let n = match cap {
       Some(cap) => cap.parse::<usize>().map_err(|_| ParseChannelError(()))?,
       // Legacy fallback: a bare integer, as accepted by other drivers' CLI
@@ -165,7 +167,9 @@ impl core::str::FromStr for Channel {
 /// Opaque — the private unit field seals construction to this module, so the
 /// error can gain detail later without a breaking change.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[error("invalid observation channel (expected `unbounded`, `bounded:<n>`, or a bare integer capacity)")]
+#[error(
+  "invalid observation channel (expected `unbounded`, `bounded:<n>`, or a bare integer capacity)"
+)]
 pub struct ParseChannelError(());
 
 /// Default delegate observation channel: [`Channel::Bounded`] at 1024 events.

--- a/memberlist-compio/src/driver/options/mod.rs
+++ b/memberlist-compio/src/driver/options/mod.rs
@@ -108,9 +108,12 @@ pub const DEFAULT_CLOSE_TIMEOUT: Duration = Duration::from_secs(10);
 /// the delegate would observe nothing.
 ///
 /// As a config value (serde / CLI) it is open-vocabulary: `Unbounded` is the
-/// bare string `"unbounded"`, `Bounded(n)` is `{"bounded": n}` under serde and
-/// `bounded:n` on the CLI (via [`FromStr`](core::str::FromStr) /
-/// [`Display`](core::fmt::Display)).
+/// bare string `"unbounded"` (case-insensitive), `Bounded(n)` is
+/// `{"bounded": n}` under serde and canonically `bounded:n` (or `bounded=n`)
+/// on the CLI (via [`FromStr`](core::str::FromStr) /
+/// [`Display`](core::fmt::Display)); a bare integer (`n`) is also accepted
+/// when parsing, as a back-compat alias for `bounded:n` — `Display` always
+/// emits the canonical `bounded:n` form.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
@@ -133,9 +136,11 @@ impl core::fmt::Display for Channel {
   }
 }
 
-/// Parse a [`Channel`] from its string form — `"unbounded"` or `"bounded:<n>"`
-/// — for a config value or a CLI flag. The inverse of [`Channel`]'s `Display`;
-/// unconditional (not gated on `clap`) so any caller can use it.
+/// Parse a [`Channel`] from its string form — `"unbounded"`, `"bounded:<n>"`,
+/// or a bare integer `"<n>"` (a back-compat alias for `"bounded:<n>"`) — for a
+/// config value or a CLI flag. `Display` only ever emits the canonical
+/// `"bounded:<n>"`/`"unbounded"` forms; `FromStr` is the more permissive
+/// inverse. Unconditional (not gated on `clap`) so any caller can use it.
 impl core::str::FromStr for Channel {
   type Err = ParseChannelError;
 
@@ -143,22 +148,24 @@ impl core::str::FromStr for Channel {
     if s.eq_ignore_ascii_case("unbounded") {
       return Ok(Self::Unbounded);
     }
-    let cap = s
-      .strip_prefix("bounded:")
-      .or_else(|| s.strip_prefix("bounded="))
-      .ok_or(ParseChannelError(()))?;
-    let n = cap.parse::<usize>().map_err(|_| ParseChannelError(()))?;
+    let cap = s.strip_prefix("bounded:").or_else(|| s.strip_prefix("bounded="));
+    let n = match cap {
+      Some(cap) => cap.parse::<usize>().map_err(|_| ParseChannelError(()))?,
+      // Legacy fallback: a bare integer, as accepted by other drivers' CLI
+      // grammar; `Display` never emits this form.
+      None => s.parse::<usize>().map_err(|_| ParseChannelError(()))?,
+    };
     Ok(Self::Bounded(n))
   }
 }
 
 /// The error from [`Channel::from_str`]: the input was neither `"unbounded"`
-/// nor a `"bounded:<n>"` with a valid capacity.
+/// nor a `"bounded:<n>"`/bare-integer capacity.
 ///
 /// Opaque — the private unit field seals construction to this module, so the
 /// error can gain detail later without a breaking change.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[error("invalid observation channel (expected `unbounded` or `bounded:<n>`)")]
+#[error("invalid observation channel (expected `unbounded`, `bounded:<n>`, or a bare integer capacity)")]
 pub struct ParseChannelError(());
 
 /// Default delegate observation channel: [`Channel::Bounded`] at 1024 events.

--- a/memberlist-compio/src/driver/options/tests.rs
+++ b/memberlist-compio/src/driver/options/tests.rs
@@ -64,8 +64,47 @@ fn channel_variants_compare_and_default() {
   assert!(!format!("{:?}", Channel::Unbounded).is_empty());
 }
 
+/// `"bounded:<n>"`, `"bounded=<n>"`, and a bare integer all parse to
+/// `Bounded(n)`; `"unbounded"` is case-insensitive; anything else is a
+/// `ParseChannelError`. The bare-integer form is a back-compat alias kept
+/// alongside the canonical `bounded:<n>` grammar.
 #[test]
-fn channel_display_and_from_str_round_trip() {
+fn channel_parses_bounded_prefixed_and_bare() {
+  use core::str::FromStr;
+
+  assert_eq!(
+    Channel::from_str("bounded:1024"),
+    Ok(Channel::Bounded(1024))
+  );
+  assert_eq!(
+    Channel::from_str("bounded=1024"),
+    Ok(Channel::Bounded(1024))
+  );
+  assert_eq!(Channel::from_str("1024"), Ok(Channel::Bounded(1024)));
+  assert_eq!(Channel::from_str("unbounded"), Ok(Channel::Unbounded));
+  assert_eq!(Channel::from_str("UNBOUNDED"), Ok(Channel::Unbounded));
+  assert_eq!(Channel::from_str("bounded=8"), Ok(Channel::Bounded(8)));
+  // Garbage, a missing capacity, and a non-numeric capacity are rejected —
+  // the bare fallback only applies when neither `bounded:`/`bounded=` prefix
+  // is present.
+  assert!(Channel::from_str("nope").is_err());
+  assert!(Channel::from_str("bounded:").is_err());
+  assert!(Channel::from_str("bounded:x").is_err());
+}
+
+/// `Display` always emits the canonical `bounded:<n>` / `unbounded` forms,
+/// matching the shared serde representation — never the legacy bare-integer
+/// form.
+#[test]
+fn channel_display_is_canonical() {
+  assert_eq!(Channel::Unbounded.to_string(), "unbounded");
+  assert_eq!(Channel::Bounded(16).to_string(), "bounded:16");
+}
+
+/// The canonical `Display` output always re-parses to the same value through
+/// `FromStr`.
+#[test]
+fn channel_display_roundtrips_through_fromstr() {
   use core::str::FromStr;
 
   for c in [
@@ -75,15 +114,25 @@ fn channel_display_and_from_str_round_trip() {
   ] {
     assert_eq!(Channel::from_str(&c.to_string()), Ok(c));
   }
-  assert_eq!(Channel::Unbounded.to_string(), "unbounded");
-  assert_eq!(Channel::Bounded(16).to_string(), "bounded:16");
-  // Case-insensitive `unbounded` and the `bounded=` spelling both parse.
-  assert_eq!(Channel::from_str("UNBOUNDED"), Ok(Channel::Unbounded));
-  assert_eq!(Channel::from_str("bounded=8"), Ok(Channel::Bounded(8)));
-  // Garbage, a missing capacity, and a non-numeric capacity are rejected.
-  assert!(Channel::from_str("nope").is_err());
-  assert!(Channel::from_str("bounded:").is_err());
-  assert!(Channel::from_str("bounded:x").is_err());
+}
+
+/// The string grammar is cross-driver: `memberlist-reactor`'s `Channel` has no
+/// crate-level dependency relationship with this one, so parity is pinned by
+/// literal string, not by importing the other crate's type. Every string
+/// reactor's canonical `Display` can emit (`"bounded:<n>"`, `"unbounded"`) and
+/// reactor's own legacy bare-integer form all parse here to the expected
+/// variant — the same strings are independently verified against reactor's
+/// `FromStr` in its own test suite.
+#[test]
+fn channel_grammar_is_cross_driver() {
+  use core::str::FromStr;
+
+  for s in ["bounded:1024", "bounded=1024", "1024"] {
+    assert_eq!(Channel::from_str(s), Ok(Channel::Bounded(1024)));
+  }
+  for s in ["unbounded", "UNBOUNDED"] {
+    assert_eq!(Channel::from_str(s), Ok(Channel::Unbounded));
+  }
 }
 
 #[cfg(feature = "serde")]

--- a/memberlist-reactor/src/options/builder_tests.rs
+++ b/memberlist-reactor/src/options/builder_tests.rs
@@ -227,19 +227,59 @@ fn options_into_parts_without_delegates_is_none() {
   assert!(merge.is_none(), "no merge delegate by default");
 }
 
-/// `Channel` parses from a string: `"unbounded"` and a bare integer round-trip
-/// through `FromStr`/`Display`; anything else is a `ParseChannelError`.
+/// `"bounded:<n>"`, `"bounded=<n>"`, and a bare integer all parse to
+/// `Bounded(n)`; `"unbounded"` is case-insensitive; anything else is a
+/// `ParseChannelError`. The bare-integer form is the back-compat legacy
+/// fallback kept alongside the canonical `bounded:<n>` grammar.
 #[test]
-fn channel_from_str_and_display_round_trip() {
+fn channel_parses_bounded_prefixed_and_bare() {
+  assert_eq!(
+    "bounded:1024".parse::<Channel>().unwrap(),
+    Channel::Bounded(1024)
+  );
+  assert_eq!(
+    "bounded=1024".parse::<Channel>().unwrap(),
+    Channel::Bounded(1024)
+  );
+  assert_eq!("1024".parse::<Channel>().unwrap(), Channel::Bounded(1024));
   assert_eq!("unbounded".parse::<Channel>().unwrap(), Channel::Unbounded);
-  assert_eq!("2048".parse::<Channel>().unwrap(), Channel::Bounded(2048));
+  assert_eq!("UNBOUNDED".parse::<Channel>().unwrap(), Channel::Unbounded);
+  assert!("nope".parse::<Channel>().is_err());
+}
+
+/// `Display` always emits the canonical `bounded:<n>` / `unbounded` forms,
+/// matching the shared serde representation — never the legacy bare-integer
+/// form.
+#[test]
+fn channel_display_is_canonical() {
+  assert_eq!(Channel::Bounded(1024).to_string(), "bounded:1024");
   assert_eq!(Channel::Unbounded.to_string(), "unbounded");
-  assert_eq!(Channel::Bounded(2048).to_string(), "2048");
-  // The Display form re-parses to the same value.
-  for ch in [Channel::Unbounded, Channel::Bounded(7)] {
+}
+
+/// The canonical `Display` output always re-parses to the same value through
+/// `FromStr`.
+#[test]
+fn channel_display_roundtrips_through_fromstr() {
+  for ch in [Channel::Unbounded, Channel::Bounded(7), Channel::Bounded(0)] {
     assert_eq!(ch.to_string().parse::<Channel>().unwrap(), ch);
   }
-  assert!("nope".parse::<Channel>().is_err());
+}
+
+/// The string grammar is cross-driver: `memberlist-compio`'s `Channel` has no
+/// crate-level dependency relationship with this one, so parity is pinned by
+/// literal string, not by importing the other crate's type. Every string
+/// compio's `Display` can emit (`"bounded:<n>"`, `"unbounded"`) and reactor's
+/// own legacy bare-integer form all parse here to the expected variant —
+/// the same strings independently verified against compio's `FromStr` in its
+/// own test suite.
+#[test]
+fn channel_grammar_is_cross_driver() {
+  for s in ["bounded:1024", "bounded=1024", "1024"] {
+    assert_eq!(s.parse::<Channel>().unwrap(), Channel::Bounded(1024));
+  }
+  for s in ["unbounded", "UNBOUNDED"] {
+    assert_eq!(s.parse::<Channel>().unwrap(), Channel::Unbounded);
+  }
 }
 
 #[cfg(feature = "serde")]

--- a/memberlist-reactor/src/options/mod.rs
+++ b/memberlist-reactor/src/options/mod.rs
@@ -549,7 +549,9 @@ impl core::str::FromStr for Channel {
     if s.eq_ignore_ascii_case("unbounded") {
       return Ok(Self::Unbounded);
     }
-    let cap = s.strip_prefix("bounded:").or_else(|| s.strip_prefix("bounded="));
+    let cap = s
+      .strip_prefix("bounded:")
+      .or_else(|| s.strip_prefix("bounded="));
     let n = match cap {
       Some(cap) => cap.parse::<usize>().map_err(|_| ParseChannelError(()))?,
       // Legacy fallback: a bare integer, as accepted before the CLI grammar

--- a/memberlist-reactor/src/options/mod.rs
+++ b/memberlist-reactor/src/options/mod.rs
@@ -504,9 +504,12 @@ pub const DEFAULT_OBSERVATION_CHANNEL_CAPACITY: usize = 1024;
 /// [`Event`](memberlist_proto::Event)s to the observation task.
 ///
 /// As a config value or CLI flag the policy parses from a string
-/// ([`Channel::from_str`]): `"unbounded"` selects [`Channel::Unbounded`], and a
-/// bare unsigned integer selects [`Channel::Bounded`] of that capacity (`"1024"`
-/// → `Bounded(1024)`).
+/// ([`Channel::from_str`]): the canonical form is `"bounded:<n>"` (or
+/// `"bounded=<n>"`) for [`Channel::Bounded`], and `"unbounded"`
+/// (case-insensitive) for [`Channel::Unbounded`]; a bare unsigned integer
+/// (e.g. `"1024"`) is also accepted for back-compat and maps to `Bounded`.
+/// [`Display`](core::fmt::Display) always emits the canonical `bounded:<n>`
+/// form.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
@@ -528,36 +531,44 @@ impl Default for Channel {
 impl core::fmt::Display for Channel {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     match self {
-      Self::Bounded(capacity) => write!(f, "{capacity}"),
+      Self::Bounded(capacity) => write!(f, "bounded:{capacity}"),
       Self::Unbounded => f.write_str("unbounded"),
     }
   }
 }
 
 /// Parse a [`Channel`] from a string — a config value or CLI flag.
-/// `"unbounded"` is [`Channel::Unbounded`]; a bare unsigned integer is
-/// [`Channel::Bounded`] of that capacity. Any other input is a
-/// [`ParseChannelError`].
+/// `"unbounded"` (case-insensitive) is [`Channel::Unbounded`]; `"bounded:<n>"`
+/// or `"bounded=<n>"` is [`Channel::Bounded`] of that capacity; a bare
+/// unsigned integer is also accepted as a back-compat alias for
+/// `"bounded:<n>"`. Any other input is a [`ParseChannelError`].
 impl core::str::FromStr for Channel {
   type Err = ParseChannelError;
 
   fn from_str(s: &str) -> Result<Self, Self::Err> {
-    if s == "unbounded" {
+    if s.eq_ignore_ascii_case("unbounded") {
       return Ok(Self::Unbounded);
     }
-    s.parse::<usize>()
-      .map(Self::Bounded)
-      .map_err(|_| ParseChannelError(()))
+    let cap = s.strip_prefix("bounded:").or_else(|| s.strip_prefix("bounded="));
+    let n = match cap {
+      Some(cap) => cap.parse::<usize>().map_err(|_| ParseChannelError(()))?,
+      // Legacy fallback: a bare integer, as accepted before the CLI grammar
+      // was canonicalized on `bounded:<n>` to match the serde form.
+      None => s.parse::<usize>().map_err(|_| ParseChannelError(()))?,
+    };
+    Ok(Self::Bounded(n))
   }
 }
 
 /// The error from [`Channel::from_str`]: the input was neither `"unbounded"`
-/// nor a bare unsigned integer.
+/// nor a `"bounded:<n>"`/bare-integer capacity.
 ///
 /// Opaque — the private unit field seals construction to this module, so the
 /// error can gain detail later without a breaking change.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[error("invalid observation channel (expected \"unbounded\" or an unsigned integer capacity)")]
+#[error(
+  "invalid observation channel (expected \"unbounded\", \"bounded:<n>\", or a bare integer capacity)"
+)]
 pub struct ParseChannelError(());
 
 /// The default membership `EventStream` capacity.


### PR DESCRIPTION
## #172 F3 — unify the observation-channel string grammar across reactor and compio

The reactor and compio `Channel` (observation-channel policy) enums are distinct types with the **same** variants (`Bounded(usize)`, `Unbounded`) and the **same** serde form (both `rename_all = "snake_case"` → `Bounded(n)` is `{"bounded": n}`, `Unbounded` is `"unbounded"`), but their CLI/`FromStr`/`Display` string grammars diverged:
- reactor emitted and required a **bare integer** (`1024`) and rejected `bounded:1024`;
- compio emitted and required `bounded:1024` and rejected a bare `1024`.

So a config value or CLI flag valid for one driver was rejected by the other. Reactor's bare-integer CLI form was also inconsistent with its *own* serde form.

### Fix
Canonicalize both `Display` on `bounded:<n>` (reactor changes from bare — also aligning it with its serde form; compio already canonical), and make **both** `FromStr` accept `"unbounded"` (case-insensitive), `"bounded:<n>"`, `"bounded=<n>"`, **and** a bare integer (a back-compat legacy alias so existing reactor bare-integer configs keep parsing). After the fix any valid string parses on both drivers and both emit the canonical form. **serde is unchanged** on both (the form was already identical and correct).
