### PR TITLE
feat(driver): expose SWIM tuning through the standard drivers via a shared EndpointTuning (#172 F4)

### DIFF
--- a/memberlist-compio/src/lib.rs
+++ b/memberlist-compio/src/lib.rs
@@ -105,7 +105,7 @@ pub use memberlist_proto::{AddrParseError, CidrPolicy, IpNet};
 )]
 pub use memberlist_proto::{ChecksumAlgorithm, ChecksumOptions};
 pub use memberlist_proto::{
-  MaybeOwned, MaybeResolved, Node, typed::NodeState as MemberlistNodeState,
+  EndpointTuning, MaybeOwned, MaybeResolved, Node, typed::NodeState as MemberlistNodeState,
 };
 pub use options::{MemberlistOptions, Options, OptionsParts};
 pub use resolver::{

--- a/memberlist-compio/src/memberlist/mod.rs
+++ b/memberlist-compio/src/memberlist/mod.rs
@@ -243,6 +243,12 @@ where
     // receive reliable user data. Checked before `initial_local_state`, which
     // is validated against this same ceiling.
     crate::options::validate_max_stream_frame_size(&memberlist_opts)?;
+    // Fail fast on a SWIM tuning knob the machine would reject at construction
+    // (currently only an `awareness_max_multiplier` of zero, which leaves the
+    // awareness tracker unconstructable). compio builds the machine through the
+    // panicking `Endpoint::new` on a detached task, so this check surfaces the
+    // misconfiguration as a clean error here instead of a task abort.
+    crate::options::validate_endpoint_tuning(&memberlist_opts)?;
     // Fail fast on an `initial_meta` larger than the effective meta cap
     // (`min(meta_max_size, Meta::MAX_SIZE)`). The machine only debug-asserts this
     // invariant, so without a release check a node could start with a meta the

--- a/memberlist-compio/src/options/mod.rs
+++ b/memberlist-compio/src/options/mod.rs
@@ -10,7 +10,9 @@ use memberlist_proto::ChecksumOptions;
 use memberlist_proto::CompressionOptions;
 #[cfg(encryption)]
 use memberlist_proto::EncryptionOptions;
-use memberlist_proto::{CheapClone, config::EndpointOptions, label::validate_label, typed::Meta};
+use memberlist_proto::{
+  CheapClone, EndpointTuning, config::EndpointOptions, label::validate_label, typed::Meta,
+};
 
 use crate::{
   delegate::{AliveDelegate, MergeDelegate},
@@ -37,6 +39,12 @@ use memberlist_proto::config::{DEFAULT_MAX_STREAM_FRAME_SIZE, DEFAULT_META_MAX_S
 /// - `max_stream_frame_size` — the reliable-stream frame ceiling; bounds the
 ///   per-event size of reliable user / push-pull payloads (and thus the
 ///   delegate-queue memory a peer can drive when a delegate falls behind).
+/// - `tuning` — the SWIM-behavioral tuning knobs (probe / suspicion / gossip
+///   cadence, membership admission ceilings) carried through to the machine via
+///   [`EndpointTuning`](memberlist_proto::EndpointTuning). Every knob defaults
+///   to unset (the machine default); an
+///   `awareness_max_multiplier` of `0` is rejected at
+///   [`Memberlist::new`](crate::Memberlist::new).
 /// - `initial_meta` — the local node's initial metadata payload.
 /// - `initial_local_state` — the local node's initial push/pull
 ///   application-state snapshot.
@@ -73,6 +81,12 @@ pub struct MemberlistOptions {
   gossip_mtu: Option<usize>,
   meta_max_size: Option<usize>,
   max_stream_frame_size: Option<usize>,
+  // The SWIM-behavioral tuning knobs (probe / suspicion / gossip cadence,
+  // membership ceilings). A nested section whose every field is an unset
+  // override by default, layered onto the machine `EndpointOptions` via
+  // `EndpointTuning::apply_to`. Container `serde(default)` makes a missing
+  // `tuning` key deserialize to the all-unset default.
+  tuning: EndpointTuning,
   // `Meta` is an opaque binary payload with no string form and no serde impl,
   // so it is neither a config-file field nor a CLI flag: configure it
   // programmatically via `with_initial_meta`.
@@ -212,6 +226,19 @@ impl MemberlistOptions {
   #[inline]
   pub fn with_max_stream_frame_size(mut self, size: usize) -> Self {
     self.max_stream_frame_size = Some(size);
+    self
+  }
+
+  /// Builder: set the SWIM-behavioral tuning knobs (probe / suspicion / gossip
+  /// cadence, membership admission ceilings) carried through to the machine.
+  /// Each unset knob leaves the machine default; see
+  /// [`EndpointTuning`](memberlist_proto::EndpointTuning). An
+  /// `awareness_max_multiplier` of `0` is rejected at
+  /// [`Memberlist::new`](crate::Memberlist::new).
+  #[must_use]
+  #[inline]
+  pub fn with_tuning(mut self, tuning: EndpointTuning) -> Self {
+    self.tuning = tuning;
     self
   }
 
@@ -356,6 +383,12 @@ impl MemberlistOptions {
     self.max_stream_frame_size
   }
 
+  /// The SWIM-behavioral tuning knobs carried through to the machine.
+  #[inline]
+  pub const fn tuning(&self) -> &EndpointTuning {
+    &self.tuning
+  }
+
   /// The configured initial `Meta`, if any.
   #[inline]
   pub const fn initial_meta(&self) -> Option<&Meta> {
@@ -481,6 +514,7 @@ const _: () = {
   impl Args for MemberlistOptions {
     fn augment_args(cmd: Command) -> Command {
       let cmd = MemberlistOptionsCli::augment_args(cmd);
+      let cmd = EndpointTuning::augment_args(cmd);
       #[cfg(compression)]
       let cmd = CompressionOptions::augment_args(cmd);
       #[cfg(checksum)]
@@ -492,6 +526,7 @@ const _: () = {
 
     fn augment_args_for_update(cmd: Command) -> Command {
       let cmd = MemberlistOptionsCli::augment_args_for_update(cmd);
+      let cmd = EndpointTuning::augment_args_for_update(cmd);
       #[cfg(compression)]
       let cmd = CompressionOptions::augment_args_for_update(cmd);
       #[cfg(checksum)]
@@ -509,6 +544,7 @@ const _: () = {
         gossip_mtu: own.gossip_mtu,
         meta_max_size: own.meta_max_size,
         max_stream_frame_size: own.max_stream_frame_size,
+        tuning: EndpointTuning::from_arg_matches(m)?,
         // The opaque binary fields are not CLI-settable; they default here and
         // are configured programmatically via the builders.
         initial_meta: None,
@@ -566,6 +602,7 @@ const _: () = {
       );
       // Delegate each flattened child to its own value-source-correct update so
       // an unrelated parent flag never resets a child's defaulted knob.
+      self.tuning.update_from_arg_matches(m)?;
       #[cfg(compression)]
       self.compression.update_from_arg_matches(m)?;
       #[cfg(checksum)]
@@ -1311,6 +1348,36 @@ pub(crate) fn validate_max_stream_frame_size(
   Ok(())
 }
 
+/// Validate the newly-exposed SWIM tuning knobs the machine would reject at
+/// construction.
+///
+/// Exactly one tuning knob is a partial input the machine refuses: an
+/// `awareness_max_multiplier` of `0` leaves the awareness tracker
+/// unconstructable (`EndpointInitError::AwarenessMultiplierZero`). compio's
+/// `Transport::run` builds the machine through the PANICKING `Endpoint::new` in
+/// a detached task, so an unvalidated zero would abort that task rather than
+/// surface a clean error. This check rejects it up-front at `Memberlist::new`,
+/// before any socket is bound, mirroring the reject-fail-fast doctrine of the
+/// sibling validators. Every other newly-exposed knob is a total input (a zero
+/// duration is a defined disable semantic, a degenerate multiplier a legal
+/// tuning extreme), so nothing else is gated here.
+///
+/// Called from `Memberlist::new`; every backend (TCP/TLS/QUIC) routes through
+/// that single path, so the check is enforced uniformly.
+pub(crate) fn validate_endpoint_tuning(opts: &MemberlistOptions) -> Result<(), MemberlistError> {
+  if opts.tuning().awareness_max_multiplier() == Some(0) {
+    return Err(MemberlistError::InvalidOption(InvalidOption::new(
+      "awareness_max_multiplier",
+      "the awareness max multiplier must be nonzero: the machine rejects a zero multiplier at \
+         construction (the awareness tracker would be unconstructable), and compio builds the \
+         machine on a detached task through a panicking constructor, so a zero would abort that \
+         task instead of surfacing a clean error"
+        .to_string(),
+    )));
+  }
+  Ok(())
+}
+
 /// Layer the [`MemberlistOptions`] overrides onto a freshly-built
 /// machine-layer [`EndpointOptions`]. Each unset knob leaves the
 /// corresponding `EndpointOptions` default untouched. Called from every
@@ -1336,6 +1403,13 @@ pub(crate) fn apply_memberlist_options<I, A>(
   if let Some(state) = opts.initial_local_state() {
     cfg = cfg.with_initial_local_state(state.clone());
   }
+  // The SWIM tuning overrides copy through last; their knob set is disjoint from
+  // the size / payload knobs above, so the order does not matter. The only
+  // machine-rejectable value among them (`awareness_max_multiplier == 0`) is
+  // caught up-front by `validate_endpoint_tuning` in `Memberlist::new`, so the
+  // `EndpointOptions` this returns is known constructable by the time compio's
+  // `Transport::run` hands it to the panicking `Endpoint::new`.
+  cfg = opts.tuning().apply_to(cfg);
   cfg
 }
 

--- a/memberlist-compio/src/options/tests.rs
+++ b/memberlist-compio/src/options/tests.rs
@@ -473,6 +473,9 @@ fn memberlist_options_default_is_all_unset() {
   assert!(opts.initial_local_state().is_none());
   assert_eq!(opts.label(), None);
   assert!(!opts.skip_inbound_label_check());
+  // The nested tuning section defaults to all-unset.
+  assert_eq!(opts.tuning().probe_interval(), None);
+  assert_eq!(opts.tuning().max_members(), None);
   // `new()` and `default()` agree on every scalar.
   let d = MemberlistOptions::default();
   assert_eq!(d.gossip_mtu(), None);
@@ -693,6 +696,60 @@ fn validate_encryption_options_accepts_usable_policies() {
   );
 }
 
+// The driver-seam assertion, cross-driver parity with the reactor by identical
+// values: the returned `EndpointOptions` is verbatim what compio's
+// `Transport::run` hands to `Endpoint::new`, so exercising the real
+// `apply_memberlist_options` proves the tuning overrides travel the driver path.
+#[test]
+fn apply_memberlist_options_installs_tuning_overrides() {
+  use core::time::Duration;
+
+  let opts = MemberlistOptions::new().with_tuning(
+    EndpointTuning::new()
+      .with_probe_interval(Duration::from_secs(5))
+      .with_max_members(32)
+      .with_suspicion_mult(7),
+  );
+  let cfg = apply_memberlist_options(EndpointOptions::<(), ()>::new((), ()), &opts);
+  assert_eq!(cfg.probe_interval(), Duration::from_secs(5));
+  assert_eq!(cfg.max_members(), Some(32));
+  assert_eq!(cfg.suspicion_mult(), 7);
+
+  // The unset arm: no tuning overrides ⇒ every knob keeps the machine default.
+  let base = EndpointOptions::<(), ()>::new((), ());
+  let cfg_default = apply_memberlist_options(
+    EndpointOptions::<(), ()>::new((), ()),
+    &MemberlistOptions::new(),
+  );
+  assert_eq!(cfg_default.probe_interval(), base.probe_interval());
+  assert_eq!(cfg_default.max_members(), base.max_members());
+  assert_eq!(cfg_default.suspicion_mult(), base.suspicion_mult());
+}
+
+// `awareness_max_multiplier == 0` is the one newly-exposed knob the machine
+// rejects at construction; compio must catch it up-front (its `Transport::run`
+// builds the machine through a panicking constructor on a detached task). A
+// nonzero value and an unset knob are both accepted.
+#[test]
+fn validate_endpoint_tuning_rejects_zero_awareness_multiplier() {
+  // Unset ⇒ Ok.
+  assert!(validate_endpoint_tuning(&MemberlistOptions::new()).is_ok());
+  // A nonzero multiplier ⇒ Ok.
+  assert!(
+    validate_endpoint_tuning(
+      &MemberlistOptions::new().with_tuning(EndpointTuning::new().with_awareness_max_multiplier(1))
+    )
+    .is_ok()
+  );
+  // Zero ⇒ InvalidOption naming the knob.
+  match validate_endpoint_tuning(
+    &MemberlistOptions::new().with_tuning(EndpointTuning::new().with_awareness_max_multiplier(0)),
+  ) {
+    Err(MemberlistError::InvalidOption(_)) => {}
+    other => panic!("a zero awareness multiplier must be InvalidOption, got {other:?}"),
+  }
+}
+
 #[cfg(feature = "serde")]
 #[test]
 fn memberlist_options_serde_round_trip_and_partial() {
@@ -710,18 +767,33 @@ fn memberlist_options_serde_round_trip_and_partial() {
     .with_gossip_mtu(1500)
     .with_meta_max_size(256)
     .with_max_stream_frame_size(4096)
-    .with_skip_inbound_label_check(true);
+    .with_skip_inbound_label_check(true)
+    .with_tuning(
+      EndpointTuning::new()
+        .with_probe_interval(core::time::Duration::from_secs(2))
+        .with_max_members(64),
+    );
   let json = serde_json::to_string(&opts).unwrap();
   let back: MemberlistOptions = serde_json::from_str(&json).unwrap();
   assert_eq!(back.gossip_mtu(), Some(1500));
   assert_eq!(back.meta_max_size(), Some(256));
   assert_eq!(back.max_stream_frame_size(), Some(4096));
   assert!(back.skip_inbound_label_check());
-  // A partial config overrides one field and defaults the rest.
-  let partial: MemberlistOptions = serde_json::from_str(r#"{"gossip_mtu": 1234}"#).unwrap();
+  // The nested tuning section survives the round-trip.
+  assert_eq!(
+    back.tuning().probe_interval(),
+    Some(core::time::Duration::from_secs(2))
+  );
+  assert_eq!(back.tuning().max_members(), Some(64));
+  // A partial config overrides one field and defaults the rest — including a
+  // `tuning` section carrying only one knob.
+  let partial: MemberlistOptions =
+    serde_json::from_str(r#"{"gossip_mtu": 1234, "tuning": {"suspicion_mult": 9}}"#).unwrap();
   assert_eq!(partial.gossip_mtu(), Some(1234));
   assert_eq!(partial.meta_max_size(), None);
   assert!(!partial.skip_inbound_label_check());
+  assert_eq!(partial.tuning().suspicion_mult(), Some(9));
+  assert_eq!(partial.tuning().probe_interval(), None);
 }
 
 #[cfg(feature = "serde")]
@@ -744,25 +816,32 @@ fn memberlist_options_clap_parses_and_wires_env() {
     memberlist: MemberlistOptions,
   }
 
-  // The `Option<usize>` and `bool` flags parse; the opaque fields have none.
+  // The `Option<usize>` and `bool` flags parse; the opaque fields have none; the
+  // manually-augmented tuning flags parse too.
   let cli = Cli::try_parse_from([
     "app",
     "--memberlist-gossip-mtu",
     "1500",
     "--memberlist-skip-inbound-label-check",
+    "--memberlist-probe-interval",
+    "5s",
+    "--memberlist-max-members",
+    "32",
   ])
   .unwrap();
   assert_eq!(cli.memberlist.gossip_mtu(), Some(1500));
   assert!(cli.memberlist.skip_inbound_label_check());
-  // Unspecified leaves the gossip-mtu override unset.
   assert_eq!(
-    Cli::try_parse_from(["app"])
-      .unwrap()
-      .memberlist
-      .gossip_mtu(),
-    None
+    cli.memberlist.tuning().probe_interval(),
+    Some(core::time::Duration::from_secs(5))
   );
+  assert_eq!(cli.memberlist.tuning().max_members(), Some(32));
+  // Unspecified leaves the overrides unset.
+  let bare = Cli::try_parse_from(["app"]).unwrap();
+  assert_eq!(bare.memberlist.gossip_mtu(), None);
+  assert_eq!(bare.memberlist.tuning().probe_interval(), None);
   // The env var is wired — assert via command introspection, never `set_var`.
+  // Check both an own flag and a manually-augmented tuning flag.
   let cmd = Cli::command();
   let arg = cmd
     .get_arguments()
@@ -771,6 +850,14 @@ fn memberlist_options_clap_parses_and_wires_env() {
   assert_eq!(
     arg.get_env().and_then(|e| e.to_str()),
     Some("MEMBERLIST_GOSSIP_MTU")
+  );
+  let tuning_arg = cmd
+    .get_arguments()
+    .find(|a| a.get_id().as_str() == "memberlist-probe-interval")
+    .expect("memberlist-probe-interval arg is registered");
+  assert_eq!(
+    tuning_arg.get_env().and_then(|e| e.to_str()),
+    Some("MEMBERLIST_PROBE_INTERVAL")
   );
 }
 
@@ -873,7 +960,12 @@ fn memberlist_options_partial_update_preserves_unset_fields() {
   // partial update supplying ONE unrelated own flag.
   let seeded = MemberlistOptions::new()
     .with_skip_inbound_label_check(true)
-    .with_meta_max_size(4242);
+    .with_meta_max_size(4242)
+    .with_tuning(
+      EndpointTuning::new()
+        .with_probe_interval(core::time::Duration::from_secs(5))
+        .with_max_members(32),
+    );
   #[cfg(compression)]
   let seeded = seeded.with_compression(
     CompressionOptions::new().with_algorithm(memberlist_proto::CompressAlgorithm::Lz4),
@@ -893,6 +985,19 @@ fn memberlist_options_partial_update_preserves_unset_fields() {
   );
   // The seeded `Option` field survives too.
   assert_eq!(cli.o.meta_max_size(), Some(4242));
+  // The manually-augmented tuning child's seeded knobs survive the partial
+  // parent update — the "an unrelated flag must not reset nested tuning"
+  // guarantee.
+  assert_eq!(
+    cli.o.tuning().probe_interval(),
+    Some(core::time::Duration::from_secs(5)),
+    "the tuning child's probe_interval must survive an unrelated partial update"
+  );
+  assert_eq!(
+    cli.o.tuning().max_members(),
+    Some(32),
+    "the tuning child's max_members must survive an unrelated partial update"
+  );
   // The seeded child knob survives the partial parent update.
   #[cfg(compression)]
   assert_eq!(
@@ -927,10 +1032,14 @@ fn memberlist_options_update_applies_explicit_override() {
       "--memberlist-skip-inbound-label-check",
       "--memberlist-gossip-mtu",
       "1600",
+      "--memberlist-suspicion-mult",
+      "11",
     ])
     .expect("explicit override parses");
   assert!(cli.o.skip_inbound_label_check());
   assert_eq!(cli.o.gossip_mtu(), Some(1600));
+  // A tuning flag supplied on update is applied via the delegated child update.
+  assert_eq!(cli.o.tuning().suspicion_mult(), Some(11));
 
   // A child flag supplied on update is applied via the delegated child update.
   #[cfg(compression)]

--- a/memberlist-compio/tests/tuning_install.rs
+++ b/memberlist-compio/tests/tuning_install.rs
@@ -1,0 +1,65 @@
+//! End-to-end proof that `MemberlistOptions::tuning` is validated on the real
+//! `Memberlist::new` path, and travels into the machine when sane.
+//!
+//! compio's `Transport::run` builds the machine through the PANICKING
+//! `Endpoint::new` on a detached task, so the one newly-exposed tuning knob the
+//! machine rejects at construction (`awareness_max_multiplier == 0`) is caught
+//! up-front by `Memberlist::new`'s validator and surfaced as a clean
+//! `MemberlistError::InvalidOption` — never a task panic. A sane value
+//! constructs cleanly through the same path.
+
+#![cfg(feature = "tcp")]
+
+use std::net::SocketAddr;
+
+use memberlist_compio::{
+  EndpointTuning, FirstAddrResolver, MaybeResolved, Memberlist, MemberlistError, MemberlistOptions,
+  Options, SocketAddrResolver, TcpTransport, TcpTransportOptions, VoidDelegate,
+};
+use smol_str::SmolStr;
+
+#[compio::test]
+async fn tcp_new_rejects_zero_awareness_multiplier_in_tuning() {
+  let opts = Options::<TcpTransport<SmolStr, SocketAddr>>::new(
+    TcpTransportOptions::<SmolStr, SocketAddr>::new()
+      .with_local_id(SmolStr::new("node-zero"))
+      .with_advertise_addr(MaybeResolved::Resolved("127.0.0.1:0".parse().unwrap())),
+  )
+  .with_memberlist(
+    MemberlistOptions::new().with_tuning(EndpointTuning::new().with_awareness_max_multiplier(0)),
+  );
+  let res = Memberlist::<SmolStr, SocketAddr>::new(
+    opts,
+    VoidDelegate::default(),
+    &SocketAddrResolver,
+    &FirstAddrResolver,
+  )
+  .await;
+  assert!(
+    matches!(res, Err(MemberlistError::InvalidOption(_))),
+    "awareness_max_multiplier=0 in tuning must be rejected up-front by Memberlist::new"
+  );
+}
+
+#[compio::test]
+async fn tcp_new_accepts_sane_awareness_multiplier_in_tuning() {
+  let opts = Options::<TcpTransport<SmolStr, SocketAddr>>::new(
+    TcpTransportOptions::<SmolStr, SocketAddr>::new()
+      .with_local_id(SmolStr::new("node-ok"))
+      .with_advertise_addr(MaybeResolved::Resolved("127.0.0.1:0".parse().unwrap())),
+  )
+  .with_memberlist(
+    MemberlistOptions::new().with_tuning(EndpointTuning::new().with_awareness_max_multiplier(4)),
+  );
+  let m = Memberlist::<SmolStr, SocketAddr>::new(
+    opts,
+    VoidDelegate::default(),
+    &SocketAddrResolver,
+    &FirstAddrResolver,
+  )
+  .await
+  .expect("a nonzero awareness multiplier constructs cleanly through the same path");
+  // Ignoring Err: best-effort teardown after the construction assertion; a
+  // shutdown error would not change what this test proves.
+  let _ = m.shutdown().await;
+}

--- a/memberlist-proto/src/config/mod.rs
+++ b/memberlist-proto/src/config/mod.rs
@@ -12,6 +12,9 @@ use core::{num::NonZeroU8, time::Duration};
 use crate::typed::{DelegateVersion, Meta, ProtocolVersion};
 use bytes::Bytes;
 
+mod tuning;
+pub use tuning::EndpointTuning;
+
 /// Default value for [`EndpointOptions::gossip_mtu`]: 1400 bytes — just under
 /// a typical 1500-byte Ethernet MTU, matching the legacy memberlist default
 /// and keeping UDP gossip un-fragmented on IPv4/IPv6 + UDP-header headroom.

--- a/memberlist-proto/src/config/tuning.rs
+++ b/memberlist-proto/src/config/tuning.rs
@@ -1,0 +1,716 @@
+//! `EndpointTuning` — the SWIM-behavioral subset of [`EndpointOptions`] the
+//! standard drivers carry through to the machine.
+//!
+//! A driver's user-facing options type builds an [`EndpointOptions`] internally
+//! and would otherwise only forward a handful of size knobs, leaving the probe /
+//! suspicion / gossip cadence and the membership admission ceilings pinned at
+//! their machine defaults. `EndpointTuning` is the shared, presence-tracking
+//! override set both standard drivers embed and hand back to the machine: every
+//! field is an `Option`, an unset field leaves the corresponding
+//! `EndpointOptions` knob untouched (byte-identical to not carrying tuning at
+//! all), and [`apply_to`](EndpointTuning::apply_to) — the single copy-through —
+//! lives here so the two drivers cannot drift.
+//!
+//! # Coverage
+//!
+//! The type exposes the SWIM tuning knobs that are total inputs: any value is a
+//! legal (if extreme) configuration, and a zero duration is a defined disable
+//! semantic rather than a fault. Four `EndpointOptions` knobs are deliberately
+//! NOT surfaced, because routing operator input to them through a driver would
+//! be a footgun rather than a convenience — an embedder that genuinely needs one
+//! builds its `EndpointOptions` directly:
+//!
+//! - `protocol_version` / `delegate_version` — wire-negotiation identity on a
+//!   V1-only, no-legacy-compat protocol. A stray version byte does not tune
+//!   behavior; it splits the cluster into non-interoperating halves.
+//! - `initial_incarnation` — crash-restart identity, an orchestrator concern,
+//!   and `with_initial_incarnation` panics above `u32::MAX / 2`. Exposing it
+//!   through a driver would convert an operator's out-of-range input into a
+//!   panic inside a driver's construction path.
+//! - `user_broadcast_tiers` — only meaningful with
+//!   `Endpoint::queue_user_broadcast_ranked`, which neither standard driver
+//!   surfaces, so as a driver knob it would configure nothing.
+
+use core::time::Duration;
+
+use super::EndpointOptions;
+
+/// The SWIM-behavioral override set the standard drivers carry through to the
+/// machine's [`EndpointOptions`].
+///
+/// Every field is an `Option`: `None` (the default for all of them) leaves the
+/// corresponding `EndpointOptions` knob at its machine default, so a default
+/// `EndpointTuning` applied over a fresh `EndpointOptions` changes nothing.
+/// Set a field with its `with_*` builder to override that one knob.
+///
+/// A zero `Duration` is not "unset" — it is the machine's documented disable
+/// semantic for the intervals that define one (`gossip_interval` /
+/// `push_pull_interval` disable that background round; `dead_node_reclaim_time`
+/// of zero disables reclaim). "Unset" is `None`; "explicitly zero" is
+/// `Some(Duration::ZERO)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default, deny_unknown_fields))]
+pub struct EndpointTuning {
+  #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
+  probe_interval: Option<Duration>,
+  #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
+  probe_timeout: Option<Duration>,
+  #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
+  gossip_interval: Option<Duration>,
+  #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
+  gossip_to_the_dead_time: Option<Duration>,
+  #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
+  dead_node_reclaim_time: Option<Duration>,
+  #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
+  push_pull_interval: Option<Duration>,
+  #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
+  stream_timeout: Option<Duration>,
+  #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
+  accept_handshake_deadline: Option<Duration>,
+  suspicion_mult: Option<u32>,
+  suspicion_max_timeout_mult: Option<u32>,
+  awareness_max_multiplier: Option<u32>,
+  indirect_checks: Option<u32>,
+  retransmit_mult: Option<u32>,
+  gossip_nodes: Option<usize>,
+  /// The membership admission ceiling. The machine default is `None`
+  /// (unlimited open-join), so "unset" (leave the machine default) and
+  /// "explicitly unlimited" coincide: a driver cannot express "set the ceiling
+  /// to unlimited" as distinct from "do not override", but the two are the same
+  /// configuration, so nothing is lost. Set `Some(n)` to cap membership at `n`.
+  max_members: Option<usize>,
+  max_indirect_forwards: Option<usize>,
+  /// The concurrent inbound-stream ceiling. As with [`Self::max_members`], the
+  /// machine default is `None` (unlimited), so "unset" and "explicitly
+  /// unlimited" coincide — lossless, since they are the same configuration.
+  /// Set `Some(n)` to cap concurrent inbound reliable exchanges at `n`.
+  max_inbound_streams: Option<usize>,
+  ack_payload_to_members_only: Option<bool>,
+}
+
+impl Default for EndpointTuning {
+  #[inline]
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl EndpointTuning {
+  /// A tuning set with every knob unset. Applied over an [`EndpointOptions`] it
+  /// changes nothing — every knob keeps its machine default.
+  #[must_use]
+  #[inline]
+  pub const fn new() -> Self {
+    Self {
+      probe_interval: None,
+      probe_timeout: None,
+      gossip_interval: None,
+      gossip_to_the_dead_time: None,
+      dead_node_reclaim_time: None,
+      push_pull_interval: None,
+      stream_timeout: None,
+      accept_handshake_deadline: None,
+      suspicion_mult: None,
+      suspicion_max_timeout_mult: None,
+      awareness_max_multiplier: None,
+      indirect_checks: None,
+      retransmit_mult: None,
+      gossip_nodes: None,
+      max_members: None,
+      max_indirect_forwards: None,
+      max_inbound_streams: None,
+      ack_payload_to_members_only: None,
+    }
+  }
+
+  /// Builder: override the probe interval (the SWIM protocol period).
+  #[must_use]
+  #[inline]
+  pub const fn with_probe_interval(mut self, v: Duration) -> Self {
+    self.probe_interval = Some(v);
+    self
+  }
+
+  /// Builder: override the direct-ping timeout before indirect fallback.
+  #[must_use]
+  #[inline]
+  pub const fn with_probe_timeout(mut self, v: Duration) -> Self {
+    self.probe_timeout = Some(v);
+    self
+  }
+
+  /// Builder: override the gossip interval. `Duration::ZERO` disables gossip.
+  #[must_use]
+  #[inline]
+  pub const fn with_gossip_interval(mut self, v: Duration) -> Self {
+    self.gossip_interval = Some(v);
+    self
+  }
+
+  /// Builder: override the window during which broadcasts are still gossiped to
+  /// recently-dead nodes.
+  #[must_use]
+  #[inline]
+  pub const fn with_gossip_to_the_dead_time(mut self, v: Duration) -> Self {
+    self.gossip_to_the_dead_time = Some(v);
+    self
+  }
+
+  /// Builder: override the dead-node reclaim time. `Duration::ZERO` disables
+  /// reclaim.
+  #[must_use]
+  #[inline]
+  pub const fn with_dead_node_reclaim_time(mut self, v: Duration) -> Self {
+    self.dead_node_reclaim_time = Some(v);
+    self
+  }
+
+  /// Builder: override the push/pull anti-entropy interval. `Duration::ZERO`
+  /// disables push/pull.
+  #[must_use]
+  #[inline]
+  pub const fn with_push_pull_interval(mut self, v: Duration) -> Self {
+    self.push_pull_interval = Some(v);
+    self
+  }
+
+  /// Builder: override the per-stream exchange timeout.
+  #[must_use]
+  #[inline]
+  pub const fn with_stream_timeout(mut self, v: Duration) -> Self {
+    self.stream_timeout = Some(v);
+    self
+  }
+
+  /// Builder: override the server-side accept handshake deadline.
+  #[must_use]
+  #[inline]
+  pub const fn with_accept_handshake_deadline(mut self, v: Duration) -> Self {
+    self.accept_handshake_deadline = Some(v);
+    self
+  }
+
+  /// Builder: override the suspicion multiplier.
+  #[must_use]
+  #[inline]
+  pub const fn with_suspicion_mult(mut self, v: u32) -> Self {
+    self.suspicion_mult = Some(v);
+    self
+  }
+
+  /// Builder: override the suspicion max-timeout multiplier.
+  #[must_use]
+  #[inline]
+  pub const fn with_suspicion_max_timeout_mult(mut self, v: u32) -> Self {
+    self.suspicion_max_timeout_mult = Some(v);
+    self
+  }
+
+  /// Builder: override the awareness max multiplier. The machine rejects a value
+  /// of `0` at construction, so a driver that reaches the machine through an
+  /// infallible path validates this knob before construction.
+  #[must_use]
+  #[inline]
+  pub const fn with_awareness_max_multiplier(mut self, v: u32) -> Self {
+    self.awareness_max_multiplier = Some(v);
+    self
+  }
+
+  /// Builder: override the number of indirect peers used as failed-direct-ping
+  /// fallback.
+  #[must_use]
+  #[inline]
+  pub const fn with_indirect_checks(mut self, v: u32) -> Self {
+    self.indirect_checks = Some(v);
+    self
+  }
+
+  /// Builder: override the broadcast retransmit multiplier.
+  #[must_use]
+  #[inline]
+  pub const fn with_retransmit_mult(mut self, v: u32) -> Self {
+    self.retransmit_mult = Some(v);
+    self
+  }
+
+  /// Builder: override the number of random peers gossiped to per round.
+  #[must_use]
+  #[inline]
+  pub const fn with_gossip_nodes(mut self, v: usize) -> Self {
+    self.gossip_nodes = Some(v);
+    self
+  }
+
+  /// Builder: set the membership admission ceiling to `v`. Leaving it unset
+  /// keeps the machine default (unlimited); see [`Self::max_members`].
+  #[must_use]
+  #[inline]
+  pub const fn with_max_members(mut self, v: usize) -> Self {
+    self.max_members = Some(v);
+    self
+  }
+
+  /// Builder: override the concurrent indirect-forward relay cap.
+  #[must_use]
+  #[inline]
+  pub const fn with_max_indirect_forwards(mut self, v: usize) -> Self {
+    self.max_indirect_forwards = Some(v);
+    self
+  }
+
+  /// Builder: set the concurrent inbound-stream ceiling to `v`. Leaving it unset
+  /// keeps the machine default (unlimited); see [`Self::max_inbound_streams`].
+  #[must_use]
+  #[inline]
+  pub const fn with_max_inbound_streams(mut self, v: usize) -> Self {
+    self.max_inbound_streams = Some(v);
+    self
+  }
+
+  /// Builder: override whether the ack payload is restricted to known members.
+  #[must_use]
+  #[inline]
+  pub const fn with_ack_payload_to_members_only(mut self, v: bool) -> Self {
+    self.ack_payload_to_members_only = Some(v);
+    self
+  }
+
+  /// The probe-interval override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn probe_interval(&self) -> Option<Duration> {
+    self.probe_interval
+  }
+
+  /// The probe-timeout override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn probe_timeout(&self) -> Option<Duration> {
+    self.probe_timeout
+  }
+
+  /// The gossip-interval override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn gossip_interval(&self) -> Option<Duration> {
+    self.gossip_interval
+  }
+
+  /// The gossip-to-the-dead-time override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn gossip_to_the_dead_time(&self) -> Option<Duration> {
+    self.gossip_to_the_dead_time
+  }
+
+  /// The dead-node-reclaim-time override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn dead_node_reclaim_time(&self) -> Option<Duration> {
+    self.dead_node_reclaim_time
+  }
+
+  /// The push/pull-interval override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn push_pull_interval(&self) -> Option<Duration> {
+    self.push_pull_interval
+  }
+
+  /// The stream-timeout override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn stream_timeout(&self) -> Option<Duration> {
+    self.stream_timeout
+  }
+
+  /// The accept-handshake-deadline override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn accept_handshake_deadline(&self) -> Option<Duration> {
+    self.accept_handshake_deadline
+  }
+
+  /// The suspicion-multiplier override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn suspicion_mult(&self) -> Option<u32> {
+    self.suspicion_mult
+  }
+
+  /// The suspicion-max-timeout-multiplier override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn suspicion_max_timeout_mult(&self) -> Option<u32> {
+    self.suspicion_max_timeout_mult
+  }
+
+  /// The awareness-max-multiplier override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn awareness_max_multiplier(&self) -> Option<u32> {
+    self.awareness_max_multiplier
+  }
+
+  /// The indirect-checks override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn indirect_checks(&self) -> Option<u32> {
+    self.indirect_checks
+  }
+
+  /// The retransmit-multiplier override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn retransmit_mult(&self) -> Option<u32> {
+    self.retransmit_mult
+  }
+
+  /// The gossip-nodes override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn gossip_nodes(&self) -> Option<usize> {
+    self.gossip_nodes
+  }
+
+  /// The membership admission ceiling override, if set. See
+  /// [`Self::max_members`].
+  #[must_use]
+  #[inline]
+  pub const fn max_members(&self) -> Option<usize> {
+    self.max_members
+  }
+
+  /// The concurrent indirect-forward relay-cap override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn max_indirect_forwards(&self) -> Option<usize> {
+    self.max_indirect_forwards
+  }
+
+  /// The concurrent inbound-stream ceiling override, if set. See
+  /// [`Self::max_inbound_streams`].
+  #[must_use]
+  #[inline]
+  pub const fn max_inbound_streams(&self) -> Option<usize> {
+    self.max_inbound_streams
+  }
+
+  /// The ack-payload-to-members-only override, if set.
+  #[must_use]
+  #[inline]
+  pub const fn ack_payload_to_members_only(&self) -> Option<bool> {
+    self.ack_payload_to_members_only
+  }
+
+  /// Layer every set override onto `cfg`, returning the result. Each unset knob
+  /// leaves the corresponding [`EndpointOptions`] value untouched, so a default
+  /// `EndpointTuning` returns `cfg` unchanged. This is the single copy-through
+  /// both standard drivers route their SWIM tuning through.
+  #[must_use]
+  pub fn apply_to<I, A>(&self, mut cfg: EndpointOptions<I, A>) -> EndpointOptions<I, A> {
+    if let Some(v) = self.probe_interval {
+      cfg = cfg.with_probe_interval(v);
+    }
+    if let Some(v) = self.probe_timeout {
+      cfg = cfg.with_probe_timeout(v);
+    }
+    if let Some(v) = self.gossip_interval {
+      cfg = cfg.with_gossip_interval(v);
+    }
+    if let Some(v) = self.gossip_to_the_dead_time {
+      cfg = cfg.with_gossip_to_the_dead_time(v);
+    }
+    if let Some(v) = self.dead_node_reclaim_time {
+      cfg = cfg.with_dead_node_reclaim_time(v);
+    }
+    if let Some(v) = self.push_pull_interval {
+      cfg = cfg.with_push_pull_interval(v);
+    }
+    if let Some(v) = self.stream_timeout {
+      cfg = cfg.with_stream_timeout(v);
+    }
+    if let Some(v) = self.accept_handshake_deadline {
+      cfg = cfg.with_accept_handshake_deadline(v);
+    }
+    if let Some(v) = self.suspicion_mult {
+      cfg = cfg.with_suspicion_mult(v);
+    }
+    if let Some(v) = self.suspicion_max_timeout_mult {
+      cfg = cfg.with_suspicion_max_timeout_mult(v);
+    }
+    if let Some(v) = self.awareness_max_multiplier {
+      cfg = cfg.with_awareness_max_multiplier(v);
+    }
+    if let Some(v) = self.indirect_checks {
+      cfg = cfg.with_indirect_checks(v);
+    }
+    if let Some(v) = self.retransmit_mult {
+      cfg = cfg.with_retransmit_mult(v);
+    }
+    if let Some(v) = self.gossip_nodes {
+      cfg = cfg.with_gossip_nodes(v);
+    }
+    if let Some(v) = self.max_members {
+      cfg = cfg.with_max_members(Some(v));
+    }
+    if let Some(v) = self.max_indirect_forwards {
+      cfg = cfg.with_max_indirect_forwards(v);
+    }
+    if let Some(v) = self.max_inbound_streams {
+      cfg = cfg.with_max_inbound_streams(Some(v));
+    }
+    if let Some(v) = self.ack_payload_to_members_only {
+      cfg = cfg.with_ack_payload_to_members_only(v);
+    }
+    cfg
+  }
+}
+
+// `clap::Args` is delegated to a private mirror rather than derived on the
+// public struct: a derived `update_from_arg_matches` treats every arg as present
+// and would reset an unset field, so a `try_update_from` carrying one unrelated
+// flag would wipe every other knob. The manual `update_from_arg_matches` applies
+// a field only when its value came from the command line or an env var. Every
+// field here is an `Option` with no clap default, so an unset flag is a no-op on
+// update. The ids/longs carry the `memberlist-` prefix so they compose with the
+// drivers' `--memberlist-*` family without colliding with proto's own
+// `endpoint-*` flags (which live on a different, un-composed command).
+#[cfg(feature = "clap")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clap")))]
+const _: () = {
+  use clap::{ArgMatches, Args, Command, Error, FromArgMatches, parser::ValueSource};
+
+  #[derive(Args)]
+  struct EndpointTuningCli {
+    #[arg(
+      id = "memberlist-probe-interval",
+      long = "memberlist-probe-interval",
+      env = "MEMBERLIST_PROBE_INTERVAL",
+      value_parser = humantime::parse_duration
+    )]
+    probe_interval: Option<Duration>,
+    #[arg(
+      id = "memberlist-probe-timeout",
+      long = "memberlist-probe-timeout",
+      env = "MEMBERLIST_PROBE_TIMEOUT",
+      value_parser = humantime::parse_duration
+    )]
+    probe_timeout: Option<Duration>,
+    #[arg(
+      id = "memberlist-gossip-interval",
+      long = "memberlist-gossip-interval",
+      env = "MEMBERLIST_GOSSIP_INTERVAL",
+      value_parser = humantime::parse_duration
+    )]
+    gossip_interval: Option<Duration>,
+    #[arg(
+      id = "memberlist-gossip-to-the-dead-time",
+      long = "memberlist-gossip-to-the-dead-time",
+      env = "MEMBERLIST_GOSSIP_TO_THE_DEAD_TIME",
+      value_parser = humantime::parse_duration
+    )]
+    gossip_to_the_dead_time: Option<Duration>,
+    #[arg(
+      id = "memberlist-dead-node-reclaim-time",
+      long = "memberlist-dead-node-reclaim-time",
+      env = "MEMBERLIST_DEAD_NODE_RECLAIM_TIME",
+      value_parser = humantime::parse_duration
+    )]
+    dead_node_reclaim_time: Option<Duration>,
+    #[arg(
+      id = "memberlist-push-pull-interval",
+      long = "memberlist-push-pull-interval",
+      env = "MEMBERLIST_PUSH_PULL_INTERVAL",
+      value_parser = humantime::parse_duration
+    )]
+    push_pull_interval: Option<Duration>,
+    #[arg(
+      id = "memberlist-stream-timeout",
+      long = "memberlist-stream-timeout",
+      env = "MEMBERLIST_STREAM_TIMEOUT",
+      value_parser = humantime::parse_duration
+    )]
+    stream_timeout: Option<Duration>,
+    #[arg(
+      id = "memberlist-accept-handshake-deadline",
+      long = "memberlist-accept-handshake-deadline",
+      env = "MEMBERLIST_ACCEPT_HANDSHAKE_DEADLINE",
+      value_parser = humantime::parse_duration
+    )]
+    accept_handshake_deadline: Option<Duration>,
+    #[arg(
+      id = "memberlist-suspicion-mult",
+      long = "memberlist-suspicion-mult",
+      env = "MEMBERLIST_SUSPICION_MULT"
+    )]
+    suspicion_mult: Option<u32>,
+    #[arg(
+      id = "memberlist-suspicion-max-timeout-mult",
+      long = "memberlist-suspicion-max-timeout-mult",
+      env = "MEMBERLIST_SUSPICION_MAX_TIMEOUT_MULT"
+    )]
+    suspicion_max_timeout_mult: Option<u32>,
+    #[arg(
+      id = "memberlist-awareness-max-multiplier",
+      long = "memberlist-awareness-max-multiplier",
+      env = "MEMBERLIST_AWARENESS_MAX_MULTIPLIER"
+    )]
+    awareness_max_multiplier: Option<u32>,
+    #[arg(
+      id = "memberlist-indirect-checks",
+      long = "memberlist-indirect-checks",
+      env = "MEMBERLIST_INDIRECT_CHECKS"
+    )]
+    indirect_checks: Option<u32>,
+    #[arg(
+      id = "memberlist-retransmit-mult",
+      long = "memberlist-retransmit-mult",
+      env = "MEMBERLIST_RETRANSMIT_MULT"
+    )]
+    retransmit_mult: Option<u32>,
+    #[arg(
+      id = "memberlist-gossip-nodes",
+      long = "memberlist-gossip-nodes",
+      env = "MEMBERLIST_GOSSIP_NODES"
+    )]
+    gossip_nodes: Option<usize>,
+    #[arg(
+      id = "memberlist-max-members",
+      long = "memberlist-max-members",
+      env = "MEMBERLIST_MAX_MEMBERS"
+    )]
+    max_members: Option<usize>,
+    #[arg(
+      id = "memberlist-max-indirect-forwards",
+      long = "memberlist-max-indirect-forwards",
+      env = "MEMBERLIST_MAX_INDIRECT_FORWARDS"
+    )]
+    max_indirect_forwards: Option<usize>,
+    #[arg(
+      id = "memberlist-max-inbound-streams",
+      long = "memberlist-max-inbound-streams",
+      env = "MEMBERLIST_MAX_INBOUND_STREAMS"
+    )]
+    max_inbound_streams: Option<usize>,
+    #[arg(
+      id = "memberlist-ack-payload-to-members-only",
+      long = "memberlist-ack-payload-to-members-only",
+      env = "MEMBERLIST_ACK_PAYLOAD_TO_MEMBERS_ONLY"
+    )]
+    ack_payload_to_members_only: Option<bool>,
+  }
+
+  impl From<EndpointTuningCli> for EndpointTuning {
+    fn from(c: EndpointTuningCli) -> Self {
+      Self {
+        probe_interval: c.probe_interval,
+        probe_timeout: c.probe_timeout,
+        gossip_interval: c.gossip_interval,
+        gossip_to_the_dead_time: c.gossip_to_the_dead_time,
+        dead_node_reclaim_time: c.dead_node_reclaim_time,
+        push_pull_interval: c.push_pull_interval,
+        stream_timeout: c.stream_timeout,
+        accept_handshake_deadline: c.accept_handshake_deadline,
+        suspicion_mult: c.suspicion_mult,
+        suspicion_max_timeout_mult: c.suspicion_max_timeout_mult,
+        awareness_max_multiplier: c.awareness_max_multiplier,
+        indirect_checks: c.indirect_checks,
+        retransmit_mult: c.retransmit_mult,
+        gossip_nodes: c.gossip_nodes,
+        max_members: c.max_members,
+        max_indirect_forwards: c.max_indirect_forwards,
+        max_inbound_streams: c.max_inbound_streams,
+        ack_payload_to_members_only: c.ack_payload_to_members_only,
+      }
+    }
+  }
+
+  impl Args for EndpointTuning {
+    fn augment_args(cmd: Command) -> Command {
+      EndpointTuningCli::augment_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: Command) -> Command {
+      EndpointTuningCli::augment_args_for_update(cmd)
+    }
+  }
+
+  impl FromArgMatches for EndpointTuning {
+    fn from_arg_matches(m: &ArgMatches) -> Result<Self, Error> {
+      EndpointTuningCli::from_arg_matches(m).map(Into::into)
+    }
+
+    fn update_from_arg_matches(&mut self, m: &ArgMatches) -> Result<(), Error> {
+      // Apply ONLY operator-supplied overrides — args whose value came from the
+      // command line or an env var, not an absent flag. Every field is an
+      // `Option` with no clap default, so an unset flag leaves the current value
+      // (including a builder-set one) untouched.
+      macro_rules! take_opt {
+        ($id:literal, $field:ident, $ty:ty) => {
+          if matches!(
+            m.value_source($id),
+            Some(ValueSource::CommandLine) | Some(ValueSource::EnvVariable)
+          ) {
+            self.$field = m.get_one::<$ty>($id).copied();
+          }
+        };
+      }
+      take_opt!("memberlist-probe-interval", probe_interval, Duration);
+      take_opt!("memberlist-probe-timeout", probe_timeout, Duration);
+      take_opt!("memberlist-gossip-interval", gossip_interval, Duration);
+      take_opt!(
+        "memberlist-gossip-to-the-dead-time",
+        gossip_to_the_dead_time,
+        Duration
+      );
+      take_opt!(
+        "memberlist-dead-node-reclaim-time",
+        dead_node_reclaim_time,
+        Duration
+      );
+      take_opt!(
+        "memberlist-push-pull-interval",
+        push_pull_interval,
+        Duration
+      );
+      take_opt!("memberlist-stream-timeout", stream_timeout, Duration);
+      take_opt!(
+        "memberlist-accept-handshake-deadline",
+        accept_handshake_deadline,
+        Duration
+      );
+      take_opt!("memberlist-suspicion-mult", suspicion_mult, u32);
+      take_opt!(
+        "memberlist-suspicion-max-timeout-mult",
+        suspicion_max_timeout_mult,
+        u32
+      );
+      take_opt!(
+        "memberlist-awareness-max-multiplier",
+        awareness_max_multiplier,
+        u32
+      );
+      take_opt!("memberlist-indirect-checks", indirect_checks, u32);
+      take_opt!("memberlist-retransmit-mult", retransmit_mult, u32);
+      take_opt!("memberlist-gossip-nodes", gossip_nodes, usize);
+      take_opt!("memberlist-max-members", max_members, usize);
+      take_opt!(
+        "memberlist-max-indirect-forwards",
+        max_indirect_forwards,
+        usize
+      );
+      take_opt!("memberlist-max-inbound-streams", max_inbound_streams, usize);
+      take_opt!(
+        "memberlist-ack-payload-to-members-only",
+        ack_payload_to_members_only,
+        bool
+      );
+      Ok(())
+    }
+  }
+};
+
+#[cfg(test)]
+mod tests;

