### PR TITLE
fix(smoltcp): reap and re-arm a half-open reliable listener; clamp the i64 duration/instant conversions (#166 ML-LIFE-01)

### DIFF
--- a/memberlist-embedded/src/engine/mod.rs
+++ b/memberlist-embedded/src/engine/mod.rs
@@ -383,6 +383,24 @@ where
     self.plane.listener.is_some()
   }
 
+  /// The connection handle currently installed as the passive-open listener, or
+  /// `None` when the pool could not replenish one.
+  ///
+  /// The engine keeps this handle installed and swaps it out only on a completed
+  /// accept (`check_listener`); it never re-arms a listener socket the link layer
+  /// closed underneath it. A driver whose link layer reaps a stalled listener to a
+  /// terminal state — the smoltcp inactivity timeout aborting an unanswered
+  /// half-open to `Closed` — reads this to find the slot and re-`listen` it in
+  /// place, so a reaped listener does not stay dead and black-hole all further
+  /// inbound reliable streams.
+  #[inline]
+  pub fn listener(&self) -> Option<C>
+  where
+    C: Copy,
+  {
+    self.plane.listener
+  }
+
   // ── Membership queries ──────────────────────────────────────────────────────
   //
   // These are thin `&self` reads over the live `Endpoint` inside the

--- a/memberlist-smoltcp/src/addr/mod.rs
+++ b/memberlist-smoltcp/src/addr/mod.rs
@@ -24,33 +24,68 @@ pub(crate) fn from_endpoint(ep: IpEndpoint) -> SocketAddr {
   ep.into()
 }
 
+/// The largest millisecond value [`to_smoltcp_instant`] will scale into
+/// smoltcp's internal `i64` microseconds.
+///
+/// smoltcp's `Instant` is `{ micros: i64 }`, and `Instant::from_millis`
+/// computes `millis * 1000` before storing it — so the representable bound is
+/// `i64::MAX` MICROSECONDS divided by 1000, not `i64::MAX` MILLISECONDS, which
+/// would overflow that multiply and wrap negative.
+const MAX_INSTANT_MILLIS: i64 = i64::MAX / 1000;
+
 /// Convert a `memberlist_proto::Instant` to a smoltcp `Instant` (millisecond granularity).
+///
+/// Saturates `since_origin`'s milliseconds at [`MAX_INSTANT_MILLIS`] rather than
+/// relying on a release-silent `debug_assert`, so an extreme instant still
+/// yields a valid, positive, far-future smoltcp instant instead of a value that
+/// overflows `from_millis`'s internal `* 1000` and wraps negative.
 #[inline]
 pub(crate) fn to_smoltcp_instant(now: Instant) -> SmoltcpInstant {
-  debug_assert!(
-    now.since_origin().as_millis() <= i64::MAX as u128,
-    "instant too far from origin for smoltcp"
-  );
-  SmoltcpInstant::from_millis(now.since_origin().as_millis() as i64)
+  let millis = now
+    .since_origin()
+    .as_millis()
+    .min(MAX_INSTANT_MILLIS as u128) as i64;
+  SmoltcpInstant::from_millis(millis)
 }
 
 /// Convert a smoltcp `Instant` back to a `memberlist_proto::Instant`.
 #[inline]
 pub(crate) fn from_smoltcp_instant(t: SmoltcpInstant) -> Instant {
+  // Bounded by construction, not merely by convention: every smoltcp `Instant`
+  // this driver converts back is `poll_at`'s return, computed by smoltcp's own
+  // arithmetic over an `s_now` this driver produced via `to_smoltcp_instant`
+  // above (itself always non-negative). A `debug_assert` catches a violation of
+  // that invariant in development; release builds do not need to pay for a
+  // saturating branch on a direction that cannot go negative without a bug
+  // elsewhere in smoltcp's own timer arithmetic.
   debug_assert!(t.total_millis() >= 0, "smoltcp instant before origin");
   Instant::from_origin(core::time::Duration::from_millis(t.total_millis() as u64))
 }
 
+/// The largest `Duration`, in microseconds, [`to_smoltcp_duration`] will
+/// install as a socket timeout: ~100 years, trivially safe headroom under
+/// smoltcp's `i64::MAX` microsecond range (~292,471 years) even after adding a
+/// running node's `since_origin` micros.
+const MAX_TIMEOUT_MICROS: u64 = 100 * 365 * 24 * 60 * 60 * 1_000_000;
+
 /// Convert a `core::time::Duration` to a smoltcp `Duration` (microsecond granularity).
 ///
