### PR TITLE
test(fuzz): drive the inbound pipeline and AEAD decrypt path + add a fuzz CI gate (#169 findings 4-5)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,82 @@
+name: fuzz
+
+# Builds and briefly smoke-runs the memberlist-proto fuzz targets — the
+# untrusted-input parsers a single inbound datagram reaches before any
+# authentication. The fuzz crate is its own workspace (it needs nightly + the
+# sanitizer runtime), so it is never reached by the other jobs' `--workspace`
+# builds; without this gate a target that fails to compile, or panics on a
+# discovered input, is caught by nobody. The push/PR gate is a fast build plus a
+# short bounded run per target; the nightly schedule fuzzes each target longer.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "memberlist-proto/**"
+      - ".github/workflows/fuzz.yml"
+  pull_request:
+    paths:
+      - "memberlist-proto/**"
+      - ".github/workflows/fuzz.yml"
+  workflow_dispatch:
+  schedule: [cron: "0 3 * * *"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fuzz:
+    name: build + smoke
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            memberlist-proto/fuzz/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('memberlist-proto/fuzz/Cargo.toml', 'memberlist-proto/Cargo.toml') }}-fuzz
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cargo-fuzz
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
+
+      - name: Build all fuzz targets
+        # The core gate: every target must compile under nightly + the sanitizer
+        # runtime. This alone closes the "targets never compile-checked" gap.
+        run: cargo +nightly fuzz build --fuzz-dir memberlist-proto/fuzz
+
+      - name: Smoke run each target
+        # A short bounded run per target as a regression gate: fail loud if a
+        # target panics or aborts on a discovered input. The nightly schedule
+        # fuzzes each target far longer; the push/PR gate stays brief.
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            duration=300
+          else
+            duration=30
+          fi
+          for target in parse_messages decode_compound decode_incoming unwrap_transforms; do
+            echo "::group::fuzz ${target} (${duration}s)"
+            cargo +nightly fuzz run --fuzz-dir memberlist-proto/fuzz "${target}" -- \
+              -max_total_time="${duration}" -rss_limit_mb=4096
+            echo "::endgroup::"
+          done

--- a/memberlist-proto/fuzz/README.md
+++ b/memberlist-proto/fuzz/README.md
@@ -9,8 +9,8 @@ or unbounded allocation.
 |---|---|
 | `parse_messages` | the compound / single-message parser (count + part-length prefixes) |
 | `decode_compound` | the compound splitter (count-vs-remaining bound before allocation) |
-| `decode_incoming` | inbound cluster-label strip + frame decode (labeled and unlabeled) |
-| `unwrap_transforms` | the tag-driven checksum / decompress / decrypt unwrap loop (decompression bombs, non-canonical nesting) |
+| `decode_incoming` | the full inbound pipeline — cluster-label strip → transform unwrap → message parse — on the plaintext path (labeled and unlabeled) |
+| `unwrap_transforms` | the tag-driven checksum / decompress / decrypt unwrap loop, both unencrypted and through a keyed AES-256 AEAD decrypt (decompression and ciphertext bombs, non-canonical nesting) |
 
 ## Running
 

--- a/memberlist-proto/fuzz/fuzz_targets/decode_incoming.rs
+++ b/memberlist-proto/fuzz/fuzz_targets/decode_incoming.rs
@@ -1,12 +1,30 @@
 #![no_main]
 
-//! Fuzz the inbound label-strip + frame decode: an arbitrary `[label?][frame]`
-//! must be rejected cleanly. The first byte selects whether a cluster label is
-//! expected, exercising both the labeled and unlabeled strip paths.
+//! Fuzz the full inbound datagram pipeline: cluster-label strip → transform
+//! unwrap → message parse. Arbitrary `[label?][frame]` bytes are driven through
+//! the real decode chain a driver applies to an inbound packet:
+//! [`decode_incoming`] strips the optional cluster label, then the inner frame
+//! feeds [`unwrap_transforms_with_encryption`] (the checksum / decompress
+//! stripping loop) and, on success, [`parse_messages`] (the compound / message
+//! parser). Every stage must reject malformed input cleanly — no panic, abort,
+//! or unbounded allocation — not just the outer label.
+//!
+//! The first byte selects whether a cluster label is expected, exercising both
+//! the labeled and unlabeled strip paths. This target drives the plaintext
+//! pipeline with an empty [`EncryptionOptions`]; the keyed AEAD decrypt path is
+//! fuzzed separately by the `unwrap_transforms` target.
+
+use core::net::SocketAddr;
 
 use bytes::Bytes;
 use libfuzzer_sys::fuzz_target;