--- a/memberlist-proto/src/config/tuning/tests.rs
+++ b/memberlist-proto/src/config/tuning/tests.rs
@@ -1,0 +1,335 @@
+use core::time::Duration;
+
+use super::EndpointTuning;
+use crate::config::EndpointOptions;
+
+#[test]
+fn endpoint_tuning_default_is_all_unset() {
+  let t = EndpointTuning::new();
+  assert_eq!(t, EndpointTuning::default());
+  assert_eq!(t.probe_interval(), None);
+  assert_eq!(t.probe_timeout(), None);
+  assert_eq!(t.gossip_interval(), None);
+  assert_eq!(t.gossip_to_the_dead_time(), None);
+  assert_eq!(t.dead_node_reclaim_time(), None);
+  assert_eq!(t.push_pull_interval(), None);
+  assert_eq!(t.stream_timeout(), None);
+  assert_eq!(t.accept_handshake_deadline(), None);
+  assert_eq!(t.suspicion_mult(), None);
+  assert_eq!(t.suspicion_max_timeout_mult(), None);
+  assert_eq!(t.awareness_max_multiplier(), None);
+  assert_eq!(t.indirect_checks(), None);
+  assert_eq!(t.retransmit_mult(), None);
+  assert_eq!(t.gossip_nodes(), None);
+  assert_eq!(t.max_members(), None);
+  assert_eq!(t.max_indirect_forwards(), None);
+  assert_eq!(t.max_inbound_streams(), None);
+  assert_eq!(t.ack_payload_to_members_only(), None);
+}
+
+#[test]
+fn endpoint_tuning_builders_round_trip_through_accessors() {
+  let t = EndpointTuning::new()
+    .with_probe_interval(Duration::from_secs(5))
+    .with_probe_timeout(Duration::from_millis(250))
+    .with_gossip_interval(Duration::from_millis(100))
+    .with_gossip_to_the_dead_time(Duration::from_secs(45))
+    .with_dead_node_reclaim_time(Duration::from_secs(60))
+    .with_push_pull_interval(Duration::from_secs(15))
+    .with_stream_timeout(Duration::from_secs(20))
+    .with_accept_handshake_deadline(Duration::from_secs(7))
+    .with_suspicion_mult(7)
+    .with_suspicion_max_timeout_mult(9)
+    .with_awareness_max_multiplier(5)
+    .with_indirect_checks(4)
+    .with_retransmit_mult(6)
+    .with_gossip_nodes(5)
+    .with_max_members(32)
+    .with_max_indirect_forwards(128)
+    .with_max_inbound_streams(64)
+    .with_ack_payload_to_members_only(true);
+
+  assert_eq!(t.probe_interval(), Some(Duration::from_secs(5)));
+  assert_eq!(t.probe_timeout(), Some(Duration::from_millis(250)));
+  assert_eq!(t.gossip_interval(), Some(Duration::from_millis(100)));
+  assert_eq!(t.gossip_to_the_dead_time(), Some(Duration::from_secs(45)));
+  assert_eq!(t.dead_node_reclaim_time(), Some(Duration::from_secs(60)));
+  assert_eq!(t.push_pull_interval(), Some(Duration::from_secs(15)));
+  assert_eq!(t.stream_timeout(), Some(Duration::from_secs(20)));
+  assert_eq!(t.accept_handshake_deadline(), Some(Duration::from_secs(7)));
+  assert_eq!(t.suspicion_mult(), Some(7));
+  assert_eq!(t.suspicion_max_timeout_mult(), Some(9));
+  assert_eq!(t.awareness_max_multiplier(), Some(5));
+  assert_eq!(t.indirect_checks(), Some(4));
+  assert_eq!(t.retransmit_mult(), Some(6));
+  assert_eq!(t.gossip_nodes(), Some(5));
+  assert_eq!(t.max_members(), Some(32));
+  assert_eq!(t.max_indirect_forwards(), Some(128));
+  assert_eq!(t.max_inbound_streams(), Some(64));
+  assert_eq!(t.ack_payload_to_members_only(), Some(true));
+}
+
+// The core parity regression: a fully-populated tuning (every value chosen to
+// differ from the machine default) applied over a fresh `EndpointOptions` must
+// move ALL 18 corresponding `EndpointOptions` accessors to the tuned value.
+// This locks the `apply_to` copy list — a knob dropped from `apply_to` would
+// leave its accessor at the default and fail here.
+#[test]
+fn endpoint_tuning_apply_to_overrides_every_knob() {
+  let t = EndpointTuning::new()
+    .with_probe_interval(Duration::from_secs(5))
+    .with_probe_timeout(Duration::from_millis(250))
+    .with_gossip_interval(Duration::from_millis(100))
+    .with_gossip_to_the_dead_time(Duration::from_secs(45))
+    .with_dead_node_reclaim_time(Duration::from_secs(60))
+    .with_push_pull_interval(Duration::from_secs(15))
+    .with_stream_timeout(Duration::from_secs(20))
+    .with_accept_handshake_deadline(Duration::from_secs(7))
+    .with_suspicion_mult(7)
+    .with_suspicion_max_timeout_mult(9)
+    .with_awareness_max_multiplier(5)
+    .with_indirect_checks(4)
+    .with_retransmit_mult(6)
+    .with_gossip_nodes(5)
+    .with_max_members(32)
+    .with_max_indirect_forwards(128)
+    .with_max_inbound_streams(64)
+    .with_ack_payload_to_members_only(true);
+
+  // Confirm every chosen value actually differs from the `EndpointOptions::new`
+  // default, so a passing assertion below cannot be a coincidence.
+  let base = EndpointOptions::<(), ()>::new((), ());
+  assert_ne!(base.probe_interval(), Duration::from_secs(5));
+  assert_ne!(base.probe_timeout(), Duration::from_millis(250));
+  assert_ne!(base.gossip_interval(), Duration::from_millis(100));
+  assert_ne!(base.gossip_to_the_dead_time(), Duration::from_secs(45));
+  assert_ne!(base.dead_node_reclaim_time(), Duration::from_secs(60));
+  assert_ne!(base.push_pull_interval(), Duration::from_secs(15));
+  assert_ne!(base.stream_timeout(), Duration::from_secs(20));
+  assert_ne!(base.accept_handshake_deadline(), Duration::from_secs(7));
+  assert_ne!(base.suspicion_mult(), 7);
+  assert_ne!(base.suspicion_max_timeout_mult(), 9);
+  assert_ne!(base.awareness_max_multiplier(), 5);
+  assert_ne!(base.indirect_checks(), 4);
+  assert_ne!(base.retransmit_mult(), 6);
+  assert_ne!(base.gossip_nodes(), 5);
+  assert_ne!(base.max_members(), Some(32));
+  assert_ne!(base.max_indirect_forwards(), 128);
+  assert_ne!(base.max_inbound_streams(), Some(64));
+  assert!(!base.ack_payload_to_members_only());
+
+  let cfg = t.apply_to(EndpointOptions::<(), ()>::new((), ()));
+  assert_eq!(cfg.probe_interval(), Duration::from_secs(5));
+  assert_eq!(cfg.probe_timeout(), Duration::from_millis(250));
+  assert_eq!(cfg.gossip_interval(), Duration::from_millis(100));
+  assert_eq!(cfg.gossip_to_the_dead_time(), Duration::from_secs(45));
+  assert_eq!(cfg.dead_node_reclaim_time(), Duration::from_secs(60));
+  assert_eq!(cfg.push_pull_interval(), Duration::from_secs(15));
+  assert_eq!(cfg.stream_timeout(), Duration::from_secs(20));
+  assert_eq!(cfg.accept_handshake_deadline(), Duration::from_secs(7));
+  assert_eq!(cfg.suspicion_mult(), 7);
+  assert_eq!(cfg.suspicion_max_timeout_mult(), 9);
+  assert_eq!(cfg.awareness_max_multiplier(), 5);
+  assert_eq!(cfg.indirect_checks(), 4);
+  assert_eq!(cfg.retransmit_mult(), 6);
+  assert_eq!(cfg.gossip_nodes(), 5);
+  assert_eq!(cfg.max_members(), Some(32));
+  assert_eq!(cfg.max_indirect_forwards(), 128);
+  assert_eq!(cfg.max_inbound_streams(), Some(64));
+  assert!(cfg.ack_payload_to_members_only());
+}
+
+// The byte-identical-when-unset guarantee: a default (all-unset) tuning applied
+// over a fresh `EndpointOptions` leaves every one of the 18 knobs at the exact
+// `EndpointOptions::new` default.
+#[test]
+fn endpoint_tuning_apply_to_unset_leaves_machine_defaults() {
+  let base = EndpointOptions::<(), ()>::new((), ());
+  let cfg = EndpointTuning::new().apply_to(EndpointOptions::<(), ()>::new((), ()));
+
+  assert_eq!(cfg.probe_interval(), base.probe_interval());
+  assert_eq!(cfg.probe_timeout(), base.probe_timeout());
+  assert_eq!(cfg.gossip_interval(), base.gossip_interval());
+  assert_eq!(
+    cfg.gossip_to_the_dead_time(),
+    base.gossip_to_the_dead_time()
+  );
+  assert_eq!(cfg.dead_node_reclaim_time(), base.dead_node_reclaim_time());
+  assert_eq!(cfg.push_pull_interval(), base.push_pull_interval());
+  assert_eq!(cfg.stream_timeout(), base.stream_timeout());
+  assert_eq!(
+    cfg.accept_handshake_deadline(),
+    base.accept_handshake_deadline()
+  );
+  assert_eq!(cfg.suspicion_mult(), base.suspicion_mult());
+  assert_eq!(
+    cfg.suspicion_max_timeout_mult(),
+    base.suspicion_max_timeout_mult()
+  );
+  assert_eq!(
+    cfg.awareness_max_multiplier(),
+    base.awareness_max_multiplier()
+  );
+  assert_eq!(cfg.indirect_checks(), base.indirect_checks());
+  assert_eq!(cfg.retransmit_mult(), base.retransmit_mult());
+  assert_eq!(cfg.gossip_nodes(), base.gossip_nodes());
+  assert_eq!(cfg.max_members(), base.max_members());
+  assert_eq!(cfg.max_indirect_forwards(), base.max_indirect_forwards());
+  assert_eq!(cfg.max_inbound_streams(), base.max_inbound_streams());
+  assert_eq!(
+    cfg.ack_payload_to_members_only(),
+    base.ack_payload_to_members_only()
+  );
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn endpoint_tuning_serde_round_trip_and_partial() {
+  // `{}` deserializes to the full default (every knob unset).
+  let from_empty = serde_json::from_str::<EndpointTuning>("{}").unwrap();
+  assert_eq!(from_empty, EndpointTuning::new());
+
+  let t = EndpointTuning::new()
+    .with_probe_interval(Duration::from_secs(2))
+    .with_suspicion_mult(9)
+    .with_max_members(500)
+    .with_ack_payload_to_members_only(true);
+  let json = serde_json::to_string(&t).unwrap();
+  // Durations render as humantime strings, not {"secs":..,"nanos":..}.
+  assert!(json.contains("\"probe_interval\":\"2s\""), "json = {json}");
+  // An unset Duration serializes as null (no skip_serializing_if).
+  assert!(json.contains("\"probe_timeout\":null"), "json = {json}");
+
+  let back = serde_json::from_str::<EndpointTuning>(&json).unwrap();
+  assert_eq!(back, t);
+  assert_eq!(back.probe_interval(), Some(Duration::from_secs(2)));
+  assert_eq!(back.suspicion_mult(), Some(9));
+  assert_eq!(back.max_members(), Some(500));
+  assert_eq!(back.ack_payload_to_members_only(), Some(true));
+  assert_eq!(back.probe_timeout(), None);
+
+  // A partial config carries one knob; the rest stay unset.
+  let partial: EndpointTuning = serde_json::from_str(r#"{"gossip_nodes":7}"#).unwrap();
+  assert_eq!(partial.gossip_nodes(), Some(7));
+  assert_eq!(partial.probe_interval(), None);
+  assert_eq!(partial.suspicion_mult(), None);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn endpoint_tuning_serde_rejects_unknown_field() {
+  // A misspelled knob (`probe_intervl`) must be rejected, not silently dropped.
+  assert!(serde_json::from_str::<EndpointTuning>(r#"{"probe_intervl":"2s"}"#).is_err());
+}
+
+#[cfg(feature = "clap")]
+#[test]
+fn endpoint_tuning_clap_parses_and_wires_env() {
+  use clap::{CommandFactory, Parser};
+
+  #[derive(Parser)]
+  struct Cli {
+    #[command(flatten)]
+    tuning: EndpointTuning,
+  }
+
+  let cli = Cli::try_parse_from([
+    "app",
+    "--memberlist-probe-interval",
+    "5s",
+    "--memberlist-suspicion-mult",
+    "7",
+    "--memberlist-max-members",
+    "32",
+    "--memberlist-max-inbound-streams",
+    "64",
+    "--memberlist-ack-payload-to-members-only",
+    "true",
+  ])
+  .unwrap();
+  assert_eq!(cli.tuning.probe_interval(), Some(Duration::from_secs(5)));
+  assert_eq!(cli.tuning.suspicion_mult(), Some(7));
+  assert_eq!(cli.tuning.max_members(), Some(32));
+  assert_eq!(cli.tuning.max_inbound_streams(), Some(64));
+  assert_eq!(cli.tuning.ack_payload_to_members_only(), Some(true));
+
+  // Unspecified knobs stay unset.
+  let bare = Cli::try_parse_from(["app"]).unwrap();
+  assert_eq!(bare.tuning.probe_interval(), None);
+  assert_eq!(bare.tuning.suspicion_mult(), None);
+  assert_eq!(bare.tuning.max_members(), None);
+  assert_eq!(bare.tuning.ack_payload_to_members_only(), None);
+
+  // Env wired (introspect the command; never set_var).
+  let cmd = Cli::command();
+  let arg = cmd
+    .get_arguments()
+    .find(|a| a.get_id().as_str() == "memberlist-probe-interval")
+    .expect("memberlist-probe-interval arg is registered");
+  assert_eq!(
+    arg.get_env().and_then(|e| e.to_str()),
+    Some("MEMBERLIST_PROBE_INTERVAL")
+  );
+}
+
+#[cfg(feature = "clap")]
+#[test]
+fn endpoint_tuning_clap_update_preserves_unoverridden_fields() {
+  use clap::Parser;
+
+  #[derive(Parser)]
+  struct Cli {
+    #[command(flatten)]
+    tuning: EndpointTuning,
+  }
+
+  let base = || {
+    EndpointTuning::new()
+      .with_probe_interval(Duration::from_secs(5))
+      .with_max_members(32)
+      .with_suspicion_mult(7)
+  };
+
+  // A partial update (only gossip_nodes) leaves the builder-seeded fields intact
+  // — clap's defaulted-arg-looks-present behavior must not reset the unset ones.
+  let mut cli = Cli { tuning: base() };
+  cli
+    .try_update_from(["app", "--memberlist-gossip-nodes", "9"])
+    .expect("update");
+  assert_eq!(
+    cli.tuning.gossip_nodes(),
+    Some(9),
+    "the supplied override is applied"
+  );
+  assert_eq!(
+    cli.tuning.probe_interval(),
+    Some(Duration::from_secs(5)),
+    "seeded probe_interval survives"
+  );
+  assert_eq!(
+    cli.tuning.max_members(),
+    Some(32),
+    "seeded max_members survives"
+  );
+  assert_eq!(
+    cli.tuning.suspicion_mult(),
+    Some(7),
+    "seeded suspicion_mult survives"
+  );
+
+  // An explicitly-supplied override IS still applied.
+  let mut cli2 = Cli { tuning: base() };
+  cli2
+    .try_update_from(["app", "--memberlist-suspicion-mult", "11"])
+    .expect("update");
+  assert_eq!(
+    cli2.tuning.suspicion_mult(),
+    Some(11),
+    "an explicit override is applied"
+  );
+  assert_eq!(
+    cli2.tuning.probe_interval(),
+    Some(Duration::from_secs(5)),
+    "the unrelated seeded probe_interval survives"
+  );
+}

--- a/memberlist-proto/src/lib.rs
+++ b/memberlist-proto/src/lib.rs
@@ -153,7 +153,7 @@ pub use broadcast::{
 #[cfg(feature = "cidr")]
 #[cfg_attr(docsrs, doc(cfg(feature = "cidr")))]
 pub use cidr::{CidrAnd, CidrPolicy};
-pub use config::{DEFAULT_GOSSIP_MTU, EndpointOptions};
+pub use config::{DEFAULT_GOSSIP_MTU, EndpointOptions, EndpointTuning};
 pub use delegate::{AliveDelegate, MergeDelegate};
 pub use endpoint::{Endpoint, Lifecycle, META_MAX_SIZE};
 pub use error::{EndpointInitError, Error, SizeExceeded, StreamError, UserDialBacklogFull};

--- a/memberlist-reactor/src/lib.rs
+++ b/memberlist-reactor/src/lib.rs
@@ -55,7 +55,7 @@ pub(crate) fn gossip_rng() -> Result<StdRng, crate::Error> {
 }
 
 pub use error::{Error, GossipMtuTooSmall, InvalidGossipMtu, InvalidOption, JoinFailed};
-pub use memberlist_proto::{EndpointInitError, LabelError, MaybeResolved};
+pub use memberlist_proto::{EndpointInitError, EndpointTuning, LabelError, MaybeResolved};
 pub use options::{
   Channel, DEFAULT_CLOSE_TIMEOUT, DEFAULT_EVENT_STREAM_CAPACITY, DEFAULT_JOIN_DEADLINE,
   DEFAULT_OBSERVATION_CHANNEL_CAPACITY, DEFAULT_RECV_BATCH, DEFAULT_TRANSMIT_BATCH,

--- a/memberlist-reactor/src/memberlist.rs
+++ b/memberlist-reactor/src/memberlist.rs
@@ -98,7 +98,7 @@ where
 }
 
 /// Layers the [`MemberlistOptions`] overrides onto a machine [`EndpointOptions`].
-fn apply_memberlist_options<I, A>(
+pub(crate) fn apply_memberlist_options<I, A>(
   mut cfg: EndpointOptions<I, A>,
   opts: &MemberlistOptions,
 ) -> EndpointOptions<I, A> {
@@ -117,6 +117,9 @@ fn apply_memberlist_options<I, A>(
   if let Some(state) = opts.initial_local_state() {
     cfg = cfg.with_initial_local_state(state.clone());
   }
+  // The SWIM tuning overrides copy through last; their knob set is disjoint from
+  // the size / payload knobs above, so the order does not matter.
+  cfg = opts.tuning().apply_to(cfg);
   cfg
 }
 

--- a/memberlist-reactor/src/options/builder_tests.rs
+++ b/memberlist-reactor/src/options/builder_tests.rs
@@ -65,6 +65,58 @@ fn memberlist_options_default_leaves_every_override_unset() {
   let _checksum = opts.checksum();
   #[cfg(encryption)]
   let _encryption = opts.encryption();
+  // The nested tuning section defaults to all-unset.
+  assert_eq!(opts.tuning().probe_interval(), None);
+  assert_eq!(opts.tuning().max_members(), None);
+}
+
+#[test]
+fn memberlist_options_tuning_builder_round_trips() {
+  use memberlist_proto::EndpointTuning;
+
+  let opts = MemberlistOptions::new().with_tuning(
+    EndpointTuning::new()
+      .with_probe_interval(Duration::from_secs(5))
+      .with_max_members(32)
+      .with_suspicion_mult(7),
+  );
+  assert_eq!(opts.tuning().probe_interval(), Some(Duration::from_secs(5)));
+  assert_eq!(opts.tuning().max_members(), Some(32));
+  assert_eq!(opts.tuning().suspicion_mult(), Some(7));
+  // A field the builder did not touch stays unset.
+  assert_eq!(opts.tuning().gossip_nodes(), None);
+  // The default carries an all-unset tuning section.
+  assert_eq!(MemberlistOptions::new().tuning().probe_interval(), None);
+}
+
+// The driver-seam assertion: the returned `EndpointOptions` is verbatim what
+// `Endpoint::try_new` receives, so exercising the real
+// `apply_memberlist_options` proves the tuning overrides travel the driver path.
+#[test]
+fn apply_memberlist_options_installs_tuning_overrides() {
+  use crate::memberlist::apply_memberlist_options;
+  use memberlist_proto::{EndpointOptions, EndpointTuning};
+
+  let opts = MemberlistOptions::new().with_tuning(
+    EndpointTuning::new()
+      .with_probe_interval(Duration::from_secs(5))
+      .with_max_members(32)
+      .with_suspicion_mult(7),
+  );
+  let cfg = apply_memberlist_options(EndpointOptions::<(), ()>::new((), ()), &opts);
+  assert_eq!(cfg.probe_interval(), Duration::from_secs(5));
+  assert_eq!(cfg.max_members(), Some(32));
+  assert_eq!(cfg.suspicion_mult(), 7);
+
+  // The unset arm: no tuning overrides ⇒ every knob keeps the machine default.
+  let base = EndpointOptions::<(), ()>::new((), ());
+  let cfg_default = apply_memberlist_options(
+    EndpointOptions::<(), ()>::new((), ()),
+    &MemberlistOptions::new(),
+  );
+  assert_eq!(cfg_default.probe_interval(), base.probe_interval());
+  assert_eq!(cfg_default.max_members(), base.max_members());
+  assert_eq!(cfg_default.suspicion_mult(), base.suspicion_mult());
 }
 
 #[cfg(all(compression, encryption))]
@@ -303,26 +355,45 @@ fn channel_serde_is_tagged_snake_case() {
 #[cfg(feature = "serde")]
 #[test]
 fn memberlist_options_serde_round_trip_and_partial() {
+  use memberlist_proto::EndpointTuning;
+
   // An empty config deserializes to the full default (every override unset).
   let from_empty = serde_json::from_str::<MemberlistOptions>("{}").unwrap();
   assert_eq!(from_empty.gossip_mtu(), None);
   assert_eq!(from_empty.meta_max_size(), None);
   assert!(!from_empty.skip_inbound_label_check());
+  // The nested tuning section deserializes to its all-unset default too.
+  assert_eq!(from_empty.tuning().probe_interval(), None);
+  assert_eq!(from_empty.tuning().max_members(), None);
 
   // A configured subset round-trips, and an omitted field stays default.
   let opts = MemberlistOptions::new()
     .with_gossip_mtu(1400)
-    .with_skip_inbound_label_check(true);
+    .with_skip_inbound_label_check(true)
+    .with_tuning(
+      EndpointTuning::new()
+        .with_probe_interval(Duration::from_secs(2))
+        .with_max_members(64),
+    );
   let json = serde_json::to_string(&opts).unwrap();
   let back = serde_json::from_str::<MemberlistOptions>(&json).unwrap();
   assert_eq!(back.gossip_mtu(), Some(1400));
   assert!(back.skip_inbound_label_check());
   assert_eq!(back.meta_max_size(), None);
+  // The nested tuning knobs survive the round-trip.
+  assert_eq!(back.tuning().probe_interval(), Some(Duration::from_secs(2)));
+  assert_eq!(back.tuning().max_members(), Some(64));
 
-  // A partial config fills the rest from the default.
-  let partial = serde_json::from_str::<MemberlistOptions>(r#"{"meta_max_size":512}"#).unwrap();
+  // A partial config fills the rest from the default — including a `tuning`
+  // section that carries only one knob.
+  let partial = serde_json::from_str::<MemberlistOptions>(
+    r#"{"meta_max_size":512,"tuning":{"suspicion_mult":9}}"#,
+  )
+  .unwrap();
   assert_eq!(partial.meta_max_size(), Some(512));
   assert_eq!(partial.gossip_mtu(), None);
+  assert_eq!(partial.tuning().suspicion_mult(), Some(9));
+  assert_eq!(partial.tuning().probe_interval(), None);
 }
 
 #[cfg(feature = "serde")]
@@ -386,22 +457,33 @@ fn memberlist_options_clap_parses_and_wires_env() {
     memberlist: MemberlistOptions,
   }
 
-  // The scalar flags parse; the bool is a flag.
+  // The scalar flags parse; the bool is a flag; the flattened tuning flags parse.
   let cli = Cli::try_parse_from([
     "app",
     "--memberlist-gossip-mtu",
     "1400",
     "--memberlist-skip-inbound-label-check",
+    "--memberlist-probe-interval",
+    "5s",
+    "--memberlist-max-members",
+    "32",
   ])
   .unwrap();
   assert_eq!(cli.memberlist.gossip_mtu(), Some(1400));
   assert!(cli.memberlist.skip_inbound_label_check());
+  assert_eq!(
+    cli.memberlist.tuning().probe_interval(),
+    Some(Duration::from_secs(5))
+  );
+  assert_eq!(cli.memberlist.tuning().max_members(), Some(32));
   // Unspecified stays default.
   let bare = Cli::try_parse_from(["app"]).unwrap();
   assert_eq!(bare.memberlist.gossip_mtu(), None);
   assert!(!bare.memberlist.skip_inbound_label_check());
+  assert_eq!(bare.memberlist.tuning().probe_interval(), None);
 
   // The env var is wired — assert via command introspection, never `set_var`.
+  // Check both an own flag and a flattened tuning flag.
   let cmd = Cli::command();
   let arg = cmd
     .get_arguments()
@@ -410,6 +492,14 @@ fn memberlist_options_clap_parses_and_wires_env() {
   assert_eq!(
     arg.get_env().and_then(|e| e.to_str()),
     Some("MEMBERLIST_GOSSIP_MTU")
+  );
+  let tuning_arg = cmd
+    .get_arguments()
+    .find(|a| a.get_id().as_str() == "memberlist-probe-interval")
+    .expect("memberlist-probe-interval arg is registered");
+  assert_eq!(
+    tuning_arg.get_env().and_then(|e| e.to_str()),
+    Some("MEMBERLIST_PROBE_INTERVAL")
   );
 }
 
@@ -545,12 +635,19 @@ fn memberlist_options_clap_update_preserves_unoverridden_fields() {
     memberlist: MemberlistOptions,
   }
 
+  use memberlist_proto::EndpointTuning;
+
   let base = || {
     let opts = MemberlistOptions::new()
       .with_gossip_mtu(1400)
       .with_skip_inbound_label_check(true)
       .with_label(Some(b"team-a".to_vec()))
-      .expect("valid label");
+      .expect("valid label")
+      .with_tuning(
+        EndpointTuning::new()
+          .with_probe_interval(Duration::from_secs(5))
+          .with_max_members(32),
+      );
     #[cfg(compression)]
     let opts = opts.with_compression(
       crate::CompressionOptions::new().with_algorithm(crate::CompressAlgorithm::Lz4),
@@ -578,6 +675,18 @@ fn memberlist_options_clap_update_preserves_unoverridden_fields() {
     cli.memberlist.label(),
     Some(b"team-a".as_slice()),
     "non-default label survives"
+  );
+  // The flattened tuning child's seeded knobs survive a partial parent update —
+  // the "an unrelated flag must not reset nested tuning" guarantee.
+  assert_eq!(
+    cli.memberlist.tuning().probe_interval(),
+    Some(Duration::from_secs(5)),
+    "the flattened tuning child's probe_interval survives a partial parent update"
+  );
+  assert_eq!(
+    cli.memberlist.tuning().max_members(),
+    Some(32),
+    "the flattened tuning child's max_members survives a partial parent update"
   );
   #[cfg(compression)]
   assert_eq!(

--- a/memberlist-reactor/src/options/mod.rs
+++ b/memberlist-reactor/src/options/mod.rs
@@ -10,7 +10,9 @@ use memberlist_proto::ChecksumOptions;
 use memberlist_proto::CompressionOptions;
 #[cfg(encryption)]
 use memberlist_proto::EncryptionOptions;
-use memberlist_proto::{AliveDelegate, MergeDelegate, label::validate_label, typed::Meta};
+use memberlist_proto::{
+  AliveDelegate, EndpointTuning, MergeDelegate, label::validate_label, typed::Meta,
+};
 
 use crate::cidr::CidrFilter;
 
@@ -26,6 +28,10 @@ use crate::cidr::CidrFilter;
 /// - `meta_max_size` — the local node's `Meta` byte ceiling (a broadcast-size
 ///   cap, not a peer-rejection filter).
 /// - `max_stream_frame_size` — the reliable-stream frame ceiling.
+/// - `tuning` — the SWIM-behavioral tuning knobs (probe / suspicion / gossip
+///   cadence, membership admission ceilings) carried through to the machine via
+///   [`EndpointTuning`](memberlist_proto::EndpointTuning). Every knob defaults
+///   to unset (the machine default).
 /// - `initial_meta` — the local node's initial metadata payload.
 /// - `initial_local_state` — the local node's initial push/pull state snapshot.
 /// - `compression` — the initial gossip+stream compression policy (disabled by
@@ -52,6 +58,12 @@ pub struct MemberlistOptions {
   gossip_mtu: Option<usize>,
   meta_max_size: Option<usize>,
   max_stream_frame_size: Option<usize>,
+  // The SWIM-behavioral tuning knobs (probe / suspicion / gossip cadence,
+  // membership ceilings). A nested section whose every field is an unset
+  // override by default, layered onto the machine `EndpointOptions` via
+  // `EndpointTuning::apply_to`. Container `serde(default)` makes a missing
+  // `tuning` key deserialize to the all-unset default.
+  tuning: EndpointTuning,
   // A binary metadata payload: not a sensible config-file or CLI value, so it is
   // left to the validating `with_initial_meta` builder and skipped by both
   // layers (`Option<Meta>` defaults to `None` on deserialize).
@@ -115,6 +127,8 @@ const _: () = {
       env = "MEMBERLIST_MAX_STREAM_FRAME_SIZE"
     )]
     max_stream_frame_size: Option<usize>,
+    #[command(flatten)]
+    tuning: EndpointTuning,
     #[cfg(compression)]
     #[command(flatten)]
     compression: CompressionOptions,
@@ -145,6 +159,7 @@ const _: () = {
         gossip_mtu: c.gossip_mtu,
         meta_max_size: c.meta_max_size,
         max_stream_frame_size: c.max_stream_frame_size,
+        tuning: c.tuning,
         initial_meta: None,
         initial_local_state: None,
         #[cfg(compression)]
@@ -218,6 +233,7 @@ const _: () = {
       // Each flattened child applies its own operator-supplied overrides through
       // its own `value_source` gate, so an unrelated parent flag never resets a
       // child's fields.
+      self.tuning.update_from_arg_matches(m)?;
       #[cfg(compression)]
       self.compression.update_from_arg_matches(m)?;
       #[cfg(checksum)]
@@ -306,6 +322,16 @@ impl MemberlistOptions {
   #[must_use]
   pub fn with_max_stream_frame_size(mut self, size: usize) -> Self {
     self.max_stream_frame_size = Some(size);
+    self
+  }
+
+  /// Sets the SWIM-behavioral tuning knobs (probe / suspicion / gossip cadence,
+  /// membership admission ceilings) carried through to the machine. Each unset
+  /// knob leaves the machine default; see
+  /// [`EndpointTuning`](memberlist_proto::EndpointTuning).
+  #[must_use]
+  pub fn with_tuning(mut self, tuning: EndpointTuning) -> Self {
+    self.tuning = tuning;
     self
   }
 
@@ -421,6 +447,12 @@ impl MemberlistOptions {
   #[must_use]
   pub const fn max_stream_frame_size(&self) -> Option<usize> {
     self.max_stream_frame_size
+  }
+
+  /// The SWIM-behavioral tuning knobs carried through to the machine.
+  #[must_use]
+  pub const fn tuning(&self) -> &EndpointTuning {
+    &self.tuning
   }
 
   /// The configured initial `Meta`, if set.

--- a/memberlist-reactor/tests/tuning_install.rs
+++ b/memberlist-reactor/tests/tuning_install.rs
@@ -1,0 +1,63 @@
+//! End-to-end proof that `MemberlistOptions::tuning` travels the real standard
+//! driver path into the machine's `Endpoint::try_new`.
+//!
+//! `awareness_max_multiplier = 0` is the one newly-exposed tuning knob the
+//! machine rejects at construction. Building a node through the ordinary
+//! `tcp(...)` constructor with that value must surface the machine's
+//! `EndpointInitError::AwarenessMultiplierZero` — which can only happen if the
+//! tuning override was copied into the `EndpointOptions` that `try_new` received.
+//! A sane value constructs cleanly through the same path.
+
+#![cfg(feature = "tcp")]
+
+use std::net::SocketAddr;
+
+use agnostic::tokio::TokioRuntime;
+use memberlist_reactor::{
+  EndpointInitError, EndpointTuning, Error, MaybeResolved, Memberlist, MemberlistOptions, Options,
+  SocketAddrResolver, VoidDelegate,
+};
+use smol_str::SmolStr;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tcp_tuning_awareness_multiplier_zero_fails_construction() {
+  let options = Options::new().with_memberlist(
+    MemberlistOptions::new().with_tuning(EndpointTuning::new().with_awareness_max_multiplier(0)),
+  );
+  let res = Memberlist::<SmolStr, _, TokioRuntime>::tcp(
+    &SocketAddrResolver,
+    SmolStr::new("node-zero"),
+    MaybeResolved::Resolved("127.0.0.1:0".parse::<SocketAddr>().unwrap()),
+    options,
+    VoidDelegate::<SmolStr, SocketAddr>::new(),
+  )
+  .await;
+  assert!(
+    matches!(
+      res,
+      Err(Error::EndpointInit(
+        EndpointInitError::AwarenessMultiplierZero
+      ))
+    ),
+    "awareness_max_multiplier=0 in tuning must fail construction via the machine's try_new"
+  );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tcp_tuning_sane_awareness_multiplier_constructs() {
+  let options = Options::new().with_memberlist(
+    MemberlistOptions::new().with_tuning(EndpointTuning::new().with_awareness_max_multiplier(4)),
+  );
+  let m = Memberlist::<SmolStr, _, TokioRuntime>::tcp(
+    &SocketAddrResolver,
+    SmolStr::new("node-ok"),
+    MaybeResolved::Resolved("127.0.0.1:0".parse::<SocketAddr>().unwrap()),
+    options,
+    VoidDelegate::<SmolStr, SocketAddr>::new(),
+  )
+  .await
+  .expect("a nonzero awareness multiplier constructs cleanly through the same path");
+  // Ignoring Err: best-effort teardown after the construction assertion; a
+  // shutdown error would not change what this test proves.
+  let _ = m.shutdown().await;
+}


### PR DESCRIPTION
## #172 F4 — expose canonical SWIM tuning through the standard drivers via a shared `EndpointTuning`

The standard drivers' `apply_memberlist_options` copied only 5 of `EndpointOptions`'s 27 knobs, so a node built through the standard construction path (`memberlist::tokio::tcp(...)`, compio `Memberlist::new`, …) was stuck at machine defaults for the entire SWIM/Lifeguard tuning surface — `probe_interval`, `probe_timeout`, suspicion/awareness multipliers, gossip cadence, `max_members`, and more were unreachable.

### Fix — a shared `EndpointTuning` type in proto, with the copy-through *in proto*
- **`memberlist-proto/src/config/tuning.rs`**: a new generic-free `EndpointTuning` with **18** `Option<T>` knobs (presence semantics — unset means "use the machine default"), builders/getters, and `apply_to<I,A>(cfg) -> EndpointOptions<I,A>` — the single `if let Some(v) … with_v(v)` copy-through. Because it lives in proto, a future knob is added in **one** place, structurally ending the parity-drift class rather than patching this instance.
- **Both drivers** gain a nested `tuning` section in `MemberlistOptions` (builder + getter + clap child-delegation), and each `apply_memberlist_options` appends `opts.tuning().apply_to(cfg)`.
- **serde**: nested section with `serde(default, deny_unknown_fields)` + `humantime_serde` on Durations — **not** `flatten` (which cannot combine with `deny_unknown_fields`), following the existing `CompressionOptions` template. A missing `tuning` key yields all-`None` (additive back-compat); an unknown tuning field is rejected.
- **clap**: a private `EndpointTuningCli` mirror with value-source-gated partial update (an unrelated flag never resets nested tuning), `--memberlist-<field>` longs / `MEMBERLIST_<FIELD>` envs.
- **compio validator**: compio constructs the machine via the *panicking* `Endpoint::new` on a detached task, so the one newly-reachable `EndpointInitError` (`awareness_max_multiplier == 0`) is rejected up front by `validate_endpoint_tuning` in `Memberlist::new`. Reactor uses the fallible `Endpoint::try_new` and needs no validator. All other new knobs are total inputs (zero durations = defined disable semantics; `gossip_nodes == 0` disables gossip; degenerate multipliers are legal tuning extremes).

### Exposed 18 of 22; 4 excluded (principled)
`protocol_version` / `delegate_version` (wire-negotiation identity, V1-only), `initial_incarnation` (crash-restart identity — and `with_initial_incarnation` *panics* above `u32::MAX/2`, which would convert operator input into a panic in compio's detached task), and `user_broadcast_tiers` (gates a ranked-broadcast API neither driver exposes — dead config). Embedders needing the excluded knobs use proto's public `EndpointOptions` directly.

### Byte-identical when unset, no wire change
A node that sets no tuning carries `EndpointTuning::default()` (all `None`); `apply_to` mutates nothing, so the `EndpointOptions` handed to the machine is field-identical to today's (locked by `endpoint_tuning_apply_to_unset_leaves_machine_defaults`). No wire-format change; the umbrella facade still compiles; existing `MemberlistOptions` construction is unbroken.