-/// Used to install the reliable-plane socket inactivity timeout. Saturates at
-/// `u64::MAX` microseconds so an out-of-range configuration yields a finite (very
-/// large) timeout rather than overflowing smoltcp's own `From` conversion, which
-/// multiplies whole seconds by 1_000_000. The value this crate feeds it — the
-/// `close_timeout`, default 10 s — is far inside range.
+/// Used to install the reliable-plane socket inactivity timeout. smoltcp
+/// stores `Duration` as unsigned microseconds, but `Instant + Duration`
+/// computes `self.micros + rhs.total_micros() as i64` — it casts those `u64`
+/// microseconds to `i64` *before* adding. A `Duration` saturated all the way to
+/// `u64::MAX` microseconds therefore casts to **-1**, installing a deadline one
+/// tick BEFORE `now` and aborting the socket immediately — the opposite of a
+/// "far future" timeout. A sub-microsecond `Duration` has the mirror problem:
+/// it truncates to `0`, which smoltcp treats as abort-on-any-inactivity. Clamp
+/// instead into `[1 µs, MAX_TIMEOUT_MICROS]`: at least one tick, and far enough
+/// below `i64::MAX` that `Instant::now() + this` can never itself overflow or
+/// cast negative. The value this crate feeds it — the `close_timeout`, default
+/// 10 s — is far inside range.
 #[inline]
 pub(crate) fn to_smoltcp_duration(d: core::time::Duration) -> SmoltcpDuration {
-  SmoltcpDuration::from_micros(u64::try_from(d.as_micros()).unwrap_or(u64::MAX))
+  let micros = d.as_micros().clamp(1, MAX_TIMEOUT_MICROS as u128) as u64;
+  SmoltcpDuration::from_micros(micros)
 }
 
 #[cfg(test)]

--- a/memberlist-smoltcp/src/addr/mod.rs
+++ b/memberlist-smoltcp/src/addr/mod.rs
@@ -3,7 +3,10 @@
 
 use core::net::SocketAddr;
 use memberlist_proto::Instant;
-use smoltcp::{time::Instant as SmoltcpInstant, wire::IpEndpoint};
+use smoltcp::{
+  time::{Duration as SmoltcpDuration, Instant as SmoltcpInstant},
+  wire::IpEndpoint,
+};
 
 /// Convert a `SocketAddr` to a smoltcp `IpEndpoint`.
 ///