-use memberlist_proto::{DecodeOptions, decode_incoming};
+use memberlist_proto::{
+  decode_incoming, parse_messages, typed::Message, unwrap_transforms_with_encryption,
+  DecodeOptions, EncryptionOptions,
+};
+use smol_str::SmolStr;
+
+const MAX_ORIG_LEN: usize = 64 * 1024;
 
 fuzz_target!(|data: &[u8]| {
   let (label, rest) = match data.split_first() {
@@ -16,5 +34,13 @@ fuzz_target!(|data: &[u8]| {
     Some((_, rest)) => (None, rest),
     None => (None, data),
   };
-  let _ = decode_incoming(Bytes::copy_from_slice(rest), &DecodeOptions::new(label));
+  let encryption = EncryptionOptions::new();
+  let Ok(inner) = decode_incoming(Bytes::copy_from_slice(rest), &DecodeOptions::new(label)) else {
+    return;
+  };
+  let Ok(plain) = unwrap_transforms_with_encryption(&inner, MAX_ORIG_LEN, &encryption) else {
+    return;
+  };
+  let _: Result<Vec<Message<SmolStr, SocketAddr>>, _> =
+    parse_messages(Bytes::copy_from_slice(&plain));
 });

--- a/memberlist-proto/fuzz/fuzz_targets/unwrap_transforms.rs
+++ b/memberlist-proto/fuzz/fuzz_targets/unwrap_transforms.rs
@@ -1,16 +1,35 @@
 #![no_main]
 
 //! Fuzz the tag-driven transform unwrap loop (checksum / decompress / decrypt
-//! stripping) on the unencrypted gossip path: a crafted nesting, a decompression
-//! bomb declaring a huge output, or a malformed checksum wrapper must be rejected
-//! within the `max_orig_len` ceiling without panicking or unbounded allocation.
+//! stripping): a crafted nesting, a decompression bomb declaring a huge output,
+//! a malformed checksum wrapper, or a forged AEAD frame must be rejected within
+//! the `max_orig_len` ceiling without panicking or unbounded allocation.
+//!
+//! The first byte selects the keyring, so both branches are fuzzed:
+//! - selector bit set — a fixed AES-256 key is installed, so an
+//!   `Encrypted`-tagged payload reaches the AEAD decrypt path (tag verification,
+//!   nonce handling, the ciphertext-bomb guard, and the inner checksum /
+//!   decompress unwrap) instead of short-circuiting at `NoMatchingKey`. The key
+//!   is fixed on purpose: the goal is to fuzz the decrypt code path, not key
+//!   recovery.
+//! - selector bit clear — an empty keyring drives the unencrypted
+//!   checksum / decompress unwrap.
+//!
+//! The remaining bytes (after the selector) are the payload.
 
 use libfuzzer_sys::fuzz_target;
-use memberlist_proto::{EncryptionOptions, unwrap_transforms_with_encryption};
+use memberlist_proto::{unwrap_transforms_with_encryption, EncryptionOptions, Keyring, SecretKey};
 
 const MAX_ORIG_LEN: usize = 64 * 1024;
 
 fuzz_target!(|data: &[u8]| {
-  let encryption = EncryptionOptions::new();
-  let _ = unwrap_transforms_with_encryption(data, MAX_ORIG_LEN, &encryption);
+  let (encryption, payload) = match data.split_first() {
+    Some((selector, rest)) if selector & 1 == 1 => (
+      EncryptionOptions::new().with_keyring(Keyring::new(SecretKey::Aes256([0x24; 32]))),
+      rest,
+    ),
+    Some((_, rest)) => (EncryptionOptions::new(), rest),
+    None => (EncryptionOptions::new(), data),
+  };
+  let _ = unwrap_transforms_with_encryption(payload, MAX_ORIG_LEN, &encryption);
 });


### PR DESCRIPTION
## #169 findings 4–5 — drive the inbound pipeline & AEAD decrypt path in the fuzz targets + add a fuzz CI gate

Completes #169 (findings 1–3 landed in #207). Test/CI only — no production code changes.

### Finding 4 — two fuzz targets never reached the parser / decryption
- **`decode_incoming`** did label-strip only (`decode_incoming` returns the label-stripped bytes, which the target discarded), never reaching transform-unwrap or the message parser. Rewritten to drive the **real inbound pipeline**: `decode_incoming` (label strip) → `unwrap_transforms_with_encryption(&inner, 64 KiB, &enc)` (checksum/decompress strip) → `parse_messages` (compound/message parse), discarding every result — the harness asserts no panic/abort/unbounded allocation. Arbitrary bytes now exercise the composed path, including the boundaries between stages that fuzzing each stage in isolation misses.
- **`unwrap_transforms`** used `EncryptionOptions::new()` (no keyring), so an `Encrypted`-tagged input short-circuited at `NoMatchingKey` and the AEAD decrypt path was never fuzzed. Rewritten with a `split_first` selector byte: when set, it installs `EncryptionOptions::new().with_keyring(Keyring::new(SecretKey::Aes256([0x24; 32])))` so an encrypted payload reaches the decrypt code path (tag verification, nonce handling, the ciphertext-bomb guard, inner unwrap); clear keeps the original unencrypted coverage. The fixed key fuzzes the decrypt *code path*, not key recovery.

`parse_messages` and `decode_compound` already fuzzed the parser/splitter and are unchanged (re-run as regression controls).

### Finding 5 — no fuzz CI gate
New **`.github/workflows/fuzz.yml`** (the fuzz crate is its own workspace — nightly + sanitizer — so the other jobs' `--workspace` builds never reach it):
- Triggers: `push` on `main` and `pull_request`, both path-filtered to `memberlist-proto/**` + the workflow file; `workflow_dispatch`; and a nightly `schedule`.
- Installs nightly (dtolnay), `protoc` (the proto `build.rs` invokes it), and `cargo-fuzz` (taiki-e), with a cache keyed on the *tracked* manifests (`fuzz/Cargo.lock` is gitignored).
- **Build gate**: `cargo +nightly fuzz build` — every target must compile (closes the "targets never compile-checked" gap).
- **Smoke gate**: a bounded `cargo +nightly fuzz run` per target — `-max_total_time=30` on push/PR (fast), `300` on the nightly schedule (longer), `-rss_limit_mb=4096` — fails loud if any target panics.

The fuzz `README` rows for the two targets, which overclaimed that they already reached the parser/decrypt, are corrected to match reality.