@@ -36,6 +39,18 @@ pub(crate) fn to_smoltcp_instant(now: Instant) -> SmoltcpInstant {
 pub(crate) fn from_smoltcp_instant(t: SmoltcpInstant) -> Instant {
   debug_assert!(t.total_millis() >= 0, "smoltcp instant before origin");
   Instant::from_origin(core::time::Duration::from_millis(t.total_millis() as u64))
+}
+
+/// Convert a `core::time::Duration` to a smoltcp `Duration` (microsecond granularity).
+///
+/// Used to install the reliable-plane socket inactivity timeout. Saturates at
+/// `u64::MAX` microseconds so an out-of-range configuration yields a finite (very
+/// large) timeout rather than overflowing smoltcp's own `From` conversion, which
+/// multiplies whole seconds by 1_000_000. The value this crate feeds it — the
+/// `close_timeout`, default 10 s — is far inside range.
+#[inline]
+pub(crate) fn to_smoltcp_duration(d: core::time::Duration) -> SmoltcpDuration {
+  SmoltcpDuration::from_micros(u64::try_from(d.as_micros()).unwrap_or(u64::MAX))
 }
 
 #[cfg(test)]

--- a/memberlist-smoltcp/src/addr/tests.rs
+++ b/memberlist-smoltcp/src/addr/tests.rs
@@ -21,3 +21,37 @@ fn machine_instant_round_trips_through_smoltcp_instant() {
   let s = to_smoltcp_instant(now);
   assert_eq!(from_smoltcp_instant(s), now);
 }
+
+#[test]
+fn duration_converts_to_smoltcp_micros() {
+  use smoltcp::time::Duration as SmoltcpDuration;
+  // The default close_timeout (10 s), the value the driver installs as the socket
+  // inactivity timeout, converts exactly.
+  assert_eq!(
+    to_smoltcp_duration(core::time::Duration::from_secs(10)),
+    SmoltcpDuration::from_secs(10)
+  );
+  // Sub-second precision is preserved at microsecond granularity.
+  assert_eq!(
+    to_smoltcp_duration(core::time::Duration::from_micros(1_500_250)),
+    SmoltcpDuration::from_micros(1_500_250)
+  );
+  // A non-zero timeout never converts to smoltcp's zero (which it treats as an
+  // immediate abort of every socket).
+  assert_ne!(
+    to_smoltcp_duration(core::time::Duration::from_millis(1)),
+    SmoltcpDuration::from_micros(0)
+  );
+}
+
+#[test]
+fn out_of_range_duration_saturates_without_panicking() {
+  use smoltcp::time::Duration as SmoltcpDuration;
+  // A duration whose microseconds exceed u64 saturates to a finite (very large)
+  // timeout instead of overflowing smoltcp's own `From`, which multiplies whole
+  // seconds by 1_000_000.
+  assert_eq!(
+    to_smoltcp_duration(core::time::Duration::MAX),
+    SmoltcpDuration::from_micros(u64::MAX)
+  );
+}

--- a/memberlist-smoltcp/src/addr/tests.rs
+++ b/memberlist-smoltcp/src/addr/tests.rs
@@ -23,6 +23,25 @@ fn machine_instant_round_trips_through_smoltcp_instant() {
 }
 
 #[test]
+fn extreme_instant_saturates_without_wrapping() {
+  use smoltcp::time::Instant as SmoltcpInstant;
+
+  // `since_origin`'s milliseconds exceed `i64::MAX / 1000` -- the real bound,
+  // since smoltcp's `Instant::from_millis` scales millis -> micros by 1000
+  // before storing them in an `i64`. `i64::MAX` millis alone would overflow
+  // that multiply and wrap negative (the same-class bug as the duration
+  // conversion below, guarded before this fix only by a release-silent
+  // `debug_assert` with the wrong bound).
+  let extreme = memberlist_proto::Instant::from_origin(core::time::Duration::from_millis(u64::MAX));
+  let converted = to_smoltcp_instant(extreme);
+  assert!(
+    converted.total_micros() > 0,
+    "an extreme instant must saturate to a positive smoltcp instant, got {converted:?}"
+  );
+  assert_eq!(converted, SmoltcpInstant::from_millis(i64::MAX / 1000));
+}
+
+#[test]
 fn duration_converts_to_smoltcp_micros() {
   use smoltcp::time::Duration as SmoltcpDuration;
   // The default close_timeout (10 s), the value the driver installs as the socket
@@ -45,13 +64,76 @@ fn duration_converts_to_smoltcp_micros() {
 }
 
 #[test]
+fn non_millisecond_duration_preserves_microseconds() {
+  use smoltcp::time::Duration as SmoltcpDuration;
+  // 1500 µs is not a whole number of milliseconds; the conversion must keep
+  // microsecond granularity rather than truncating to `from_millis(1)`.
+  assert_eq!(
+    to_smoltcp_duration(core::time::Duration::from_micros(1_500)),
+    SmoltcpDuration::from_micros(1_500)
+  );
+}
+
+#[test]
+fn sub_microsecond_duration_is_at_least_one_tick() {
+  use smoltcp::time::Duration as SmoltcpDuration;
+  // 1 ns truncates to 0 whole microseconds; the conversion must clamp up to
+  // one tick rather than yielding smoltcp's abort-on-any-inactivity zero.
+  let converted = to_smoltcp_duration(core::time::Duration::from_nanos(1));
+  assert!(
+    converted >= SmoltcpDuration::from_micros(1),
+    "a sub-microsecond duration must clamp up to at least one tick, got {converted:?}"
+  );
+}
+
+#[test]
 fn out_of_range_duration_saturates_without_panicking() {
   use smoltcp::time::Duration as SmoltcpDuration;
-  // A duration whose microseconds exceed u64 saturates to a finite (very large)
-  // timeout instead of overflowing smoltcp's own `From`, which multiplies whole
-  // seconds by 1_000_000.
+  // A duration whose microseconds exceed u64 clamps to the ~100y cap instead
+  // of overflowing smoltcp's own `From`, which multiplies whole seconds by
+  // 1_000_000 -- and, unlike the pre-fix `u64::MAX` saturation, the cap stays
+  // far enough below smoltcp's i64 microsecond range that adding it to an
+  // `Instant` can never cast negative (see
+  // `extreme_duration_does_not_install_a_past_deadline` below).
   assert_eq!(
     to_smoltcp_duration(core::time::Duration::MAX),
-    SmoltcpDuration::from_micros(u64::MAX)
+    SmoltcpDuration::from_micros(MAX_TIMEOUT_MICROS)
   );
+}
+
+#[test]
+fn extreme_duration_does_not_install_a_past_deadline() {
+  use smoltcp::time::{Duration as SmoltcpDuration, Instant as SmoltcpInstant};
+
+  let base = SmoltcpInstant::from_millis(1_000_000i64);
+
+  // Mutation anchor: the pre-fix conversion saturated straight to `u64::MAX`
+  // microseconds. smoltcp's `Instant + Duration` computes `self.micros +
+  // rhs.total_micros() as i64`, and `u64::MAX as i64 == -1`, so the old value
+  // installed a deadline ONE MICROSECOND BEFORE `base` -- a past deadline that
+  // aborts the socket immediately, the opposite of a "far future" timeout.
+  // Confirm the unpatched primitive still reproduces that bug (guarding
+  // against smoltcp changing this representation out from under the fix),
+  // then assert the real conversion flips it.
+  let old_buggy = SmoltcpDuration::from_micros(u64::MAX);
+  assert!(
+    base + old_buggy < base,
+    "sanity check: the pre-fix saturation must reproduce a past deadline"
+  );
+
+  for extreme in [
+    core::time::Duration::MAX,
+    core::time::Duration::new(u64::MAX, 0),
+  ] {
+    let converted = to_smoltcp_duration(extreme);
+    assert!(
+      (converted.total_micros() as i64) > 0,
+      "converted micros must stay representable as a positive i64, got {converted:?}"
+    );
+    let deadline = base + converted;
+    assert!(
+      deadline > base,
+      "an extreme duration must install a FUTURE deadline, got {deadline:?} <= base {base:?}"
+    );
+  }
 }

--- a/memberlist-smoltcp/src/memberlist/mod.rs
+++ b/memberlist-smoltcp/src/memberlist/mod.rs
@@ -22,7 +22,7 @@ use smoltcp::{
 
 use crate::{
   InitError, InterfaceOptions, JoinError, Options, Resolver, TransformOptions,
-  addr::{from_smoltcp_instant, to_endpoint, to_smoltcp_instant},
+  addr::{from_smoltcp_instant, to_endpoint, to_smoltcp_duration, to_smoltcp_instant},
   error::{GossipMtuTooLarge, MediumMismatch},
   gossip_io::SmoltcpGossip,
   interface::{HardwareAddress, Medium},
@@ -678,13 +678,27 @@ where
     // gets independent rx/tx ring buffers sized by the config. One socket is
     // immediately moved into listen state and installed as the engine's listener;
     // the rest stay free for outbound dials and accepted inbound connections.
+    //
+    // Every socket carries a finite inactivity timeout derived from
+    // `close_timeout`. The single direct-smoltcp listener would otherwise pin
+    // forever on an unauthenticated half-open — a `SynReceived` whose final ACK is
+    // withheld: the accept gate `may_send()` never becomes true, nothing frees the
+    // slot, and ALL inbound reliable streams are black-holed until the node
+    // restarts. `set_timeout` drives such a half-open (and a stalled established
+    // exchange) to `Closed` after `close_timeout` of silence, so `poll` can re-arm
+    // the listener and the DoS is bounded to one timeout window instead of forever.
+    // Set at socket creation so it survives every listen/accept/reset cycle
+    // (smoltcp's `reset()` preserves the timeout); this mirrors the per-slot
+    // `set_timeout` the embassy-net driver installs in its worker. `close_timeout`
+    // is validated non-zero above, so this is never the zero value smoltcp would
+    // treat as an immediate abort.
+    let socket_timeout = to_smoltcp_duration(cfg.close_timeout);
     for _ in 0..cfg.tcp_pool_size {
       let rx = tcp::SocketBuffer::new(vec![0u8; cfg.tcp_socket_rx_bytes]);
       let tx = tcp::SocketBuffer::new(vec![0u8; cfg.tcp_socket_tx_bytes]);
-      engine
-        .plane_mut()
-        .pool
-        .push(sockets.add(tcp::Socket::new(rx, tx)));
+      let mut sock = tcp::Socket::new(rx, tx);
+      sock.set_timeout(Some(socket_timeout));
+      engine.plane_mut().pool.push(sockets.add(sock));
     }
     // Dedicate one pooled socket to listening for inbound reliable connections.
     if let Some(h) = engine.plane_mut().pool.take() {
@@ -1094,13 +1108,27 @@ where
     // gets independent rx/tx ring buffers sized by the config. One socket is
     // immediately moved into listen state and installed as the engine's listener;
     // the rest stay free for outbound dials and accepted inbound connections.
+    //
+    // Every socket carries a finite inactivity timeout derived from
+    // `close_timeout`. The single direct-smoltcp listener would otherwise pin
+    // forever on an unauthenticated half-open — a `SynReceived` whose final ACK is
+    // withheld: the accept gate `may_send()` never becomes true, nothing frees the
+    // slot, and ALL inbound reliable streams are black-holed until the node
+    // restarts. `set_timeout` drives such a half-open (and a stalled established
+    // exchange) to `Closed` after `close_timeout` of silence, so `poll` can re-arm
+    // the listener and the DoS is bounded to one timeout window instead of forever.
+    // Set at socket creation so it survives every listen/accept/reset cycle
+    // (smoltcp's `reset()` preserves the timeout); this mirrors the per-slot
+    // `set_timeout` the embassy-net driver installs in its worker. `close_timeout`
+    // is validated non-zero above, so this is never the zero value smoltcp would
+    // treat as an immediate abort.
+    let socket_timeout = to_smoltcp_duration(cfg.close_timeout);
     for _ in 0..cfg.tcp_pool_size {
       let rx = tcp::SocketBuffer::new(vec![0u8; cfg.tcp_socket_rx_bytes]);
       let tx = tcp::SocketBuffer::new(vec![0u8; cfg.tcp_socket_tx_bytes]);
-      engine
-        .plane_mut()
-        .pool
-        .push(sockets.add(tcp::Socket::new(rx, tx)));
+      let mut sock = tcp::Socket::new(rx, tx);
+      sock.set_timeout(Some(socket_timeout));
+      engine.plane_mut().pool.push(sockets.add(sock));
     }
     // Dedicate one pooled socket to listening for inbound reliable connections.
     if let Some(h) = engine.plane_mut().pool.take() {
@@ -1197,6 +1225,25 @@ where
   #[inline]
   pub fn listener_present(&self) -> bool {
     self.engine.listener_present()
+  }
+
+  /// Whether the installed listener socket is actually in the `Listen` state
+  /// (ready to accept), as opposed to merely installed.
+  ///
+  /// A diagnostic for the listener-reap self-heal: an unanswered half-open reaped
+  /// by the socket inactivity timeout leaves the listener handle installed
+  /// ([`listener_present`](Self::listener_present) stays `true`) but its socket in
+  /// `Closed`, accepting nothing. `poll` re-`listen`s it in place; a test uses
+  /// this to witness that a reaped listener is `Closed` (not listening) before the
+  /// re-arm and back in `Listen` after it.
+  #[doc(hidden)]
+  #[inline]
+  pub fn listener_is_listening(&self) -> bool {
+    self
+      .engine
+      .listener()
+      .map(|h| self.sockets.get::<tcp::Socket>(h).is_listening())
+      .unwrap_or(false)
   }
 
   /// Number of reliable exchanges still in `PendingDial`: a dial was requested
@@ -1689,6 +1736,33 @@ where
       let mut stream = SmoltcpStream::new(&mut self.iface, &sockets);
       self.engine.pump(now, &mut gossip, &mut stream)
     };
+
+    // 2b. Re-arm a listener the inactivity timeout just reaped. When an
+    // unauthenticated half-open (a `SynReceived` whose final ACK is withheld) — or
+    // a stalled established exchange — sits idle past the socket timeout, step 1's
+    // stack tick drives that socket to `Closed`. The engine keeps its handle
+    // installed as the listener (it swaps the slot out only on a completed accept,
+    // and never re-arms a socket the link layer closed underneath it), so without
+    // this the single direct-smoltcp listener would stay `Closed` and the node
+    // would accept no further inbound reliable streams — turning the bounded reap
+    // back into a permanent black-hole. Re-`listen` in place restores it: the
+    // handle is unchanged, so the engine's listener bookkeeping still holds, and
+    // the timeout — preserved across `reset()` — reaps the next half-open too,
+    // keeping the DoS bounded to one timeout window. A socket mid-handshake
+    // (`SynReceived`, still `is_open()`) or a healthy `Listen` is left untouched;
+    // only a reaped (`!is_open()`, i.e. `Closed`) listener is re-armed. This is the
+    // smoltcp analog of the per-slot self-heal the embassy-net worker performs
+    // after its own `set_timeout` fires.
+    if let Some(listener) = self.engine.listener() {
+      let port = self.engine.port();
+      let sock = self.sockets.get_mut::<tcp::Socket>(listener);
+      if !sock.is_open() {
+        // Ignoring Err: `listen` fails only on port 0 (rejected at construction) or
+        // an already-open socket (excluded by the `!is_open()` guard); neither can
+        // occur here.
+        let _ = sock.listen(port);
+      }
+    }
 
     // 3. Fold the smoltcp stack's next scheduled event into the engine's returned
     // deadline. The engine returns only `min(machine, closing)` — the SWIM timers

--- a/memberlist-smoltcp/src/memberlist/tests.rs
+++ b/memberlist-smoltcp/src/memberlist/tests.rs
@@ -293,3 +293,158 @@ fn invalid_config_is_rejected_before_resolution() {
     Ok(_) => panic!("a zero close timeout must be rejected at construction"),
   }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ML-LIFE-01 integration: `poll` re-arms a listener the socket inactivity timeout
+// reaped. A raw peer drives a real unauthenticated half-open (a SYN with the final
+// ACK withheld) against the driver's single internal listener over a paired
+// `Medium::Ip` link — something the self-looping `Loopback` device the other
+// full-driver tests use cannot source. After the timeout reaps the half-open to
+// `Closed`, `poll` must re-`listen` the slot in place so the node keeps accepting
+// inbound reliable streams; without that re-arm the listener stays `Closed` and the
+// DoS is permanent rather than bounded to one timeout window.
+
+use smoltcp::{
+  phy::{ChecksumCapabilities, DeviceCapabilities, RxToken, TxToken},
+  time::Instant as SmolInstant,
+};
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
+
+/// A shared in-memory IP-frame FIFO (one direction of a paired link).
+#[derive(Clone)]
+struct IpWire(Rc<RefCell<VecDeque<Vec<u8>>>>);
+
+/// One end of a paired `Medium::Ip` link: reads from `rx`, writes to `tx`.
+struct PairedIp {
+  rx: IpWire,
+  tx: IpWire,
+}
+
+/// Cross-wire two ends so each side's TX is the other's RX.
+fn ip_link() -> (PairedIp, PairedIp) {
+  let a2b = IpWire(Rc::new(RefCell::new(VecDeque::new())));
+  let b2a = IpWire(Rc::new(RefCell::new(VecDeque::new())));
+  (
+    PairedIp {
+      rx: b2a.clone(),
+      tx: a2b.clone(),
+    },
+    PairedIp { rx: a2b, tx: b2a },
+  )
+}
+
+struct IpRx(Vec<u8>);
+struct IpTx(IpWire);
+
+impl RxToken for IpRx {
+  fn consume<R, F: FnOnce(&[u8]) -> R>(self, f: F) -> R {
+    f(&self.0)
+  }
+}
+
+impl TxToken for IpTx {
+  fn consume<R, F: FnOnce(&mut [u8]) -> R>(self, len: usize, f: F) -> R {
+    let mut buf = vec![0u8; len];
+    let r = f(&mut buf);
+    (self.0).0.borrow_mut().push_back(buf);
+    r
+  }
+}
+
+impl Device for PairedIp {
+  type RxToken<'a> = IpRx;
+  type TxToken<'a> = IpTx;
+
+  fn receive(&mut self, _t: SmolInstant) -> Option<(IpRx, IpTx)> {
+    let frame = self.rx.0.borrow_mut().pop_front()?;
+    Some((IpRx(frame), IpTx(self.tx.clone())))
+  }
+
+  fn transmit(&mut self, _t: SmolInstant) -> Option<IpTx> {
+    Some(IpTx(self.tx.clone()))
+  }
+
+  fn capabilities(&self) -> DeviceCapabilities {
+    let mut caps = DeviceCapabilities::default();
+    caps.medium = Medium::Ip;
+    caps.max_transmission_unit = 1500;
+    caps.checksum = ChecksumCapabilities::ignored();
+    caps
+  }
+}
+
+/// A raw smoltcp peer at `10.0.0.2/24` on the other end of the link.
+fn peer_iface(dev: &mut PairedIp) -> Interface {
+  let mut cfg = IfConfig::new(HardwareAddress::Ip);
+  cfg.random_seed = 0x50a2_1166;
+  let mut iface = Interface::new(cfg, dev, SmolInstant::from_millis(0));
+  iface.update_ip_addrs(|addrs| {
+    addrs
+      .push(IpCidr::new(crate::IpAddress::v4(10, 0, 0, 2), 24))
+      .expect("push peer ip");
+  });
+  iface
+}
+
+#[test]
+fn poll_re_arms_a_listener_reaped_by_the_inactivity_timeout() {
+  // A short close_timeout keeps the reap prompt; it is the value installed as the
+  // per-socket inactivity timeout.
+  const CLOSE_MS: u64 = 300;
+  let (mut dev_m, mut dev_peer) = ip_link();
+
+  // M: a full driver on 10.0.0.1, listening on 7946.
+  let t0 = memberlist_proto::Instant::from_origin(Duration::from_millis(1_000));
+  let mut m: Memberlist<SmolStr, SocketAddr, _> = Memberlist::new(
+    crate::Options::new().with_close_timeout(Duration::from_millis(CLOSE_MS)),
+    ip_iface(),
+    TransformOptions::default(),
+    memberlist_proto::EndpointOptions::new(SmolStr::new("m"), addr(7946)),
+    &crate::SocketAddrResolver,
+    &mut dev_m,
+    t0,
+  );
+  m.start(t0);
+  m.poll(t0, &mut dev_m);
+  assert!(
+    m.listener_present() && m.listener_is_listening(),
+    "the listener is armed and listening at start"
+  );
+
+  // The peer dials M, emitting a SYN. We deliver that SYN to M but NEVER poll the
+  // peer again, so it never ACKs M's SYN-ACK: M's listener parks half-open.
+  let mut peer_if = peer_iface(&mut dev_peer);
+  let mut peer_set = SocketSet::new(Vec::new());
+  let hp = peer_set.add(tcp::Socket::new(
+    tcp::SocketBuffer::new(vec![0u8; 4096]),
+    tcp::SocketBuffer::new(vec![0u8; 4096]),
+  ));
+  let m_listener = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 7946);
+  peer_set
+    .get_mut::<tcp::Socket>(hp)
+    .connect(peer_if.context(), to_endpoint(m_listener), 49_000u16)
+    .expect("peer connect");
+  peer_if.poll(
+    SmolInstant::from_millis(1_000),
+    &mut dev_peer,
+    &mut peer_set,
+  );
+
+  let t1 = memberlist_proto::Instant::from_origin(Duration::from_millis(1_001));
+  m.poll(t1, &mut dev_m);
+  assert!(
+    m.listener_present() && !m.listener_is_listening(),
+    "M's listener consumed the SYN and is now half-open (SynReceived, not Listen)"
+  );
+
+  // Advance M past the inactivity timeout (remote_last_ts ~1_001 + CLOSE_MS). One
+  // poll reaps the half-open to Closed (step 1 stack tick) and re-arms it (step 2b).
+  let t2 = memberlist_proto::Instant::from_origin(Duration::from_millis(1_001 + CLOSE_MS + 200));
+  m.poll(t2, &mut dev_m);
+  assert!(
+    m.listener_present() && m.listener_is_listening(),
+    "poll must re-arm the listener the inactivity timeout reaped, so the node \
+     accepts inbound reliable streams again (mutation anchor: without poll's \
+     re-arm the listener stays Closed and this is false)"
+  );
+}

--- a/memberlist-smoltcp/src/stream_io/tests.rs
+++ b/memberlist-smoltcp/src/stream_io/tests.rs
@@ -6,7 +6,7 @@ use core::net::{IpAddr, Ipv4Addr};
 use smoltcp::{
   iface::{Config as IfConfig, Interface, SocketSet},
   phy::{ChecksumCapabilities, Device, DeviceCapabilities, Medium, RxToken, TxToken},
-  time::Instant as SmolInstant,
+  time::{Duration as SmolDuration, Instant as SmolInstant},
   wire::{HardwareAddress, IpAddress, IpCidr},
 };
 
@@ -249,5 +249,160 @@ fn mid_stream_reset_is_not_reported_as_eof() {
   assert!(
     !recv_finished(&mut a),
     "a mid-stream reset must not be reported as a graceful EOF"
+  );
+}
+
+/// Build a fresh 4 KiB `tcp::Socket` carrying the finite inactivity timeout the
+/// driver installs at socket creation (`Options::close_timeout` → smoltcp
+/// `Duration`), the mechanism that reaps a stalled reliable socket.
+fn timed_socket(timeout_ms: u64) -> tcp::Socket<'static> {
+  let mut sock = tcp::Socket::new(
+    tcp::SocketBuffer::new(vec![0u8; 4096]),
+    tcp::SocketBuffer::new(vec![0u8; 4096]),
+  );
+  sock.set_timeout(Some(SmolDuration::from_millis(timeout_ms)));
+  sock
+}
+
+/// ML-LIFE-01: a single unauthenticated half-open (a peer SYN with the final ACK
+/// withheld) must NOT pin the direct-smoltcp listener forever. With the socket
+/// inactivity timeout installed, the parked `SynReceived` is reaped to `Closed`,
+/// and re-`listen` (what `Memberlist::poll` does) frees the slot to accept again —
+/// bounding the DoS to one timeout window instead of a permanent black-hole.
+///
+/// Mutation anchor: delete the `set_timeout` inside `timed_socket` and the socket
+/// stays `SynReceived` forever, so the `Closed` assertion below fails.
+#[test]
+fn half_open_listener_is_reaped_by_inactivity_timeout() {
+  const TIMEOUT_MS: i64 = 200;
+  let (mut dev_a, mut dev_b) = link();
+  let mut if_a = iface(&mut dev_a, 1);
+  let mut if_b = iface(&mut dev_b, 2);
+  let mut set_a = SocketSet::new(Vec::new());
+  let mut set_b = SocketSet::new(Vec::new());
+
+  // B is the listener carrying the inactivity timeout.
+  let hb = set_b.add(timed_socket(TIMEOUT_MS as u64));
+  set_b
+    .get_mut::<tcp::Socket>(hb)
+    .listen(7946)
+    .expect("listen");
+
+  // A dials B, emitting a SYN. We deliver A's SYN to B (B: Listen → SynReceived,
+  // which sends a SYN-ACK) but then NEVER poll A again, so A never sees the
+  // SYN-ACK and never sends the final ACK — precisely the withheld-ACK attack.
+  let ha = set_a.add(timed_socket(TIMEOUT_MS as u64));
+  let remote_b = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 7946);
+  set_a
+    .get_mut::<tcp::Socket>(ha)
+    .connect(if_a.context(), to_endpoint(remote_b), 49_000u16)
+    .expect("connect");
+
+  if_a.poll(SmolInstant::from_millis(0), &mut dev_a, &mut set_a);
+  if_b.poll(SmolInstant::from_millis(0), &mut dev_b, &mut set_b);
+  assert_eq!(
+    set_b.get::<tcp::Socket>(hb).state(),
+    tcp::State::SynReceived,
+    "the withheld-ACK peer must park B half-open"
+  );
+
+  // Advance B's clock past the inactivity timeout, never delivering A's ACK (A is
+  // never polled again). B's dispatch observes the timeout and aborts to Closed.
+  let mut t = 1i64;
+  while t < TIMEOUT_MS + 500 {
+    if_b.poll(SmolInstant::from_millis(t), &mut dev_b, &mut set_b);
+    if set_b.get::<tcp::Socket>(hb).state() == tcp::State::Closed {
+      break;
+    }
+    t += 10;
+  }
+  assert_eq!(
+    set_b.get::<tcp::Socket>(hb).state(),
+    tcp::State::Closed,
+    "the inactivity timeout must reap the half-open listener to Closed"
+  );
+
+  // The reaped socket is free again: re-`listen` restores it IN PLACE (the same
+  // handle the engine keeps as its listener), and the timeout survives the reset
+  // so the next half-open is reaped too.
+  set_b
+    .get_mut::<tcp::Socket>(hb)
+    .listen(7946)
+    .expect("re-listen");
+  assert!(
+    set_b.get::<tcp::Socket>(hb).is_listening(),
+    "a reaped listener must re-listen so the node accepts inbound streams again"
+  );
+  assert_eq!(
+    set_b.get::<tcp::Socket>(hb).timeout(),
+    Some(SmolDuration::from_millis(TIMEOUT_MS as u64)),
+    "the inactivity timeout must survive the reap + re-listen (smoltcp reset() \
+     preserves it) so a re-armed listener stays protected"
+  );
+}
+
+/// Control: the socket timeout is an INACTIVITY timeout, not a hard cap on a live
+/// exchange. An established pair that keeps exchanging data across a span far
+/// longer than the timeout is never aborted, because each delivered packet resets
+/// the inactivity clock.
+#[test]
+fn active_exchange_within_window_not_reaped() {
+  const TIMEOUT_MS: i64 = 200;
+  let (mut dev_a, mut dev_b) = link();
+  let mut if_a = iface(&mut dev_a, 1);
+  let mut if_b = iface(&mut dev_b, 2);
+  let mut set_a = SocketSet::new(Vec::new());
+  let mut set_b = SocketSet::new(Vec::new());
+
+  let ha = set_a.add(timed_socket(TIMEOUT_MS as u64));
+  let hb = set_b.add(timed_socket(TIMEOUT_MS as u64));
+  set_b
+    .get_mut::<tcp::Socket>(hb)
+    .listen(7946)
+    .expect("listen");
+  let remote_b = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 7946);
+  set_a
+    .get_mut::<tcp::Socket>(ha)
+    .connect(if_a.context(), to_endpoint(remote_b), 49_000u16)
+    .expect("connect");
+
+  // Complete the handshake.
+  let mut t = 0i64;
+  for _ in 0..50 {
+    if_a.poll(SmolInstant::from_millis(t), &mut dev_a, &mut set_a);
+    if_b.poll(SmolInstant::from_millis(t), &mut dev_b, &mut set_b);
+    t += 1;
+    if set_a.get::<tcp::Socket>(ha).may_send() && set_b.get::<tcp::Socket>(hb).may_send() {
+      break;
+    }
+  }
+  assert!(set_a.get::<tcp::Socket>(ha).may_send(), "A must establish");
+  assert!(set_b.get::<tcp::Socket>(hb).may_send(), "B must establish");
+
+  // Exchange data across 3x the timeout window, sending on each side every half
+  // window so neither is ever idle for a full timeout. Both stay Established.
+  let end = t + TIMEOUT_MS * 3;
+  let mut last_send = t;
+  while t < end {
+    if t - last_send >= TIMEOUT_MS / 2 {
+      // Ignoring Err: both sockets stay Established throughout and the 4 KiB rings
+      // dwarf the few bytes sent, so send_slice always succeeds; the exchange
+      // exists only to keep the inactivity timer fed.
+      let _ = set_a.get_mut::<tcp::Socket>(ha).send_slice(b"ping");
+      let _ = set_b.get_mut::<tcp::Socket>(hb).send_slice(b"pong");
+      last_send = t;
+    }
+    if_a.poll(SmolInstant::from_millis(t), &mut dev_a, &mut set_a);
+    if_b.poll(SmolInstant::from_millis(t), &mut dev_b, &mut set_b);
+    t += 5;
+  }
+
+  assert!(
+    set_a.get::<tcp::Socket>(ha).may_send(),
+    "an actively-exchanging socket must not be reaped by the inactivity timeout"
+  );
+  assert!(
+    set_b.get::<tcp::Socket>(hb).may_send(),
+    "an actively-exchanging socket must not be reaped by the inactivity timeout"
   );
 }


### PR DESCRIPTION
## #166 ML-LIFE-01 — reap and re-arm the smoltcp half-open reliable listener

`memberlist-smoltcp` installed no `set_timeout` on its single direct-smoltcp listening socket, and the accept gate is `may_send()` (never true for a half-open SYN). So a **single unauthenticated SYN with the final ACK withheld** parked the socket in `SynReceived` forever, and — because direct-smoltcp has one listener — **permanently disabled all inbound reliable streams** (joins, inbound push/pull, reliable user messages) on the default config until the peer reset or the node restarted. External, unauthenticated, pre-trust, default-config.

### Fix (two parts)
- **Install a socket inactivity timeout at creation** (`memberlist/mod.rs`, both pool-seeding loops): `set_timeout(Some(to_smoltcp_duration(close_timeout)))`, mirroring what `memberlist-embassy`'s worker already does. Verified against smoltcp 0.13.1 that `tcp::Socket::reset()` does **not** clear the timeout, so it persists across every listen→accept→reset cycle. A half-open (or a stalled established exchange) is reaped to `Closed` after `close_timeout` (default 10s) of silence; an actively-transferring exchange is untouched (inactivity, not a hard cap).
- **Re-arm the reaped listener** (`Memberlist::poll`): `set_timeout` alone only moves the pin from permanent-`SynReceived` to permanent-`Closed` (the engine keeps `plane.listener = Some(closed_handle)`; `check_listener` swaps only on a completed accept). `poll` now re-`listen`s the handle in place when `!sock.is_open()` — smoltcp's `is_open()` is `true` for `Listen`/`SynReceived` (a live handshake is **not** dropped) and `false` only for `Closed`/`TimeWait`, so only a genuinely reaped listener is re-armed. This is smoltcp-driver-local (a cross-driver re-arm keyed on `is_open` would be unsafe — Embassy's healthy-listening slot reports `open == false`); the only shared-crate change is an additive read-only `Engine::listener()` getter, and `memberlist-embassy` is byte-unaffected.

This bounds the DoS from **permanent → transient**: a half-open is reaped and the listener genuinely re-armed (proven end-to-end). A full listener-pool / accept-backlog is the larger socket-lifecycle work (the X6 teardown effort) and is out of scope here.

### Also — clamp the smoltcp i64 duration/instant conversions (adversarial-review catch)
`to_smoltcp_duration` originally saturated an out-of-range timeout to `u64::MAX`. But smoltcp 0.13.1 stores `Instant`/`Duration` as i64 microseconds and `Instant + Duration` casts the `u64` micros to `i64`, so `u64::MAX` becomes **−1 µs** — a deadline in the *past* that aborts every connection immediately. Fixed to clamp into `[1 µs, ~100 y]` (≥ one tick, far below the i64 limit, never `u64::MAX`). The sibling `to_smoltcp_instant` had the same class bug (a release-silent `debug_assert` at the wrong bound); it now release-saturates at the correct `i64::MAX/1000` millis — which also **closes #161's `to_smoltcp_instant` hardening item**. Scheduling-level tests verify the actual behavior (`Duration::MAX` no longer installs a past deadline; a sub-µs value is ≥ 1 tick; a non-ms value is preserved), with a mutation-anchor reproducing the old past-deadline.