### PR TITLE
feat(embedded): generation-tagged slot-teardown protocol — StreamIo + engine ledger (#162 X6 stage 1/4)

### DIFF
--- a/memberlist-embassy/src/mailbox.rs
+++ b/memberlist-embassy/src/mailbox.rs
@@ -17,6 +17,8 @@
 use alloc::collections::VecDeque;
 use core::net::SocketAddr;
 
+use memberlist_embedded::SlotGen;
+
 /// A directive the engine (via [`EmbassyStream`](crate::stream_io::EmbassyStream))
 /// posts to a slot's worker, consumed on the next worker wake.
 ///
@@ -80,13 +82,23 @@ pub(crate) struct Mailbox {
   /// `true` for a fresh slot (a newly-created `TcpSocket` is Closed) and after the
   /// worker's `reset_socket` (`abort()` + flush, then [`Mailbox::reset`]); `false`
   /// from the instant the worker picks up a `Listen` / `Dial` (the socket is now in
-  /// use) until that reset completes. The engine reads it via
-  /// [`EmbassyStream::reuse_ready`](crate::stream_io::EmbassyStream) so it never
-  /// re-`listen`s / re-`connect`s a slot whose teardown the worker has not yet run —
-  /// which would clobber the pending `Abort`/`Close` and leak the prior connection's
-  /// `open` / `accepted_peer` / buffers into the reused slot. This is the
-  /// acknowledged reset→idle transition that makes the async teardown safe.
+  /// use) until that reset completes. The worker sets it (see [`crate::worker`]);
+  /// paired with [`gen`](Self::gen) it forms the engine's generation-tagged reuse
+  /// gate ([`EmbassyStream::teardown_done`](crate::stream_io::EmbassyStream)):
+  /// the teardown of occupancy `g` is done iff `reset_done && gen == g`, i.e. the
+  /// worker has reset the socket AND the reset it acknowledged is this occupancy's.
+  /// Until then the engine keeps the slot in its `retiring` ledger, never reusing a
+  /// slot whose teardown the worker has not yet run (which would clobber the pending
+  /// `Abort`/`Close` and leak the prior connection's state into the reused slot).
   pub reset_done: bool,
+  /// The occupancy generation the engine last stamped onto this slot (via
+  /// [`EmbassyStream`](crate::stream_io::EmbassyStream)'s `listen` / `connect` /
+  /// `close` / `abort`). Combined with [`reset_done`](Self::reset_done) it makes the
+  /// reuse gate generation-tagged: a `reset_done` that acknowledges a PRIOR
+  /// occupancy (a stale generation) never frees a later one, since `gen` no longer
+  /// matches the queried generation. Preserved across [`Mailbox::reset`] (a reset
+  /// acknowledges the CURRENT occupancy's teardown, it does not start a new one).
+  pub generation: SlotGen,
 }
 
 impl Mailbox {
@@ -110,6 +122,9 @@ impl Mailbox {
       // A freshly-created `TcpSocket` is Closed, so the slot is immediately
       // reuse-ready for its first `Listen` / `Dial`.
       reset_done: true,
+      // The first occupancy the engine mints for any slot is `START`; the view
+      // overwrites this on the first gen-carrying command.
+      generation: SlotGen::START,
     }
   }
 

--- a/memberlist-embassy/src/memberlist/mod.rs
+++ b/memberlist-embassy/src/memberlist/mod.rs
@@ -16,7 +16,8 @@ use embassy_time::Timer;
 #[cfg(compression)]
 use memberlist_embedded::transform::CompressionOptions;
 use memberlist_embedded::{
-  AliveDelegate, Engine, MaybeResolved, MergeDelegate, Options as EngineConfig, TransformOptions,
+  AliveDelegate, Engine, MaybeResolved, MergeDelegate, Options as EngineConfig, SlotGen,
+  TransformOptions,
 };
 #[cfg(encryption)]
 use memberlist_embedded::{ControlError, transform::EncryptionOptions};
@@ -425,7 +426,16 @@ where
     // replenishes subsequent listeners via the `StreamIo` view; this is the
     // construction-time seed of the first one.)
     if let Some(listener) = engine.plane_mut().pool.take() {
-      mailboxes[listener.0].borrow_mut().command = Command::Listen(cfg.port);
+      {
+        let mut mb = mailboxes[listener.0].borrow_mut();
+        mb.command = Command::Listen(cfg.port);
+        // This direct seed bypasses the `StreamIo` view (whose `listen` would stamp
+        // the generation), so stamp the listener slot's FIRST occupancy generation
+        // to match the engine ledger's — `set_listener` below records `SlotGen::START`
+        // for this slot, so a later retire of the reaped listener is acknowledged
+        // against the same generation the engine queries.
+        mb.generation = SlotGen::START;
+      }
       // The worker is not yet running, so no wake is needed; it reads the command
       // on its first poll. Install the slot as the engine's listener.
       engine.set_listener(listener);
@@ -877,6 +887,18 @@ where
   #[inline]
   pub fn accepted_inbound_count(&self) -> u64 {
     self.shared.engine.borrow().accepted_inbound_count()
+  }
+
+  #[doc(hidden)]
+  #[inline]
+  pub fn retiring_count(&self) -> usize {
+    self.shared.engine.borrow().retiring_count()
+  }
+
+  #[doc(hidden)]
+  #[inline]
+  pub fn teardown_overruns(&self) -> u64 {
+    self.shared.engine.borrow().teardown_overruns()
   }
 
   /// Number of TCP slots currently parked mid-close (our FIN sent, the peer's not

--- a/memberlist-embassy/src/stream_io/mod.rs
+++ b/memberlist-embassy/src/stream_io/mod.rs
@@ -17,7 +17,7 @@
 use core::{cell::RefCell, net::SocketAddr};
 
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
-use memberlist_embedded::{StreamIo, StreamIoError};
+use memberlist_embedded::{SlotGen, StreamIo, StreamIoError};
 
 use crate::mailbox::{Command, Mailbox};
 use alloc::vec::Vec;
@@ -70,10 +70,21 @@ impl<'a> EmbassyStream<'a> {
     }
   }
 
-  /// Post a command to slot `c`'s mailbox and wake its worker.
+  /// Stamp occupancy `g` onto slot `c`, post a command, and wake its worker.
+  ///
+  /// The generation is recorded so the worker's later teardown acknowledgement
+  /// (`reset` → [`teardown_done`](StreamIo::teardown_done)) is matched to this
+  /// exact occupancy. Every gen-carrying command (`listen` / `connect` / `close` /
+  /// `abort`) stamps it, including `abort` on a never-activated slot (the CIDR /
+  /// routable reject issued before any `connect`), so that retire is acknowledged
+  /// against the generation the engine actually retired.
   #[inline]
-  fn post(&self, c: SlotId, cmd: Command) {
-    self.slots[c.0].borrow_mut().command = cmd;
+  fn post_gen(&self, c: SlotId, cmd: Command, g: SlotGen) {
+    {
+      let mut mb = self.slots[c.0].borrow_mut();
+      mb.generation = g;
+      mb.command = cmd;
+    }
     self.cmd_wakes[c.0].signal(());
   }
 }
@@ -104,23 +115,30 @@ impl StreamIo for EmbassyStream<'_> {
     self.free.len()
   }
 
-  fn reuse_ready(&self, c: Self::Conn) -> bool {
+  fn teardown_done(&self, c: Self::Conn, g: SlotGen) -> bool {
     // embassy-net teardown is ASYNCHRONOUS: `abort`/`close` post a command to the
-    // slot's worker, which resets the `TcpSocket` on a later wake — so a slot the
-    // engine just `give`s back to the pool is NOT yet clean. The worker clears
-    // `reset_done` the instant it begins a `Listen`/`Dial` and re-sets it only after
-    // `reset_socket` (`abort()` + flush + mailbox clear), so this gate is `true`
-    // exactly when the slot's socket is back in a clean Closed state. The engine
-    // consults it before reusing any pooled slot, so a freed-but-still-tearing-down
-    // slot is skipped this tick and retried once its worker has finished the reset —
-    // never re-`listen`ed/`connect`ed over a pending teardown (which would leak the
-    // prior connection's `open`/`accepted_peer`/buffers into the reused slot).
-    self.slots[c.0].borrow().reset_done
+    // slot's worker, which resets the `TcpSocket` on a later wake and (via
+    // `Mailbox::reset`) sets `reset_done` back to `true`. The worker clears
+    // `reset_done` the instant it begins a `Listen`/`Dial` (the socket is now in
+    // use) and re-sets it only after `reset_socket` (`abort()` + flush + mailbox
+    // clear), so `reset_done` is `true` exactly when the socket is back in a clean
+    // Closed state.
+    //
+    // The occupancy generation makes the gate exact: `reset_done` alone would let a
+    // reset that acknowledged a PRIOR occupancy free a later one. `gen == g` pins
+    // the acknowledgement to the occupancy the engine is retiring — a stale/unknown
+    // generation is inert (the mailbox has since moved to a newer generation). A
+    // never-activated occupancy (the CIDR/routable reject aborts before any
+    // `Listen`/`Dial`) still has `reset_done == true` and its generation was just
+    // stamped by `abort`, so it is acknowledged and freed at once — matching the
+    // synchronous drivers' same-tick reclaim of a never-connected socket.
+    let mb = self.slots[c.0].borrow();
+    mb.reset_done && mb.generation == g
   }
 
   // ── Listener / accept ───────────────────────────────────────────────────────
 
-  fn listen(&mut self, c: Self::Conn, port: u16) -> Result<(), StreamIoError> {
+  fn listen(&mut self, c: Self::Conn, port: u16, g: SlotGen) -> Result<(), StreamIoError> {
     // embassy-net binds its listen endpoint to the port; port 0 is rejected by
     // `accept` (`InvalidPort`). The engine only ever passes its non-zero bound
     // port, so this never fires in practice; surface a non-fatal error rather
@@ -128,7 +146,7 @@ impl StreamIo for EmbassyStream<'_> {
     if port == 0 {
       return Err(StreamIoError::Unaddressable);
     }
-    self.post(c, Command::Listen(port));
+    self.post_gen(c, Command::Listen(port), g);
     Ok(())
   }
 
@@ -146,12 +164,13 @@ impl StreamIo for EmbassyStream<'_> {
     c: Self::Conn,
     remote: SocketAddr,
     _local_port: u16,
+    g: SlotGen,
   ) -> Result<(), StreamIoError> {
     // `_local_port` is unused: embassy-net's `TcpSocket::connect` binds its own
     // ephemeral local port from the stack (`get_local_port`), so the engine's
     // requested local port has no effect here. (smoltcp threaded it through; the
     // embassy-net stack owns ephemeral-port selection.)
-    self.post(c, Command::Dial(remote));
+    self.post_gen(c, Command::Dial(remote), g);
     Ok(())
   }
 
@@ -250,12 +269,12 @@ impl StreamIo for EmbassyStream<'_> {
 
   // ── Close ─────────────────────────────────────────────────────────────────────
 
-  fn close(&mut self, c: Self::Conn) {
-    self.post(c, Command::Close);
+  fn close(&mut self, c: Self::Conn, g: SlotGen) {
+    self.post_gen(c, Command::Close, g);
   }
 
-  fn abort(&mut self, c: Self::Conn) {
-    self.post(c, Command::Abort);
+  fn abort(&mut self, c: Self::Conn, g: SlotGen) {
+    self.post_gen(c, Command::Abort, g);
   }
 }
 

--- a/memberlist-embassy/src/stream_io/tests.rs
+++ b/memberlist-embassy/src/stream_io/tests.rs
@@ -1,7 +1,7 @@
 use super::{Command, EmbassyStream, Mailbox, SlotId, SlotWake};
 use alloc::vec::Vec;
 use core::{cell::RefCell, net::SocketAddr};
-use memberlist_embedded::{StreamIo, StreamIoError};
+use memberlist_embedded::{SlotGen, StreamIo, StreamIoError};
 
 /// Build `n` fresh mailboxes (each `cap` bytes per ring) and `n` wakes for a
 /// view. Returns them so the test frame owns them for the view's lifetime.
@@ -45,19 +45,76 @@ fn free_list_take_give_and_count() {
   assert_eq!(view.free_count(), 0);
 }
 
-/// `reuse_ready` reads the slot's `reset_done`: true for a fresh slot, false
-/// once the worker has begun using it (cleared `reset_done`).
+/// `teardown_done` is `reset_done && generation == g`: a fresh slot (reset_done,
+/// generation START) is done for START; a mid-use slot (reset_done cleared) is
+/// not; and a reset that acknowledged a PRIOR generation never frees a later one.
 #[test]
-fn reuse_ready_tracks_reset_done() {
+fn teardown_done_tracks_reset_done_and_generation() {
   let (mb, wakes) = slots(1, 64);
   let mut free = Vec::new();
   let view = EmbassyStream::new(&mb, &wakes, &mut free);
 
-  assert!(view.reuse_ready(SlotId(0)), "a fresh slot is reuse-ready");
+  // Fresh slot: reset_done, generation START ⇒ done for START.
+  assert!(
+    view.teardown_done(SlotId(0), SlotGen::START),
+    "a fresh slot's teardown is done for its START occupancy"
+  );
+
+  // Worker begins using the slot (clears reset_done): not done.
   mb[0].borrow_mut().reset_done = false;
   assert!(
-    !view.reuse_ready(SlotId(0)),
-    "a slot whose worker is mid-use (reset_done cleared) is not reuse-ready"
+    !view.teardown_done(SlotId(0), SlotGen::START),
+    "a slot whose worker is mid-use (reset_done cleared) is not torn down"
+  );
+
+  // The slot has since moved to a LATER occupancy; a reset that acknowledges only
+  // the prior generation must not free the later one.
+  {
+    let mut m = mb[0].borrow_mut();
+    m.reset_done = true;
+    m.generation = SlotGen::START.next();
+  }
+  assert!(
+    !view.teardown_done(SlotId(0), SlotGen::START),
+    "a reset acknowledging a stale generation never frees a later occupancy"
+  );
+  assert!(
+    view.teardown_done(SlotId(0), SlotGen::START.next()),
+    "the matching generation is torn down"
+  );
+}
+
+/// `worker_reset_acks_the_occupancy`: a `Mailbox::reset` (what the worker runs via
+/// `reset_socket` after tearing a slot down) leaves the slot acknowledged for the
+/// generation the engine stamped — so `teardown_done` reports `true` for that
+/// occupancy and the engine's reap frees it. (No worker-behavior assertions here;
+/// those belong to a later stage.)
+#[test]
+fn worker_reset_acks_the_occupancy() {
+  let (mb, wakes) = slots(1, 64);
+  let mut free = Vec::new();
+  let mut view = EmbassyStream::new(&mb, &wakes, &mut free);
+
+  // The engine stamps occupancy g and posts a dial; the worker picks it up and
+  // clears reset_done (modelled directly here — the worker is not driven in a unit
+  // test).
+  let g = SlotGen::START.next();
+  view
+    .connect(SlotId(0), sa(2), 1234, g)
+    .expect("connect posts");
+  assert_eq!(mb[0].borrow().generation, g, "connect stamps the occupancy");
+  mb[0].borrow_mut().reset_done = false;
+  assert!(
+    !view.teardown_done(SlotId(0), g),
+    "while the worker holds the slot its teardown is not done"
+  );
+
+  // The worker tears the slot down and resets it (Mailbox::reset), acknowledging
+  // the occupancy it served.
+  mb[0].borrow_mut().reset();
+  assert!(
+    view.teardown_done(SlotId(0), g),
+    "after the worker's reset the occupancy's teardown is acknowledged"
   );
 }
 
@@ -70,7 +127,7 @@ fn listen_posts_for_a_valid_port_and_rejects_port_zero() {
   let mut view = EmbassyStream::new(&mb, &wakes, &mut free);
 
   assert!(matches!(
-    view.listen(SlotId(0), 0),
+    view.listen(SlotId(0), 0, SlotGen::START),
     Err(StreamIoError::Unaddressable)
   ));
   assert_eq!(
@@ -80,7 +137,7 @@ fn listen_posts_for_a_valid_port_and_rejects_port_zero() {
   );
 
   view
-    .listen(SlotId(0), 7946)
+    .listen(SlotId(0), 7946, SlotGen::START)
     .expect("a non-zero port is accepted");
   assert_eq!(mb[0].borrow().command, Command::Listen(7946));
   assert!(
@@ -97,7 +154,9 @@ fn connect_posts_a_dial() {
   let mut free = Vec::new();
   let mut view = EmbassyStream::new(&mb, &wakes, &mut free);
 
-  view.connect(SlotId(0), sa(2), 1234).expect("connect posts");
+  view
+    .connect(SlotId(0), sa(2), 1234, SlotGen::START)
+    .expect("connect posts");
   assert_eq!(mb[0].borrow().command, Command::Dial(sa(2)));
   assert!(wakes[0].signaled());
 }
@@ -224,12 +283,12 @@ fn close_and_abort_post_commands() {
   let mut free = Vec::new();
   let mut view = EmbassyStream::new(&mb, &wakes, &mut free);
 
-  view.close(SlotId(0));
+  view.close(SlotId(0), SlotGen::START);
   assert_eq!(mb[0].borrow().command, Command::Close);
   assert!(wakes[0].signaled());
 
   wakes[0].reset();
-  view.abort(SlotId(0));
+  view.abort(SlotId(0), SlotGen::START);
   assert_eq!(mb[0].borrow().command, Command::Abort);
   assert!(wakes[0].signaled());
 }

--- a/memberlist-embassy/tests/lifecycle.rs
+++ b/memberlist-embassy/tests/lifecycle.rs
@@ -246,10 +246,23 @@ fn abort_reuse_does_not_carry_stale_state() {
   });
 }
 
-/// Repeated dial/abort churn must not WEDGE the pool: every dead dial's slot must
-/// return to the free-list once its worker resets the socket, so the free count
-/// recovers to its construction value. A slot reused before its reset (the bug)
-/// would either zombie-leak (never returning) or corrupt a later reuse.
+/// Repeated dial/abort churn must not LEAK a reliable slot: every dead dial's
+/// slot must stay accounted for — either back in the free-list once its worker has
+/// reset the socket, or held in the engine's `retiring` ledger while its teardown
+/// is still pending — so `pool_free_count + retiring_count` recovers to the
+/// construction dial-slot count. A slot reused before its reset (the bug the
+/// generation-tagged teardown protocol closes) would zombie-leak, appearing in
+/// NEITHER, dropping the accounted total below construction.
+///
+/// A dead ON-LINK dial whose ARP never resolves pins its worker in the socket
+/// teardown (the embassy-net RST cannot egress, a pre-existing worker limitation):
+/// that slot's teardown never completes, so it stays VISIBLE in `retiring` (and its
+/// deadline eventually ticks `teardown_overruns`) rather than — as before this
+/// protocol — being returned to the pool and counted as free while its socket was
+/// still a zombie. The engine never reuses such a pinned slot in EITHER regime; the
+/// ledger merely makes the residual pin visible instead of masking it in the free
+/// count. The load-bearing property here is that NO slot is lost (the accounted
+/// total holds) and the listener self-heals.
 #[test]
 fn pool_does_not_wedge_under_dial_abort_churn() {
   let (dev_a, dev_b) = pair();
@@ -278,17 +291,27 @@ fn pool_does_not_wedge_under_dial_abort_churn() {
         // Let the dead bridges elapse and their slots reap before the next wave.
         Timer::after(Duration::from_millis(120)).await;
       }
-      // After the churn quiesces, the pool must recover to its construction count
-      // and the listener must still be present (self-healed).
-      until(|| ml_a.pool_free_count() >= free_at_start && ml_a.listener_present()).await;
-      (ml_a.pool_free_count(), ml_a.listener_present())
+      // After the churn quiesces, every dial slot must be accounted for — free or
+      // visibly retiring, none leaked — and the listener must still be present
+      // (self-healed). A dial still mid-flight (in a Dialing connection) leaves the
+      // accounted total transiently below construction, so wait for it to settle.
+      until(|| {
+        ml_a.pool_free_count() + ml_a.retiring_count() >= free_at_start && ml_a.listener_present()
+      })
+      .await;
+      (
+        ml_a.pool_free_count(),
+        ml_a.retiring_count(),
+        ml_a.listener_present(),
+      )
     };
-    let (free, listener) = drive(op, run_a, run_b, &mut net_a, &mut net_b).await;
+    let (free, retiring, listener) = drive(op, run_a, run_b, &mut net_a, &mut net_b).await;
     assert_eq!(
-      free, free_at_start,
-      "the reliable pool wedged under dial/abort churn: free recovered to only {} \
-       of {} (a slot reused before its worker reset leaked or corrupted)",
-      free, free_at_start
+      free + retiring,
+      free_at_start,
+      "the reliable pool leaked under dial/abort churn: only {free} free + {retiring} \
+       retiring of {free_at_start} dial slots are accounted for (a slot reused before \
+       its worker reset would appear in neither)"
     );
     assert!(
       listener,

--- a/memberlist-embedded/src/engine/mod.rs
+++ b/memberlist-embedded/src/engine/mod.rs
@@ -31,11 +31,11 @@ use hashbrown::HashMap;
 use smallvec_wrapper::MediumVec;
 
 use crate::{
-  GossipIo, InitError, Options, StreamIo, TransformOptions,
+  GossipIo, InitError, Options, SlotGen, StreamIo, TransformOptions,
   addr::socket_addr_is_routable,
   cidr::{CidrFilter, cidr_blocks},
   error::GossipMtuTooLarge,
-  reliable::{ConnState, Connection, ReliablePlane},
+  reliable::{ConnState, Connection, ReliablePlane, RetirePhase, Retiring},
 };
 use core::hash::Hash;
 use memberlist_proto::{codec::EncodeOptions, event::Event};
@@ -342,9 +342,20 @@ where
 
   /// Install the initial passive-open listener handle, set by the driver after it
   /// has `listen`ed on that connection slot at construction.
+  ///
+  /// The construction-time listen bypasses the engine's acquire path, so this
+  /// also records the slot's first occupancy generation ([`SlotGen::START`]) in
+  /// the ledger. A driver whose teardown gate is generation-tagged (embassy-net)
+  /// stamps the SAME `START` on that slot's bridge state at construction, so the
+  /// two agree from the first tick; a later re-arm of a reaped listener advances
+  /// to the next generation through the normal acquire path.
   #[inline]
-  pub fn set_listener(&mut self, c: C) {
+  pub fn set_listener(&mut self, c: C)
+  where
+    C: Copy + Eq + Hash,
+  {
     self.plane.listener = Some(c);
+    self.plane.slot_gen.insert(c, SlotGen::START);
   }
 
   /// The configured local port (gossip + reliable listener both bind it).
@@ -371,10 +382,29 @@ where
     self.plane.pool.free_len()
   }
 
-  /// Number of connection slots currently parked mid-close.
+  /// Number of connection slots currently parked mid-graceful-close (the
+  /// `Draining` retire phase). Slots aborted (or a graceful close escalated to
+  /// `Aborting` past its deadline) are excluded — an abort reclaims as soon as
+  /// its RST egress is acknowledged, so it does not "park" the way a graceful
+  /// close awaiting the peer does. This preserves the pre-ledger `closing`
+  /// diagnostic: only a graceful FIN-in-flight counts.
   #[inline]
   pub fn closing_count(&self) -> usize {
-    self.plane.closing.len()
+    self.plane.draining_count()
+  }
+
+  /// Number of connection slots currently retiring (any phase) — a graceful
+  /// close draining or an abort awaiting its teardown acknowledgement.
+  #[inline]
+  pub fn retiring_count(&self) -> usize {
+    self.plane.retiring.len()
+  }
+
+  /// Diagnostic count of retire deadlines that expired while still `Aborting` —
+  /// a residual socket pin the engine has made visible but could not free.
+  #[inline]
+  pub fn teardown_overruns(&self) -> u64 {
+    self.plane.teardown_overruns
   }
 
   /// Whether a passive-open listener slot is currently installed.
@@ -1213,57 +1243,126 @@ where
 }
 
 // Reliable-plane lifecycle helpers that move the connection handle `C` by value
-// (into the pool, the listener slot, and the `StreamIo` socket calls), so they
-// need `C: Copy`. The two that also key the `closing` map (`teardown`,
-// `flush_closing`) add `C: Eq + Hash` method-locally.
+// (into the pool, the listener slot, and the `StreamIo` socket calls) and key the
+// `retiring` / `slot_gen` ledgers by it, so they need `C: Copy + Eq + Hash`.
 impl<I, C, R> Engine<I, C, R>
 where
   I: memberlist_proto::Id,
-  C: Copy,
+  C: Copy + Eq + Hash,
 {
-  /// Reclaim gracefully-closing connections that have finished closing or whose
-  /// close has exceeded `cfg.close_timeout`.
+  /// Advance a slot's occupancy generation as it leaves the pool for a fresh
+  /// `listen` / `connect`, returning the new generation to stamp onto the socket
+  /// call. The first-ever occupancy of a slot uses [`SlotGen::START`]; each later
+  /// acquire is the successor of the slot's last generation.
   ///
-  /// A graceful `teardown` issues a FIN and parks the handle in `plane.closing`
-  /// with a deadline (see `teardown`). The socket then works through the TCP FIN
-  /// states (FinWait / Closing / LastAck / TimeWait) before becoming reusable.
-  /// This pass returns to the pool every parked handle that has reached a reusable
-  /// state and leaves the rest parked for a later tick.
+  /// The engine never advances past a generation before it has observed
+  /// [`StreamIo::teardown_done`] for it (the reap is the only path that frees a
+  /// slot back to the pool), so at most one generation of a slot is ever live.
+  fn advance_slot_gen(&mut self, c: C) -> SlotGen {
+    let g = self
+      .plane
+      .slot_gen
+      .get(&c)
+      .map_or(SlotGen::START, |prev| prev.next());
+    self.plane.slot_gen.insert(c, g);
+    g
+  }
+
+  /// The current occupancy generation of slot `c` (the one a retire tears down).
+  /// A slot always has a recorded generation by the time it is retired — it was
+  /// stamped when acquired (or by `set_listener` at construction) — but fall back
+  /// to [`SlotGen::START`] defensively so a missing entry never panics.
+  fn current_slot_gen(&self, c: C) -> SlotGen {
+    self
+      .plane
+      .slot_gen
+      .get(&c)
+      .copied()
+      .unwrap_or(SlotGen::START)
+  }
+
+  /// Park a retired occupancy in the ledger and immediately run one completion
+  /// check, so a slot whose teardown is ALREADY complete (a synchronous driver's
+  /// aborted-and-clean socket, the clean both-FIN close, or an embassy slot the
+  /// worker already reset) is freed THIS tick — preserving the pre-ledger
+  /// same-tick reclaim — while one still tearing down waits in `retiring`.
   ///
-  /// "Reusable" is `!is_open()` — false only in the `Closed` and `TimeWait`
-  /// states, exactly the states in which the socket's next consumer (`connect()`
-  /// dial or `listen()` replenish) is accepted; both reject an open socket and
-  /// both reset it on reuse, discarding any `TimeWait` 2MSL remainder. A socket
-  /// still flushing its FIN (FinWait1/2, Closing, LastAck) is still `is_open()` and
-  /// stays parked, so a socket is never reclaimed before its FIN completes.
-  ///
-  /// The deadline bounds that wait: the link layer applies no TCP timeout by
-  /// default, so a peer that vanishes mid-FIN leaves the socket `is_open()` forever
-  /// and the handle would leak. When `now >= deadline`, this pass `abort()`s the
-  /// socket (forcing it straight to `Closed`) before returning it, so a stuck
-  /// graceful close cannot permanently shrink the pool. A healthy close reaches
-  /// `Closed` long before the deadline and is reclaimed on the `!is_open()` path.
-  fn reap_closing<S>(&mut self, now: Instant, stream: &mut S)
+  /// The caller has already issued the `close(c, g)` / `abort(c, g)` (or the
+  /// socket was already terminal). NEVER `pool.give` directly on a retire path:
+  /// the slot returns to the pool only through [`reap_retiring`], gated on the
+  /// driver's teardown acknowledgement.
+  fn retire<S>(&mut self, c: C, g: SlotGen, phase: RetirePhase, now: Instant, stream: &mut S)
   where
     S: StreamIo<Conn = C>,
   {
-    // Retain the still-closing handles; give the finished (or timed-out) ones back
-    // to the pool.
-    let pool = &mut self.plane.pool;
-    self.plane.closing.retain(|&c, &mut deadline| {
-      if !stream.is_open(c) {
-        // Clean close completed (Closed / TimeWait): reclaim.
+    self.plane.retiring.insert(
+      c,
+      Retiring {
+        generation: g,
+        deadline: now + self.cfg.close_timeout,
+        phase,
+      },
+    );
+    self.reap_retiring(now, stream);
+  }
+
+  /// Reclaim retired occupancies whose teardown the driver has acknowledged, and
+  /// escalate any whose teardown has stalled past `cfg.close_timeout`.
+  ///
+  /// A retire (`close` or `abort`) parks the handle in `plane.retiring` with a
+  /// deadline and phase (see [`retire`](Self::retire)). This pass:
+  ///
+  /// - returns to the pool every handle whose [`StreamIo::teardown_done`] now
+  ///   reports the socket is reset and reusable — the ONLY path a slot rejoins
+  ///   the pool, so a handle is never reused while a pending RST/FIN could be
+  ///   clobbered or suppressed;
+  /// - escalates a `Draining` entry past its deadline to `Aborting`, issuing the
+  ///   RST (a peer that vanished mid-FIN never drains on its own);
+  /// - on an `Aborting` entry past its deadline, re-issues the (idempotent) abort,
+  ///   re-arms the deadline, and counts a `teardown_overruns` — a residual pin the
+  ///   engine has surfaced but cannot free (an embassy socket owned by a worker
+  ///   future the engine cannot dispossess; freeing it into a new occupancy would
+  ///   be a lie). It NEVER blind-frees an unacknowledged teardown.
+  fn reap_retiring<S>(&mut self, now: Instant, stream: &mut S)
+  where
+    S: StreamIo<Conn = C>,
+  {
+    // Split the disjoint plane fields so the `retiring.retain` closure can also
+    // `pool.give` and bump `teardown_overruns`; `close_timeout` is copied out of
+    // `cfg` up front so no borrow of it outlives the closure.
+    let close_timeout = self.cfg.close_timeout;
+    let ReliablePlane {
+      pool,
+      retiring,
+      teardown_overruns,
+      ..
+    } = &mut self.plane;
+    retiring.retain(|&c, r| {
+      if stream.teardown_done(c, r.generation) {
+        // The driver acknowledged the teardown: the socket is reset and reusable.
         pool.give(c);
         return false;
       }
-      if now >= deadline {
-        // Peer vanished mid-FIN: force the socket to Closed and reclaim so the pool
-        // (and the listener replenished from it) recover.
-        stream.abort(c);
-        pool.give(c);
-        return false;
+      if now >= r.deadline {
+        match r.phase {
+          RetirePhase::Draining => {
+            // A graceful close stalled (peer vanished mid-FIN): force the RST and
+            // switch to Aborting, re-arming the deadline for the abort's own egress.
+            stream.abort(c, r.generation);
+            r.phase = RetirePhase::Aborting;
+            r.deadline = now + close_timeout;
+          }
+          RetirePhase::Aborting => {
+            // The abort's teardown is STILL unacknowledged a full close_timeout on:
+            // re-issue the (idempotent) RST, re-arm, and surface the residual pin.
+            // Never blind-free — an async worker still owns this socket.
+            stream.abort(c, r.generation);
+            r.deadline = now + close_timeout;
+            *teardown_overruns += 1;
+          }
+        }
       }
-      // Still flushing its FIN within the deadline — keep parked.
+      // Keep parked: teardown not yet acknowledged.
       true
     });
   }
@@ -1299,14 +1398,17 @@ where
     };
 
     // Reject a reliable connection from a CIDR-blocked peer at the transport
-    // boundary: abort the connected listener socket and return it to the pool
+    // boundary: abort the connected listener socket and RETIRE its occupancy
     // WITHOUT registering the exchange, then re-arm a fresh listener — the same
-    // abort-and-reclaim shape the `dial` reject path uses. (The advertised-address
-    // filter is the composed routable-address alive delegate.)
+    // abort-and-retire shape the `dial` reject path uses. The accepted socket is
+    // established (a real peer tuple), so on smoltcp the reap holds the slot until
+    // the RST egresses. (The advertised-address filter is the composed
+    // routable-address alive delegate.)
     if cidr_blocks(&self.cidr_policy, peer.ip()) {
-      stream.abort(c);
-      self.plane.pool.give(c);
+      let g = self.current_slot_gen(c);
+      stream.abort(c, g);
       self.plane.listener = None;
+      self.retire(c, g, RetirePhase::Aborting, now, stream);
       self.ensure_listener(stream);
       return;
     }
@@ -1325,12 +1427,13 @@ where
           .insert(eid, Connection::accepted(peer, c));
         self.plane.accepted_inbound += 1;
       }
-      // Abort the just-accepted socket AND return its handle to the pool — the
-      // same abort-and-reclaim shape the CIDR reject path above uses — so a
-      // rejection does not shrink the finite reliable pool one slot at a time.
+      // Abort the just-accepted socket AND retire its occupancy — the same
+      // abort-and-retire shape the CIDR reject path above uses — so a rejection
+      // does not shrink the finite reliable pool one slot at a time.
       None => {
-        stream.abort(c);
-        self.plane.pool.give(c);
+        let g = self.current_slot_gen(c);
+        stream.abort(c, g);
+        self.retire(c, g, RetirePhase::Aborting, now, stream);
       }
     }
 
@@ -1367,21 +1470,60 @@ where
     if self.plane.listener.is_some() {
       return;
     }
-    // Take only a slot the driver reports as fully reset and reuse-ready. An
-    // async-teardown driver (embassy-net) returns a just-aborted slot to the pool
-    // before its worker has reset the socket; re-`listen`ing it now would clobber
-    // the pending abort and leak the prior connection into the listener. A
-    // still-resetting slot is left in the pool and a later tick re-establishes the
-    // listener once the worker has finished. For a synchronous driver every slot is
-    // ready, so this is unchanged.
-    if let Some(c) = self.plane.pool.take_where(|&c| stream.reuse_ready(c)) {
+    // Every pooled slot is reusable by construction — a slot still tearing down
+    // lives in `retiring`, not the pool, and is returned only once its teardown is
+    // acknowledged — so a plain `take` always yields a slot safe to `listen`.
+    if let Some(c) = self.plane.pool.take() {
+      // Mint this slot's next occupancy generation and stamp it onto the listen.
+      let g = self.advance_slot_gen(c);
       // `listen()` only fails on port 0 or an already-open socket. Neither applies:
       // a pooled socket is Closed (freshly created, or reset on reuse out of
       // TimeWait/Closed) and `cfg.port` is the user-supplied non-zero port.
       // Ignoring Err: the two failure modes above are both unreachable here.
-      let _ = stream.listen(c, self.cfg.port);
+      let _ = stream.listen(c, self.cfg.port, g);
       self.plane.listener = Some(c);
     }
+  }
+
+  /// Re-arm a listener whose socket the link layer reaped to a terminal state,
+  /// routing it through the occupancy ledger rather than re-`listen`ing the dead
+  /// socket in place.
+  ///
+  /// A driver whose link layer can reap a stalled listener — the smoltcp
+  /// inactivity timeout aborting an unanswered half-open to `Closed` — calls this
+  /// after its stack tick. When the installed listener socket is no longer open
+  /// (`!is_open`), the listener is a self-abort: its occupancy is RETIRED
+  /// (`abort` → `Aborting` → the reap frees it once the RST egress is
+  /// acknowledged) and a fresh listener is re-acquired from the pool, minting the
+  /// NEXT generation. Expressing the reap as an occupancy retire+reacquire — not a
+  /// raw re-listen — is what closes #161 for the listener too: re-`listen`ing a
+  /// socket whose abort RST has not yet egressed would suppress that RST (the
+  /// link layer's `listen` resets the socket and clears the pending reset).
+  ///
+  /// A no-op when there is no listener or its socket is still open (a healthy
+  /// `Listen`, or an in-progress half-open the accept path handles).
+  pub fn rearm_reaped_listener<S>(&mut self, now: Instant, stream: &mut S)
+  where
+    S: StreamIo<Conn = C>,
+  {
+    let Some(c) = self.plane.listener else {
+      return;
+    };
+    // A healthy listener is `Listen` (open); a just-accepted one is swapped out by
+    // `check_listener`. Only a link-layer-reaped listener is terminal here.
+    if stream.is_open(c) {
+      return;
+    }
+    // Retire the reaped occupancy and re-acquire. The reaped socket already sent
+    // its RST during the stack tick (its tuple is cleared), so on smoltcp the reap
+    // acknowledges the teardown at once and re-arms the listener THIS call; a
+    // socket whose RST has not yet egressed instead waits for a later reap, never
+    // re-listened over a pending reset.
+    let g = self.current_slot_gen(c);
+    stream.abort(c, g);
+    self.plane.listener = None;
+    self.retire(c, g, RetirePhase::Aborting, now, stream);
+    self.ensure_listener(stream);
   }
 
   /// Abort the exchange for the machine's `StreamAction::Abort`, discarding any
@@ -1401,7 +1543,7 @@ where
   /// A `PendingDial` connection (pool was exhausted, no slot assigned) has nothing to
   /// reset or reclaim: removing it is the whole abort, so a failed exchange is never
   /// later dialed.
-  fn abort_exchange<S>(&mut self, eid: ExchangeId, stream: &mut S)
+  fn abort_exchange<S>(&mut self, eid: ExchangeId, now: Instant, stream: &mut S)
   where
     S: StreamIo<Conn = C>,
   {
@@ -1410,10 +1552,12 @@ where
     };
     // Removing the `Connection` already dropped its parked `out` bytes, the deferred
     // FIN flag, and the EOF-delivered flag. Reclaim the socket (if any) with a hard
-    // reset so a half-delivered frame is not flushed.
+    // reset so a half-delivered frame is not flushed; retire the occupancy so the
+    // slot is freed only once the RST egress is acknowledged.
     if let Some(c) = conn.socket {
-      stream.abort(c);
-      self.plane.pool.give(c);
+      let g = self.current_slot_gen(c);
+      stream.abort(c, g);
+      self.retire(c, g, RetirePhase::Aborting, now, stream);
     }
   }
 
@@ -1473,8 +1617,6 @@ where
   fn teardown<S>(&mut self, eid: ExchangeId, now: Instant, stream: &mut S)
   where
     S: StreamIo<Conn = C>,
-    // Keys the `closing` map when parking an in-flight FIN.
-    C: Eq + Hash,
   {
     // Inspect the connection WITHOUT removing it: a graceful close that still has
     // bytes to deliver must stay mapped (transition to `Closing`) so the egress pump
@@ -1505,20 +1647,22 @@ where
     let may_send = stream.may_send(c);
     let tx_unacked = stream.send_queue(c);
 
+    let g = self.current_slot_gen(c);
     if !is_open {
       // `!is_open()` is exactly `Closed | TimeWait`: both FINs already exchanged (or
-      // the socket was already aborted). Reclaim directly, no close handshake left to
-      // wait on.
+      // the socket was already aborted). Retire (Draining) and run the immediate
+      // completion check — a clean close is acknowledged at once and freed this
+      // tick, no close handshake left to wait on.
       self.plane.connections.remove(&eid);
-      self.plane.pool.give(c);
+      self.retire(c, g, RetirePhase::Draining, now, stream);
     } else if was_half_closed {
       // Our graceful FIN is in flight but the peer has not finished the close. Do NOT
       // close()/abort() now: the FIN was already sent and the tx half is closed, so
-      // any `out` remainder is undeliverable. Park the handle in `closing` with a
-      // `now + close_timeout` deadline so the reap pass reclaims it once it reaches
-      // Closed, or force-aborts it at the deadline if the peer vanished mid-FIN.
+      // any `out` remainder is undeliverable. Retire (Draining) with a
+      // `now + close_timeout` deadline so the reap reclaims it once its teardown is
+      // acknowledged, or force-aborts it at the deadline if the peer vanished mid-FIN.
       self.plane.connections.remove(&eid);
-      self.plane.closing.insert(c, now + self.cfg.close_timeout);
+      self.retire(c, g, RetirePhase::Draining, now, stream);
     } else if may_send && (out_pending || tx_unacked != 0) {
       // Send-capable (Established / CloseWait) with outbound bytes the peer has NOT yet
       // received — parked in `out` (partial-write backpressure) and/or still
@@ -1547,22 +1691,22 @@ where
       // Established one-shot teardown with an empty ring. Emit the graceful FIN
       // immediately — `close()` (CloseWait → LastAck, Established → FinWait1) sends our
       // FIN, giving the peer a clean EOF so its initiator commits the response — and
-      // park the handle in `closing` for the reap backstop.
+      // retire (Draining) for the reap backstop.
       self.plane.connections.remove(&eid);
-      stream.close(c);
-      self.plane.closing.insert(c, now + self.cfg.close_timeout);
+      stream.close(c, g);
+      self.retire(c, g, RetirePhase::Draining, now, stream);
     } else {
       // Abrupt teardown: a graceful `Close` whose socket is not send-capable and never
       // half-closed (e.g. a connection still in SynSent / never promoted). FAILED
       // exchanges no longer reach here — they arrive via `StreamAction::Abort` →
       // `abort_exchange` — but a graceful `Close` over a socket the peer never
-      // established is handled defensively the same way: RST and reclaim at once.
-      // `abort()` sets the state to Closed immediately, so reuse is safe without waiting
-      // for a close handshake, and any stale tx bytes are discarded rather than flushed
-      // — there is nothing to deliver over a connection the peer never established.
+      // established is handled defensively the same way: RST and retire. `abort()`
+      // moves the socket to Closed and the reap frees the slot once the RST egress is
+      // acknowledged; any stale tx bytes are discarded rather than flushed — there is
+      // nothing to deliver over a connection the peer never established.
       self.plane.connections.remove(&eid);
-      stream.abort(c);
-      self.plane.pool.give(c);
+      stream.abort(c, g);
+      self.retire(c, g, RetirePhase::Aborting, now, stream);
     }
   }
 
@@ -1598,15 +1742,13 @@ where
   fn flush_closing<S>(&mut self, now: Instant, stream: &mut S)
   where
     S: StreamIo<Conn = C>,
-    // Keys the `closing` map when parking an in-flight FIN.
-    C: Eq + Hash,
   {
     // Classify each Closing connection without holding the `connections` borrow across
-    // the mutating socket / pool / closing-map calls below.
+    // the mutating socket / pool / retiring-ledger calls below.
     enum ClosingAction<C> {
-      /// Drained: emit the FIN and park the handle in `closing`.
+      /// Drained: emit the FIN and retire (Draining) the handle.
       Fin(C),
-      /// No drain progress for the full `close_timeout`: abort and reclaim.
+      /// No drain progress for the full `close_timeout`: abort and retire.
       Abort(C),
       /// The drain made progress this tick (the peer acked bytes): re-arm the idle
       /// deadline with the new undelivered mark.
@@ -1643,16 +1785,19 @@ where
       match outcome {
         ClosingAction::Fin(c) => {
           // Every byte was delivered: FIN the transmit half so the peer reads a clean
-          // EOF, then park for the reap backstop.
+          // EOF, then retire (Draining) for the reap backstop.
           self.plane.connections.remove(&eid);
-          stream.close(c);
-          self.plane.closing.insert(c, now + self.cfg.close_timeout);
+          let g = self.current_slot_gen(c);
+          stream.close(c, g);
+          self.retire(c, g, RetirePhase::Draining, now, stream);
         }
         ClosingAction::Abort(c) => {
-          // Idle deadline elapsed: RST and reclaim at once.
+          // Idle deadline elapsed: RST and retire (Aborting); the reap frees the slot
+          // once the RST egress is acknowledged.
           self.plane.connections.remove(&eid);
-          stream.abort(c);
-          self.plane.pool.give(c);
+          let g = self.current_slot_gen(c);
+          stream.abort(c, g);
+          self.retire(c, g, RetirePhase::Aborting, now, stream);
         }
         ClosingAction::Progress(mark) => {
           // Re-arm the idle deadline from `now`; keep the connection mapped so the egress
@@ -1874,8 +2019,9 @@ where
       // on the TRANSMIT half only. The connection stays in `connections` so the peer's
       // reply + FIN still pump inbound; the transition to HalfClosed (and clearing
       // `fin_pending`) records the FIN is sent so a later flush tick does not `close()`
-      // twice, and the eventual `StreamAction::Close` reclaims the socket.
-      stream.close(c);
+      // twice, and the eventual `StreamAction::Close` reclaims the socket. The FIN
+      // rides the slot's current occupancy generation.
+      stream.close(c, self.current_slot_gen(c));
       if let Some(conn) = self.plane.connections.get_mut(&eid) {
         conn.fin_pending = false;
         conn.state = ConnState::HalfClosed;
@@ -2005,11 +2151,11 @@ where
     G: GossipIo,
     S: StreamIo<Conn = C>,
   {
-    // 1a. Reap gracefully-closing connections. The driver's step-1 stack tick may
-    // have advanced FIN exchanges to completion; reclaim any that are now fully
-    // closed (or have exceeded `cfg.close_timeout`) so the freed handles back new
-    // dials/accepts this same tick.
-    self.reap_closing(now, stream);
+    // 1a. Reap retired occupancies. The driver's step-1 stack tick may have
+    // advanced FIN/RST exchanges to completion; return to the pool any whose
+    // teardown the driver now acknowledges (or escalate a stalled one) so the
+    // freed handles back new dials/accepts this same tick.
+    self.reap_retiring(now, stream);
 
     // The accept/replenish/dial phase is ordered LISTENER-FIRST: the inbound
     // listener gets first claim on a free slot and a deferred outbound dial takes
@@ -2039,7 +2185,7 @@ where
     // 1c. Self-heal a still-missing listener, then assign any remaining free slots
     // to deferred dials (listener-first). This runs the SAME rebalance as the late
     // call after the in-tick frees below (step 7), here over whatever
-    // `reap_closing` freed plus the spare pool. Running it BEFORE the machine tick
+    // `reap_retiring` freed plus the spare pool. Running it BEFORE the machine tick
     // (step 6) is required: a `PendingDial` deferred on a PRIOR tick must be
     // assigned a freed slot and dialed before step 6's `handle_timeout` could
     // elapse its bridge and tear it down — so the early site cannot move later.
@@ -2165,44 +2311,42 @@ where
 
     // 7d''. Re-run the listener/dial rebalance over every slot the machine tick and
     // teardown just freed back to the pool IN THIS TICK. The early 1c rebalance ran
-    // before step 6 and saw only what `reap_closing` had freed; the slot-freeing
-    // close paths run LATER (after the machine tick fires the `Close` actions), so a
-    // slot freed here would otherwise sit idle until the next pump — stranding a
-    // deferred `PendingDial` or a missing listener until some unrelated timer
-    // happened to wake the driver, possibly past the waiting exchange's own bridge
-    // deadline (which would then kill it before it ever got the slot). Servicing the
-    // frees in-tick lets a freed slot immediately back the oldest waiting dial — its
-    // SYN egress is then driven by the stack deadline, which the driver reports as
-    // ~now — or restore the listener, so the returned wakeup is naturally correct
-    // with no `pending_dial` deadline term needed.
+    // before step 6 and saw only what the 1a reap had freed; the slot-freeing
+    // teardown paths run LATER (after the machine tick fires the `Close`/`Abort`
+    // actions), so a slot freed here would otherwise sit idle until the next pump —
+    // stranding a deferred `PendingDial` or a missing listener until some unrelated
+    // timer happened to wake the driver, possibly past the waiting exchange's own
+    // bridge deadline (which would then kill it before it ever got the slot).
+    // Servicing the frees in-tick lets a freed slot immediately back the oldest
+    // waiting dial — its SYN egress is then driven by the stack deadline, which the
+    // driver reports as ~now — or restore the listener, so the returned wakeup is
+    // naturally correct with no `pending_dial` deadline term needed.
     //
-    // This MUST stay positioned after EVERY late `pool.give()` path so it dominates
-    // all of them. Today those are exactly three, all upstream here:
-    //   - 7a `drain_stream_actions` → `teardown`: the `Closed | TimeWait` branch
-    //     and the abrupt `abort()` branch both `pool.give(h)`.
-    //   - 7d' `flush_closing`: the deadline-`Abort` branch `pool.give(h)`.
-    // (`teardown`'s and `flush_closing`'s graceful-FIN branches `closing.insert`
-    // instead of `give`; those handles are reaped to the pool by a LATER tick's 1a
-    // `reap_closing`, whose freed slots the next tick's 1c rebalance claims — so they
-    // need no in-tick rebalance here.) If a new late free path is ever added, it must
-    // precede this call or the end-of-tick invariant below regresses.
+    // A slot returns to the pool ONLY through a reap (`retire` runs an immediate
+    // reap, and 1a runs the periodic one): a teardown whose completion the driver
+    // acknowledges this tick — a synchronous driver's clean/aborted socket — is
+    // freed by that immediate reap and serviced here; one still tearing down waits
+    // in `retiring` and is freed by a LATER tick's 1a reap, whose freed slots the
+    // next tick's 1c rebalance claims. Either way this late rebalance dominates
+    // every in-tick free; if a new late free path is ever added, it must precede
+    // this call or the end-of-tick invariant below regresses.
     self.rebalance_pool(now, stream);
 
-    // Invariant held at end-of-tick: if the reliable pool holds a REUSE-READY slot
-    // then a listener is present AND no connection remains in `PendingDial`. The late
+    // Invariant held at end-of-tick: if the reliable pool is non-empty then a
+    // listener is present AND no connection remains in `PendingDial`. The late
     // rebalance above is the last pool-touching reliable phase — the gossip egress
     // touches only the gossip socket, never the reliable pool — so the invariant
-    // cannot be disturbed before the deadline is computed below. The readiness
-    // qualifier matters for an async-teardown driver: a freed-but-still-resetting
-    // slot is intentionally NOT reused this tick (its worker has not reset the
-    // socket yet), so a pool holding only such slots is not a rebalance miss — the
-    // listener / deferred dial is serviced on the later tick the worker completes its
-    // reset. For a synchronous driver every freed slot is ready, so this is the same
-    // "non-empty pool ⇒ listener present and no PendingDial" guarantee as before.
+    // cannot be disturbed before the deadline is computed below. Every pooled slot
+    // is reusable by construction now (a slot still tearing down lives in
+    // `retiring`, never the pool), so there is no readiness qualifier: a non-empty
+    // pool is unconditionally a listener + deferred-dial the rebalance must have
+    // spent. A freed-but-still-resetting slot (async-teardown driver) is simply not
+    // in the pool this tick — it is serviced on the later tick its teardown is
+    // acknowledged and the reap returns it.
     debug_assert!(
-      !self.plane.pool.any_where(|&c| stream.reuse_ready(c))
+      self.plane.pool.is_empty()
         || (self.plane.listener.is_some() && self.plane.pending_dial_count() == 0),
-      "end-of-tick: a reuse-ready reliable slot left a listener missing or a PendingDial unserviced"
+      "end-of-tick: a reusable reliable slot left a listener missing or a PendingDial unserviced"
     );
 
     // 7e. Egress: drain outbound gossip transmits, encode, and send.
@@ -2216,40 +2360,45 @@ where
     //
     // - `machine` — the SWIM machine's next timer (probe / gossip / push-pull /
     //   bridge handshake-and-dial deadlines).
-    // - `closing` — the soonest force-abort deadline among connections parked
-    //   mid-close. Two engine-owned deadline sources feed this class, both enforced
-    //   only on a tick that actually runs: the `plane.closing` map (a detached
-    //   handle whose FIN is in flight, reaped by `reap_closing`) and the
-    //   `close_deadline` of any connection still draining in `Closing` before its
-    //   terminal FIN (the backstop in `flush_closing`). If either were omitted, a
-    //   peer that vanished mid-close would keep its socket `is_open()` forever (the
-    //   link layer sets no TCP timeout), and a deadline-driven caller could sleep
-    //   arbitrarily past `close_timeout`. Folding the soonest of BOTH in guarantees
-    //   the caller wakes by `close_timeout` to reap it, so pool / listener recovery
-    //   is bounded by `Options::close_timeout` as documented.
+    // - `closing` — the soonest teardown-escalation deadline. Two engine-owned
+    //   deadline sources feed this class, both enforced only on a tick that
+    //   actually runs: the `plane.retiring` ledger (a retired occupancy whose
+    //   teardown the driver has not acknowledged — a Draining entry's escalation to
+    //   Aborting, or an Aborting entry's overrun re-arm, both driven by 1a
+    //   `reap_retiring`) and the `close_deadline` of any connection still draining
+    //   in `Closing` before its terminal FIN (the backstop in `flush_closing`). If
+    //   either were omitted, a peer that vanished mid-close would keep its socket
+    //   `is_open()` forever (the link layer sets no TCP timeout), and a
+    //   deadline-driven caller could sleep arbitrarily past `close_timeout`.
+    //   Folding the soonest of BOTH in guarantees the caller wakes by
+    //   `close_timeout` to escalate it, so pool / listener recovery is bounded by
+    //   `Options::close_timeout` as documented.
     //
     // `pending_dial` deliberately contributes NO deadline of its own: a buffered
     // dial is serviced when a slot frees, never on a clock of its own, and every
     // free either is handled THIS tick or already feeds one of the terms above. A
-    // slot freed straight to the pool by a teardown / close this tick (7a / 7d') is
-    // spent on the oldest waiting dial by the late 7d'' rebalance immediately, so its
-    // SYN is queued before this deadline is computed and surfaces in the driver's
-    // stack term. A slot whose graceful FIN is still in flight is reaped to the pool
-    // only on a LATER tick by `reap_closing`, but that tick is itself guaranteed by
-    // the `closing` deadline folded in here; the next tick's early rebalance then
-    // dials the waiting connection. Either way the unblocking event is already
-    // covered, so a `pending_dial` term would be redundant.
+    // slot whose teardown is acknowledged this tick is spent on the oldest waiting
+    // dial by the late 7d'' rebalance immediately, so its SYN is queued before this
+    // deadline is computed and surfaces in the driver's stack term. A slot still
+    // tearing down is reaped to the pool only on a LATER tick by `reap_retiring`,
+    // and the driver's own link-layer deadline (the smoltcp socket's pending-RST
+    // dispatch, ~now) plus the folded `retiring` escalation deadline both guarantee
+    // that tick runs; the next tick's early rebalance then dials the waiting
+    // connection. Either way the unblocking event is already covered, so a
+    // `pending_dial` term would be redundant.
     //
     // The driver folds its own link-layer next-event deadline into the returned
     // instant before sleeping.
     let machine = self.endpoint.poll_timeout();
-    // Soonest force-abort deadline across BOTH close backstops: detached handles
-    // parked in `plane.closing`, and connections still draining in `Closing` before
-    // their terminal FIN (their `close_deadline`).
+    // Soonest teardown-escalation deadline across BOTH close backstops: retired
+    // occupancies parked in `plane.retiring` (a Draining entry's escalation to
+    // Aborting, or an Aborting entry's overrun re-arm), and connections still
+    // draining in `Closing` before their terminal FIN (their `close_deadline`).
     let closing = self
       .plane
-      .closing
+      .retiring
       .values()
+      .map(|r| &r.deadline)
       .chain(
         self
           .plane
@@ -2275,21 +2424,29 @@ where
   /// so the bridge is ultimately retired by its own dial/handshake deadline; the
   /// driver has no prompt dial-cancel path.) Shared by the live `Connect` drain and
   /// the deferred `drain_pending_dials` retry so both dial identically.
-  fn dial<S>(&mut self, eid: ExchangeId, peer: SocketAddr, c: C, now: Instant, stream: &mut S)
-  where
+  fn dial<S>(
+    &mut self,
+    eid: ExchangeId,
+    peer: SocketAddr,
+    c: C,
+    g: SlotGen,
+    now: Instant,
+    stream: &mut S,
+  ) where
     S: StreamIo<Conn = C>,
   {
     // Reject an outbound dial to a CIDR-blocked peer before `connect`: a blocked
     // peer forms no reliable connection in either direction (the accept guard
     // drops its passive opens; this drops our active dials, so a join toward a
-    // blocked seed fails rather than completing the push/pull). Reclaim the
+    // blocked seed fails rather than completing the push/pull). Abort + retire the
     // freshly-assigned socket and terminalize via `handle_dial_failed`: a
     // never-connected dial must FAIL the exchange, not feed a benign EOF that a
-    // one-way user-message send would read as success.
+    // one-way user-message send would read as success. The socket never connected
+    // (no peer tuple), so the retire is acknowledged and the slot freed this tick.
     if cidr_blocks(&self.cidr_policy, peer.ip()) {
-      stream.abort(c);
-      self.plane.pool.give(c);
+      stream.abort(c, g);
       self.plane.connections.remove(&eid);
+      self.retire(c, g, RetirePhase::Aborting, now, stream);
       self.endpoint.handle_dial_failed(eid, now);
       return;
     }
@@ -2298,14 +2455,14 @@ where
     // a useful TCP destination: the link layer's `connect` rejects the unspecified
     // address and port 0 with `Unaddressable`, and a multicast/broadcast remote
     // resolves only to a derived L2 multicast/broadcast MAC. Screen here on the same
-    // `is_unicast` predicate so no doomed connect is started, and reclaim cleanly
+    // `is_unicast` predicate so no doomed connect is started, and retire the socket
     // exactly as the connect-rejection path does: the freshly-assigned socket is
-    // still Closed, so `abort()` is a no-op that returns it reusable (never leaked),
-    // and terminalize the exchange as a dial failure.
+    // still Closed with no peer tuple, so its teardown is acknowledged at once and
+    // the slot freed this tick; terminalize the exchange as a dial failure.
     if !socket_addr_is_routable(&peer) {
-      stream.abort(c);
-      self.plane.pool.give(c);
+      stream.abort(c, g);
       self.plane.connections.remove(&eid);
+      self.retire(c, g, RetirePhase::Aborting, now, stream);
       self.endpoint.handle_dial_failed(eid, now);
       return;
     }
@@ -2315,13 +2472,13 @@ where
     // ExchangeId is a monotonically increasing u64 per endpoint, making this a cheap,
     // collision-resistant scheme without an explicit port allocator.
     let local_port = 49152u16 + (eid.get() as u16 % 16384);
-    if stream.connect(c, peer, local_port).is_err() {
-      // The connect was rejected before any SYN: abort, reclaim the socket, drop the
-      // Connection (with all its parked state), and terminalize the exchange as a
-      // dial failure.
-      stream.abort(c);
-      self.plane.pool.give(c);
+    if stream.connect(c, peer, local_port, g).is_err() {
+      // The connect was rejected before any SYN: abort + retire the socket (still
+      // Closed, no peer tuple, so freed this tick), drop the Connection (with all
+      // its parked state), and terminalize the exchange as a dial failure.
+      stream.abort(c, g);
       self.plane.connections.remove(&eid);
+      self.retire(c, g, RetirePhase::Aborting, now, stream);
       self.endpoint.handle_dial_failed(eid, now);
     }
   }
@@ -2333,7 +2490,7 @@ where
   /// which is the machine's monotonically increasing per-endpoint correlation
   /// token, so the oldest deferred dial is dialed first. Stops the moment the pool
   /// empties again so the rest stay parked for a later tick. Called each `pump` LAST
-  /// in the accept/replenish/dial phase — after `reap_closing`, `check_listener`,
+  /// in the accept/replenish/dial phase — after `reap_retiring`, `check_listener`,
   /// and the `ensure_listener` self-heal — so the inbound listener has already taken
   /// its slot and a deferred dial claims only what remains, yet a slot freed by a
   /// timed-out dead-seed bridge is still promptly spent on the oldest waiting viable
@@ -2362,13 +2519,16 @@ where
     waiting.sort_by_key(|(eid, _)| eid.get());
 
     for (eid, peer) in waiting {
-      // Only a reset, reuse-ready slot may back a fresh dial (see `ensure_listener`
-      // for the async-teardown rationale). When none is ready — the pool is empty,
-      // or every freed slot is still resetting — leave the rest parked for a later
-      // tick; the deferred dials are retried once a worker finishes its reset.
-      let Some(c) = self.plane.pool.take_where(|&c| stream.reuse_ready(c)) else {
+      // Every pooled slot is reusable by construction (a slot still tearing down
+      // lives in `retiring`, not the pool), so a plain `take` yields a slot safe to
+      // dial. When the pool is empty, leave the rest parked for a later tick; the
+      // deferred dials are retried once a retire is acknowledged and the reap frees a
+      // slot.
+      let Some(c) = self.plane.pool.take() else {
         break;
       };
+      // Mint this slot's next occupancy generation for the dial.
+      let g = self.advance_slot_gen(c);
       // Assign the freed slot and transition PendingDial → Dialing, then issue the
       // connect. `assign_socket` retains any parked `out` / `fin_pending`. The
       // connection is still present (a racing Close would have removed it, but
@@ -2377,7 +2537,7 @@ where
       if let Some(conn) = self.plane.connections.get_mut(&eid) {
         conn.assign_socket(c);
       }
-      self.dial(eid, peer, c, now, stream);
+      self.dial(eid, peer, c, g, now, stream);
     }
   }
 
@@ -2389,7 +2549,7 @@ where
   /// before `drain_pending_dials` touches the pool, so an inbound listener is never
   /// starved by deferred outbound intent — and a no-op when the pool is empty or
   /// there is no unmet demand. Run at two points each `pump`: early (1c), over the
-  /// slots `reap_closing` freed plus the spare pool, BEFORE the machine tick so a
+  /// slots `reap_retiring` freed plus the spare pool, BEFORE the machine tick so a
   /// prior-tick `PendingDial` is dialed before its bridge can time out; and late
   /// (7d''), over every slot the machine's teardown / close paths freed THIS tick, so
   /// an in-tick free immediately backs a waiting dial or restores the listener
@@ -2452,19 +2612,19 @@ where
           // dial defers to `PendingDial`): the exchange exists and will complete.
           self.outbound_stream_ids.insert(eid, info.stream_id());
 
-          // Only a reset, reuse-ready slot may back a fresh dial (see
-          // `ensure_listener`); a freed-but-still-resetting slot (async-teardown
-          // driver) is skipped and the dial defers to `PendingDial` until its worker
-          // finishes the reset.
-          match self.plane.pool.take_where(|&c| stream.reuse_ready(c)) {
+          // Every pooled slot is reusable by construction (a slot still tearing down
+          // lives in `retiring`, not the pool); when the pool is exhausted the dial
+          // defers to `PendingDial` until a retire is acknowledged and a slot frees.
+          match self.plane.pool.take() {
             Some(c) => {
-              // A slot is free: create the Dialing connection (slot assigned) and
-              // issue the connect this same tick.
+              // A slot is free: mint its occupancy generation, create the Dialing
+              // connection (slot assigned), and issue the connect this same tick.
+              let g = self.advance_slot_gen(c);
               self
                 .plane
                 .connections
                 .insert(eid, Connection::dialing(peer, c));
-              self.dial(eid, peer, c, now, stream);
+              self.dial(eid, peer, c, g, now, stream);
             }
             None => {
               // Pool exhausted (or every freed slot still resetting): no slot free to
@@ -2472,7 +2632,7 @@ where
               // poll_action and is never re-emitted, so dropping it would LOSE the
               // dial intent. Record a PendingDial connection (no slot yet) instead;
               // this same tick's request bytes and a same-tick Shutdown accumulate on
-              // it, and `drain_pending_dials` assigns a slot once `reap_closing` frees
+              // it, and `drain_pending_dials` assigns a slot once `reap_retiring` frees
               // one (e.g. when a dead seed's bridge times out). This is what lets a
               // multi-seed `join()` reach a viable later seed even when earlier dead
               // seeds momentarily hold every slot.
@@ -2516,9 +2676,10 @@ where
           // elapsed exchange deadline): its buffered `out` bytes are stale and MUST be
           // discarded, not drained. Hard-reset the socket (RST) and reclaim it
           // immediately — no `Closing` drain, no graceful FIN. Unlike `Close`,
-          // `abort_exchange` never parks the connection: a failed exchange owes nothing
-          // to the peer, so its socket returns straight to the pool.
-          self.abort_exchange(r.id(), stream);
+          // `abort_exchange` never drains: a failed exchange owes nothing to the
+          // peer, so its socket is retired and freed once its RST egress is
+          // acknowledged.
+          self.abort_exchange(r.id(), now, stream);
         }
       }
     }

--- a/memberlist-embedded/src/engine/tests.rs
+++ b/memberlist-embedded/src/engine/tests.rs
@@ -116,7 +116,17 @@ impl StreamIo for NoStream {
     self.free.len()
   }
 
-  fn listen(&mut self, _c: u32, _port: u16) -> Result<(), crate::StreamIoError> {
+  fn teardown_done(&self, _c: u32, _g: crate::SlotGen) -> bool {
+    // Synchronous mock: a retired slot is immediately reusable.
+    true
+  }
+
+  fn listen(
+    &mut self,
+    _c: u32,
+    _port: u16,
+    _g: crate::SlotGen,
+  ) -> Result<(), crate::StreamIoError> {
     Ok(())
   }
 
@@ -129,6 +139,7 @@ impl StreamIo for NoStream {
     _c: u32,
     _remote: SocketAddr,
     _local_port: u16,
+    _g: crate::SlotGen,
   ) -> Result<(), crate::StreamIoError> {
     Err(crate::StreamIoError::Busy)
   }
@@ -165,9 +176,9 @@ impl StreamIo for NoStream {
     0
   }
 
-  fn close(&mut self, _c: u32) {}
+  fn close(&mut self, _c: u32, _g: crate::SlotGen) {}
 
-  fn abort(&mut self, _c: u32) {}
+  fn abort(&mut self, _c: u32, _g: crate::SlotGen) {}
 }
 
 fn node_addr(port: u16) -> SocketAddr {
@@ -1048,7 +1059,14 @@ impl StreamIo for ProgRel {
     self.free.len()
   }
 
-  fn listen(&mut self, c: u32, _port: u16) -> Result<(), crate::StreamIoError> {
+  fn teardown_done(&self, c: u32, _g: crate::SlotGen) -> bool {
+    // Synchronous mock: a retired slot is reusable once its socket is Closed
+    // (`abort` drops `open` at once; a graceful `close` leaves it open until the
+    // test/fabric drops `open`, mirroring the old `!is_open()` reap gate).
+    !self.sock(c).open
+  }
+
+  fn listen(&mut self, c: u32, _port: u16, _g: crate::SlotGen) -> Result<(), crate::StreamIoError> {
     // A listening socket is open and awaiting a passive open; reset any prior
     // per-slot residue so a reclaimed-then-relistened handle starts clean.
     *self.sock_mut(c) = SockState::idle();
@@ -1065,6 +1083,7 @@ impl StreamIo for ProgRel {
     c: u32,
     remote: SocketAddr,
     _local_port: u16,
+    _g: crate::SlotGen,
   ) -> Result<(), crate::StreamIoError> {
     if self.connect_fails {
       return Err(crate::StreamIoError::Busy);
@@ -1122,13 +1141,13 @@ impl StreamIo for ProgRel {
     self.sock(c).tx_unacked
   }
 
-  fn close(&mut self, c: u32) {
+  fn close(&mut self, c: u32, _g: crate::SlotGen) {
     self.closed.push(c);
     // A graceful close leaves the socket open (FIN in flight) until the test (or
-    // reap) drops `open`; the engine parks it in `closing` for the reap pass.
+    // reap) drops `open`; the engine parks it in `retiring` (Draining) for the reap.
   }
 
-  fn abort(&mut self, c: u32) {
+  fn abort(&mut self, c: u32, _g: crate::SlotGen) {
     self.aborted.push(c);
     let s = self.sock_mut(c);
     s.open = false;
@@ -1270,7 +1289,9 @@ fn pending_dial_when_pool_exhausted_then_dialed_once_slot_frees() {
   // but not the path under test.)
   engine.set_listener(9);
   let mut stream = ProgRel::new(&[5, 9]);
-  stream.listen(9, 7946).expect("mock listen succeeds");
+  stream
+    .listen(9, 7946, crate::SlotGen::START)
+    .expect("mock listen succeeds");
 
   let to = node_addr(7002);
   engine
@@ -1421,42 +1442,82 @@ fn reliable_partial_write_parks_remainder_then_flushes_in_order() {
   );
 }
 
-/// The reap pass reclaims a gracefully-closing handle as soon as its socket
-/// reaches a reusable (`!is_open`) state, and force-aborts one whose close has
-/// exceeded `close_timeout` — so a vanished-mid-FIN peer can never permanently
-/// shrink the pool. Both `closing`-map handles are driven directly.
+/// The reap pass reclaims a retired handle as soon as its teardown is
+/// acknowledged (`teardown_done`), and escalates a Draining handle whose close has
+/// exceeded `close_timeout` to Aborting (force-abort) — reclaiming it only once
+/// that abort's teardown is itself acknowledged, so a vanished-mid-FIN peer can
+/// never permanently shrink the pool yet the engine never blind-frees an
+/// unacknowledged teardown. Both `retiring` handles are driven directly.
 #[test]
-fn reap_closing_reclaims_finished_and_force_aborts_timed_out() {
+fn reap_retiring_reclaims_finished_and_escalates_timed_out() {
+  use crate::{RetirePhase, Retiring, SlotGen};
+
   let (mut engine, now) = engine_with_stream_timeout(Duration::from_secs(30));
   let mut stream = ProgRel::new(&[0, 1]);
-  // Slot 0: a clean close that has reached Closed (`!is_open`). Slot 1: a peer that
-  // vanished mid-FIN — still open, past its deadline.
+  // Slot 0: a clean graceful close that has reached Closed (`teardown_done`). Slot
+  // 1: a peer that vanished mid-FIN — still open, its Draining deadline elapsed.
   stream.sock_mut(0).open = false;
   stream.sock_mut(1).open = true;
   let close_timeout = Duration::from_secs(10);
-  // Park both in `closing`, slot 1 with an already-elapsed deadline.
-  engine.plane_mut().closing.insert(0, now + close_timeout);
-  engine.plane_mut().closing.insert(1, now);
+  // Park both Draining, slot 1 with an already-elapsed deadline.
+  engine.plane_mut().retiring.insert(
+    0,
+    Retiring {
+      generation: SlotGen::START,
+      deadline: now + close_timeout,
+      phase: RetirePhase::Draining,
+    },
+  );
+  engine.plane_mut().retiring.insert(
+    1,
+    Retiring {
+      generation: SlotGen::START,
+      deadline: now,
+      phase: RetirePhase::Draining,
+    },
+  );
 
-  assert_eq!(engine.closing_count(), 2, "two handles parked mid-close");
+  assert_eq!(engine.retiring_count(), 2, "two handles retiring");
+  assert_eq!(
+    engine.closing_count(),
+    2,
+    "both are Draining (graceful close)"
+  );
 
-  // Pump at `now`: slot 0 is reusable (reclaimed on the `!is_open` path); slot 1 is
-  // past its deadline (`now >= deadline`) so it is force-aborted then reclaimed.
+  // Pump at `now`: slot 0's teardown is acknowledged (reclaimed on the
+  // `teardown_done` path); slot 1 is past its Draining deadline, so it is escalated
+  // — force-aborted and switched to Aborting — but NOT freed this pass (the engine
+  // never blind-frees an unacknowledged teardown).
   let mut gossip = NoGossip;
   engine.pump(now, &mut gossip, &mut stream);
 
-  assert_eq!(
-    engine.closing_count(),
-    0,
-    "both closing handles must be reaped (one clean, one force-aborted)"
-  );
   assert!(
     stream.aborted.contains(&1),
-    "the vanished-mid-FIN handle past its deadline must be force-aborted"
+    "the vanished-mid-FIN handle past its Draining deadline must be force-aborted"
   );
   assert!(
     !stream.aborted.contains(&0),
     "the cleanly-closed handle must be reclaimed without an abort"
+  );
+  assert_eq!(
+    engine.closing_count(),
+    0,
+    "slot 0 reaped; slot 1 escalated out of Draining into Aborting"
+  );
+  assert_eq!(
+    engine.retiring_count(),
+    1,
+    "the escalated handle stays retiring (Aborting) until its teardown is acknowledged"
+  );
+
+  // The escalation's `abort` dropped slot 1's `open`, so its teardown is now
+  // acknowledged: a second pass reaps it and the ledger empties.
+  let later = now + Duration::from_millis(1);
+  engine.pump(later, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.retiring_count(),
+    0,
+    "the escalated handle is reclaimed once its abort teardown is acknowledged"
   );
 }
 
@@ -1472,7 +1533,9 @@ fn check_listener_admits_inbound_and_replenishes_the_listener() {
   engine.plane_mut().pool.push(0);
   engine.set_listener(1);
   let mut stream = ProgRel::new(&[0, 1]);
-  stream.listen(1, 7946).expect("mock listen succeeds");
+  stream
+    .listen(1, 7946, crate::SlotGen::START)
+    .expect("mock listen succeeds");
   // The listener's passive open settled with a known, in-policy remote.
   stream.sock_mut(1).accepted = Some(node_addr(7950));
   stream.sock_mut(1).established = true;
@@ -1662,7 +1725,15 @@ impl StreamIo for LinkRel {
     self.free.len()
   }
 
-  fn listen(&mut self, c: u32, _port: u16) -> Result<(), crate::StreamIoError> {
+  fn teardown_done(&self, c: u32, _g: crate::SlotGen) -> bool {
+    // Synchronous fabric mock: a retired occupancy is reusable once its pipe is no
+    // longer open (a RST, or both FINs exchanged) — exactly the pre-ledger reap
+    // gate. A graceful close whose peer FIN has not arrived stays `is_open`, so it
+    // waits in `retiring` (Draining) until the peer FINs, then frees.
+    !self.is_open(c)
+  }
+
+  fn listen(&mut self, c: u32, _port: u16, _g: crate::SlotGen) -> Result<(), crate::StreamIoError> {
     self.role.borrow_mut().insert(c, SlotRole::Listening);
     Ok(())
   }
@@ -1693,6 +1764,7 @@ impl StreamIo for LinkRel {
     c: u32,
     remote: SocketAddr,
     _local_port: u16,
+    _g: crate::SlotGen,
   ) -> Result<(), crate::StreamIoError> {
     let mut fab = self.fabric.borrow_mut();
     let pipe = fab.next_pipe;
@@ -1842,7 +1914,7 @@ impl StreamIo for LinkRel {
     }
   }
 
-  fn close(&mut self, c: u32) {
+  fn close(&mut self, c: u32, _g: crate::SlotGen) {
     if let Some(SlotRole::Bound(pipe, end)) = self.role_of(c) {
       let mut fab = self.fabric.borrow_mut();
       if let Some(p) = fab.pipes.get_mut(&pipe) {
@@ -1854,7 +1926,7 @@ impl StreamIo for LinkRel {
     }
   }
 
-  fn abort(&mut self, c: u32) {
+  fn abort(&mut self, c: u32, _g: crate::SlotGen) {
     if let Some(SlotRole::Bound(pipe, _)) = self.role_of(c) {
       let mut fab = self.fabric.borrow_mut();
       if let Some(p) = fab.pipes.get_mut(&pipe) {
@@ -1949,8 +2021,12 @@ impl LinkPair {
     // mock free-lists so a re-listen does not double-hand a listener.
     a_rel.free.retain(|h| h != a_listener);
     b_rel.free.retain(|h| h != b_listener);
-    a_rel.listen(*a_listener, 7946).expect("listen");
-    b_rel.listen(*b_listener, 7947).expect("listen");
+    a_rel
+      .listen(*a_listener, 7946, crate::SlotGen::START)
+      .expect("listen");
+    b_rel
+      .listen(*b_listener, 7947, crate::SlotGen::START)
+      .expect("listen");
 
     let a2b: Rc<RefCell<Vec<(SocketAddr, Vec<u8>)>>> = Rc::new(RefCell::new(Vec::new()));
     let b2a: Rc<RefCell<Vec<(SocketAddr, Vec<u8>)>>> = Rc::new(RefCell::new(Vec::new()));
@@ -2817,7 +2893,9 @@ fn check_listener_rejects_cidr_blocked_inbound_and_rearms() {
 
   let before = engine.accepted_inbound_count();
   let mut stream = ProgRel::new(&[0, 1]);
-  stream.listen(1, 7946).expect("listen");
+  stream
+    .listen(1, 7946, crate::SlotGen::START)
+    .expect("listen");
   // The passive open settled, but the remote is out-of-policy (192.168/16).
   stream.sock_mut(1).accepted = Some(SocketAddr::new(
     IpAddr::V4(Ipv4Addr::new(192, 168, 1, 9)),
@@ -2842,19 +2920,25 @@ fn check_listener_rejects_cidr_blocked_inbound_and_rearms() {
   );
 }
 
-/// `reap_closing` leaves a still-closing handle parked when its socket has not yet
-/// reached a reusable state AND its deadline has not elapsed — it is reclaimed only
-/// later. This pins the keep-parked arm (the complement of the reclaim/abort arms).
+/// `reap_retiring` leaves a still-draining handle parked when its teardown is not
+/// yet acknowledged AND its deadline has not elapsed — it is reclaimed only later.
+/// This pins the keep-parked arm (the complement of the reclaim/escalate arms).
 #[test]
-fn reap_closing_keeps_a_still_closing_handle_parked() {
+fn reap_retiring_keeps_a_still_draining_handle_parked() {
+  use crate::{RetirePhase, Retiring, SlotGen};
+
   let (mut engine, now) = engine_with_stream_timeout(Duration::from_secs(30));
   let mut stream = ProgRel::new(&[0]);
   // Slot 0 is still flushing its FIN: open, and its deadline is in the future.
   stream.sock_mut(0).open = true;
-  engine
-    .plane_mut()
-    .closing
-    .insert(0, now + Duration::from_secs(60));
+  engine.plane_mut().retiring.insert(
+    0,
+    Retiring {
+      generation: SlotGen::START,
+      deadline: now + Duration::from_secs(60),
+      phase: RetirePhase::Draining,
+    },
+  );
 
   let mut gossip = NoGossip;
   engine.pump(now, &mut gossip, &mut stream);
@@ -2862,7 +2946,7 @@ fn reap_closing_keeps_a_still_closing_handle_parked() {
   assert_eq!(
     engine.closing_count(),
     1,
-    "a still-open, within-deadline closing handle must stay parked for a later tick"
+    "a still-open, within-deadline draining handle must stay parked for a later tick"
   );
   assert!(
     !stream.aborted.contains(&0),
@@ -2965,5 +3049,321 @@ fn encrypted_node_drops_plaintext_inbound_gossip() {
     engine.num_members(),
     1,
     "a plaintext datagram on an encrypted node must be dropped — no ghost admitted"
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Generation-tagged slot-teardown protocol (the reuse ledger).
+//
+// A generation-aware async-teardown mock whose `teardown_done` reports `true`
+// ONLY once the test explicitly acknowledges the matching occupancy generation
+// (`ack`) — modelling the embassy-net worker that resets a socket on a later wake
+// and acknowledges the exact occupancy it served. It pins the ledger's
+// generation-tagged reuse gate directly, without a second engine.
+
+struct AckRel {
+  /// Driver-side free-list (unused by the engine, which owns `ReliablePlane::pool`).
+  free: Vec<u32>,
+  /// The occupancy generation whose teardown the "worker" has acknowledged, per
+  /// slot. Absent = not yet acknowledged.
+  acked: BTreeMap<u32, crate::SlotGen>,
+  /// Per-slot open flag (set by `listen`/`connect`; `ack` clears it, modelling the
+  /// socket reaching a clean Closed state).
+  open: BTreeMap<u32, bool>,
+  /// `(slot, gen)` of every `abort`, for assertions.
+  aborts: Vec<(u32, crate::SlotGen)>,
+}
+
+impl AckRel {
+  fn new(handles: &[u32]) -> Self {
+    Self {
+      free: handles.to_vec(),
+      acked: BTreeMap::new(),
+      open: BTreeMap::new(),
+      aborts: Vec::new(),
+    }
+  }
+
+  /// Acknowledge that the worker finished tearing down occupancy `g` of slot `c`
+  /// (the async reset completed), so `teardown_done(c, g)` now reports `true`.
+  fn ack(&mut self, c: u32, g: crate::SlotGen) {
+    self.acked.insert(c, g);
+    self.open.insert(c, false);
+  }
+}
+
+impl StreamIo for AckRel {
+  type Conn = u32;
+
+  fn take_free(&mut self) -> Option<u32> {
+    self.free.pop()
+  }
+
+  fn give(&mut self, c: u32) {
+    self.free.push(c);
+  }
+
+  fn free_count(&self) -> usize {
+    self.free.len()
+  }
+
+  fn teardown_done(&self, c: u32, g: crate::SlotGen) -> bool {
+    // Only the acknowledged occupancy is reusable; a mismatched/unknown gen is inert.
+    self.acked.get(&c) == Some(&g)
+  }
+
+  fn listen(&mut self, c: u32, _port: u16, _g: crate::SlotGen) -> Result<(), crate::StreamIoError> {
+    self.open.insert(c, true);
+    Ok(())
+  }
+
+  fn accepted_peer(&self, _c: u32) -> Option<SocketAddr> {
+    None
+  }
+
+  fn connect(
+    &mut self,
+    c: u32,
+    _remote: SocketAddr,
+    _local_port: u16,
+    _g: crate::SlotGen,
+  ) -> Result<(), crate::StreamIoError> {
+    self.open.insert(c, true);
+    Ok(())
+  }
+
+  fn may_send(&self, _c: u32) -> bool {
+    false
+  }
+
+  fn may_recv(&self, _c: u32) -> bool {
+    false
+  }
+
+  fn is_open(&self, c: u32) -> bool {
+    self.open.get(&c).copied().unwrap_or(false)
+  }
+
+  fn is_established(&self, _c: u32) -> bool {
+    false
+  }
+
+  fn recv(&mut self, _c: u32, _buf: &mut [u8]) -> Option<usize> {
+    None
+  }
+
+  fn recv_finished(&self, _c: u32) -> bool {
+    false
+  }
+
+  fn send(&mut self, _c: u32, _bytes: &[u8]) -> usize {
+    0
+  }
+
+  fn send_queue(&self, _c: u32) -> usize {
+    0
+  }
+
+  fn close(&mut self, _c: u32, _g: crate::SlotGen) {}
+
+  fn abort(&mut self, c: u32, g: crate::SlotGen) {
+    self.aborts.push((c, g));
+  }
+}
+
+/// (a) A retired slot is NOT returned to the pool until the driver acknowledges
+/// its teardown for the retired generation; the matching acknowledgement then
+/// frees it on the next reap.
+#[test]
+fn retiring_slot_is_not_freed_until_teardown_done() {
+  use crate::{RetirePhase, Retiring, SlotGen};
+
+  let (mut engine, now) = engine_with_stream_timeout(Duration::from_secs(30));
+  // A listener is already installed so the freed slot is not immediately re-armed
+  // as the listener (which would hide it from the pool count).
+  engine.set_listener(9);
+  let mut stream = AckRel::new(&[]);
+  engine.plane_mut().slot_gen.insert(0, SlotGen::START);
+  engine.plane_mut().retiring.insert(
+    0,
+    Retiring {
+      generation: SlotGen::START,
+      deadline: now + Duration::from_secs(30),
+      phase: RetirePhase::Aborting,
+    },
+  );
+
+  let mut gossip = NoGossip;
+  engine.pump(now, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.retiring_count(),
+    1,
+    "an unacknowledged teardown keeps the slot retiring"
+  );
+  assert_eq!(
+    engine.pool_free_count(),
+    0,
+    "a retiring slot is never in the pool"
+  );
+
+  // The worker acknowledges the occupancy: the next reap frees it.
+  stream.ack(0, SlotGen::START);
+  engine.pump(now, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.retiring_count(),
+    0,
+    "an acknowledged teardown frees the slot"
+  );
+  assert_eq!(
+    engine.pool_free_count(),
+    1,
+    "the freed slot returns to the pool"
+  );
+}
+
+/// (b) A stale (mismatched-generation) acknowledgement never frees a later
+/// occupancy — the reuse gate is generation-tagged, so an ack for a prior
+/// occupancy of the same slot is inert.
+#[test]
+fn a_stale_gen_ack_never_frees_a_later_occupancy() {
+  use crate::{RetirePhase, Retiring, SlotGen};
+
+  let (mut engine, now) = engine_with_stream_timeout(Duration::from_secs(30));
+  engine.set_listener(9);
+  let mut stream = AckRel::new(&[]);
+  // Slot 0 is on its SECOND occupancy (generation START.next()).
+  let g1 = SlotGen::START.next();
+  engine.plane_mut().slot_gen.insert(0, g1);
+  engine.plane_mut().retiring.insert(
+    0,
+    Retiring {
+      generation: g1,
+      deadline: now + Duration::from_secs(30),
+      phase: RetirePhase::Aborting,
+    },
+  );
+
+  let mut gossip = NoGossip;
+  // A stale acknowledgement for the PRIOR occupancy (START) must not free g1.
+  stream.ack(0, SlotGen::START);
+  engine.pump(now, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.retiring_count(),
+    1,
+    "a mismatched-generation ack must never free a later occupancy"
+  );
+
+  // The matching acknowledgement frees it.
+  stream.ack(0, g1);
+  engine.pump(now, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.retiring_count(),
+    0,
+    "the matching-generation ack frees the slot"
+  );
+}
+
+/// (c) An `Aborting` occupancy whose teardown is never acknowledged past its
+/// deadline re-issues the (idempotent) abort, re-arms the deadline, and counts a
+/// `teardown_overruns` — surfacing the residual pin without ever blind-freeing it.
+#[test]
+fn an_unacknowledged_abort_past_its_deadline_counts_a_teardown_overrun() {
+  use crate::{RetirePhase, Retiring, SlotGen};
+
+  let (mut engine, now) = engine_with_stream_timeout(Duration::from_secs(30));
+  engine.set_listener(9);
+  let mut stream = AckRel::new(&[]);
+  // `engine_with_stream_timeout` fixes `close_timeout` at 10s.
+  let close_timeout = Duration::from_secs(10);
+  engine.plane_mut().slot_gen.insert(0, SlotGen::START);
+  // Already Aborting with an elapsed deadline; the worker never acknowledges.
+  engine.plane_mut().retiring.insert(
+    0,
+    Retiring {
+      generation: SlotGen::START,
+      deadline: now,
+      phase: RetirePhase::Aborting,
+    },
+  );
+
+  let mut gossip = NoGossip;
+  assert_eq!(engine.teardown_overruns(), 0);
+
+  engine.pump(now, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.teardown_overruns(),
+    1,
+    "an Aborting deadline expiry counts an overrun"
+  );
+  assert_eq!(
+    engine.retiring_count(),
+    1,
+    "the residual pin is surfaced, never blind-freed"
+  );
+  assert!(
+    stream.aborts.iter().any(|&(c, _)| c == 0),
+    "the overrun re-issues the (idempotent) abort"
+  );
+
+  // The deadline was re-armed to now + close_timeout, so a same-instant pump does
+  // not double-count.
+  engine.pump(now, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.teardown_overruns(),
+    1,
+    "the re-armed deadline is not immediately re-expired"
+  );
+
+  // Past the re-armed deadline it counts again.
+  let later = now + close_timeout + Duration::from_millis(1);
+  engine.pump(later, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.teardown_overruns(),
+    2,
+    "a second Aborting deadline expiry counts again"
+  );
+}
+
+/// (d) A never-activated occupancy — a retired slot whose socket was never opened
+/// (the CIDR / routable reject inside `dial`, aborting before any `listen` /
+/// `connect`) — round-trips cleanly through the ledger: retire → acknowledge →
+/// free. With a synchronous driver the never-opened socket is already reusable, so
+/// the immediate reap frees it the SAME tick, exactly as the real dial-reject
+/// paths (`reliable_non_routable_dial_fails_before_connect`,
+/// `reliable_dial_connect_rejection_fails_and_reclaims_slot`) rely on.
+#[test]
+fn a_never_activated_occupancy_round_trips_through_the_ledger() {
+  use crate::{RetirePhase, Retiring, SlotGen};
+
+  let (mut engine, now) = engine_with_stream_timeout(Duration::from_secs(30));
+  engine.set_listener(9);
+  // Slot 0 was taken and its generation minted, but never listened/connected, so
+  // its socket is `!open` — a synchronous driver reports its teardown done at once.
+  let mut stream = ProgRel::new(&[0, 9]);
+  assert!(
+    !stream.sock(0).open,
+    "the never-activated slot's socket is closed"
+  );
+  engine.plane_mut().slot_gen.insert(0, SlotGen::START);
+  engine.plane_mut().retiring.insert(
+    0,
+    Retiring {
+      generation: SlotGen::START,
+      deadline: now + Duration::from_secs(30),
+      phase: RetirePhase::Aborting,
+    },
+  );
+
+  let mut gossip = NoGossip;
+  engine.pump(now, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.retiring_count(),
+    0,
+    "a never-activated occupancy's teardown is acknowledged and freed the same tick"
+  );
+  assert_eq!(
+    engine.pool_free_count(),
+    1,
+    "the reclaimed slot is back in the pool"
   );
 }

--- a/memberlist-embedded/src/lib.rs
+++ b/memberlist-embedded/src/lib.rs
@@ -51,9 +51,9 @@ pub use memberlist_proto::{AliveDelegate, MaybeOwned, MaybeResolved, MergeDelega
 #[cfg(feature = "cidr")]
 #[cfg_attr(docsrs, doc(cfg(feature = "cidr")))]
 pub use memberlist_proto::{AddrParseError, CidrPolicy, IpNet};
-pub use reliable::{ConnState, Connection, Pool, ReliablePlane};
+pub use reliable::{ConnState, Connection, Pool, ReliablePlane, RetirePhase, Retiring};
 pub use resolver::{MAX_RESOLVED_ADDRS_PER_SEED, ResolvedAddrs};
-pub use stream_io::{StreamIo, StreamIoError};
+pub use stream_io::{SlotGen, StreamIo, StreamIoError};
 #[cfg(checksum)]
 #[cfg_attr(
   docsrs,

--- a/memberlist-embedded/src/reliable/mod.rs
+++ b/memberlist-embedded/src/reliable/mod.rs
@@ -35,6 +35,8 @@ use hashbrown::HashMap;
 use memberlist_proto::{Instant, streams::ExchangeId};
 use std::{collections::VecDeque, vec::Vec};
 
+use crate::stream_io::SlotGen;
+
 /// Free-list of pre-created reliable-stream connection handles.
 ///
 /// Handles are added at construction via [`Pool::push`]. The dial/accept paths
@@ -58,47 +60,29 @@ impl<C> Pool<C> {
 
   /// Remove and return a free connection handle, or `None` if all slots are in
   /// use (pool exhausted).
+  ///
+  /// The free-list holds ONLY reusable slots by construction: a slot mid-teardown
+  /// lives in [`ReliablePlane::retiring`], not here, and is returned to the pool
+  /// only once its teardown is acknowledged
+  /// ([`StreamIo::teardown_done`](crate::StreamIo::teardown_done)). So the plain
+  /// LIFO pop always yields a slot the engine may immediately `listen` / `connect`.
   pub fn take(&mut self) -> Option<C> {
     self.free.pop()
   }
 
-  /// Remove and return the most-recently-freed handle for which `ready` is
-  /// `true`, leaving every other handle (those still tearing down) in the pool.
-  ///
-  /// A driver whose teardown is asynchronous returns a freed slot to the pool
-  /// before its worker has reset the underlying socket; reusing such a slot for a
-  /// fresh `listen` / `connect` would clobber the pending reset and leak the prior
-  /// connection's state. This lets the engine pick a slot that is actually reset
-  /// (`StreamIo::reuse_ready`) and skip the rest until a later tick, without
-  /// reordering the survivors (so the still-tearing-down slots stay available the
-  /// instant they become ready). For a synchronous-teardown driver every slot is
-  /// ready, so this is exactly `take`.
-  pub fn take_where(&mut self, mut ready: impl FnMut(&C) -> bool) -> Option<C> {
-    // Scan newest-first (the end of the Vec) to match `take`'s LIFO reuse, and
-    // remove the first ready handle in place, preserving the order of the rest.
-    let pos = (0..self.free.len()).rev().find(|&i| ready(&self.free[i]))?;
-    Some(self.free.remove(pos))
-  }
-
-  /// Return a handle to the free-list once its exchange is complete. The caller
-  /// is responsible for resetting / aborting the socket first so it is ready for
-  /// reuse.
+  /// Return a handle to the free-list once its occupancy's teardown has been
+  /// acknowledged. The engine returns a slot here only after
+  /// [`StreamIo::teardown_done`](crate::StreamIo::teardown_done) reports the
+  /// socket is reset and reusable, so every pooled slot is reusable by
+  /// construction.
   pub fn give(&mut self, c: C) {
     self.free.push(c);
   }
 
-  /// Whether the free-list is empty (all slots assigned to active exchanges or
-  /// the listener).
+  /// Whether the free-list is empty (all slots assigned to active exchanges, the
+  /// listener, or a pending teardown in [`ReliablePlane::retiring`]).
   pub fn is_empty(&self) -> bool {
     self.free.is_empty()
-  }
-
-  /// Whether any free handle currently satisfies `ready` — i.e. at least one
-  /// pooled slot the engine could reuse THIS tick. Used by the end-of-tick
-  /// invariant so a pool holding only still-resetting (not reuse-ready) slots does
-  /// not count as "a free slot the rebalance should have spent".
-  pub fn any_where(&self, ready: impl FnMut(&C) -> bool) -> bool {
-    self.free.iter().any(ready)
   }
 
   /// Number of slots currently in the free-list. A diagnostic surfaced by the
@@ -278,6 +262,42 @@ impl<C> Connection<C> {
   }
 }
 
+/// The phase of a retired slot occupancy in [`ReliablePlane::retiring`].
+///
+/// A retire begins as `Draining` after a graceful `close` (our FIN is flushing;
+/// the socket works through the TCP FIN states before it is reusable) or as
+/// `Aborting` after an `abort` (the RST is egressing). The reap escalates a
+/// `Draining` entry past its deadline to `Aborting`; an `Aborting` entry never
+/// regresses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetirePhase {
+  /// A graceful close is in flight (subsumes the pre-ledger "closing" state):
+  /// our FIN was emitted and the socket is draining toward a reusable state, or
+  /// the peer's FIN is still pending. Reclaimed once the driver acknowledges the
+  /// teardown; escalated to [`RetirePhase::Aborting`] if it stalls past its
+  /// deadline.
+  Draining,
+  /// An abort (RST) has been issued and the slot is awaiting the driver's
+  /// acknowledgement that the reset has egressed and the socket is reusable.
+  Aborting,
+}
+
+/// One retired slot occupancy awaiting its teardown acknowledgement in
+/// [`ReliablePlane::retiring`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Retiring {
+  /// The generation of the occupancy being torn down. Matched against the
+  /// driver's [`StreamIo::teardown_done`](crate::StreamIo::teardown_done) so an
+  /// acknowledgement frees only the occupancy it actually completed.
+  pub generation: SlotGen,
+  /// The instant at which the reap escalates this teardown: a `Draining` entry
+  /// switches to `Aborting` (issuing the RST); an `Aborting` entry re-issues the
+  /// abort and counts a `teardown_overruns`.
+  pub deadline: Instant,
+  /// Whether this retire is a graceful drain or an abort.
+  pub phase: RetirePhase,
+}
+
 /// Maps in-flight exchanges to their [`Connection`], plus the pool and listener.
 ///
 /// `connections` is keyed by [`ExchangeId`] (the machine's correlation token);
@@ -297,33 +317,44 @@ pub struct ReliablePlane<C> {
   pub connections: HashMap<ExchangeId, Connection<C>>,
   /// The dedicated passive-open slot.
   pub listener: Option<C>,
-  /// Slots parked mid-close (our FIN sent, the peer's not yet completed), each
-  /// paired with the deadline by which the reap pass force-aborts it; reclaimed
-  /// to the free-list once they reach `Closed` (the peer's FIN completed the
-  /// close) OR the deadline elapses.
+  /// Slots whose occupancy has been retired (a graceful `close` or an `abort`
+  /// issued) but whose teardown the driver has not yet acknowledged
+  /// ([`StreamIo::teardown_done`](crate::StreamIo::teardown_done)). Keyed by the
+  /// connection handle, each entry records the retired occupancy's generation,
+  /// the deadline by which the reap pass escalates a stalled teardown, and its
+  /// [`RetirePhase`]. A slot is returned to [`Pool`] ONLY once its teardown is
+  /// acknowledged, so a handle is never reused while a pending RST/FIN could be
+  /// clobbered or suppressed.
   ///
-  /// Populated by the engine's `teardown` (or `flush_closing`) when a graceful
-  /// close emits the terminal FIN on a socket whose peer has not finished the
-  /// close: the exchange already half-closed (its graceful FIN went out earlier
-  /// while the `Connection` stayed mapped so the peer's reply still pumped); an
-  /// acceptor torn down in `CloseWait` whose reply was already fully delivered;
-  /// or a connection that finished draining its buffered reply in
-  /// [`ConnState::Closing`] and only then FIN-ed. In each case the `Connection`
-  /// is removed and the detached handle is parked here (with deadline
-  /// `now + close_timeout`) so it stays reachable. Without this map the handle
-  /// would be unreachable (absent from `connections`, `pool`, and `listener`)
-  /// and the slot would leak, permanently shrinking the pool after enough closes
-  /// whose peer lingered.
+  /// Populated by every engine teardown path — a graceful `close` whose peer has
+  /// not finished the close (parked `Draining`), an `abort` of a failed or
+  /// never-established exchange (`Aborting`), and the force-abort of a stalled
+  /// drain. Without this ledger a detached handle would be unreachable (absent
+  /// from `connections`, `pool`, and `listener`) and the slot would leak.
   ///
-  /// The deadline bounds the close: a link layer such as smoltcp sets no TCP
-  /// timeout by default, so a peer that vanishes mid-FIN (stuck in
-  /// FinWait/LastAck) would keep the socket `is_open()` forever and the handle
-  /// would never return to the pool. The reap pass force-`abort()`s any handle
-  /// parked past its deadline, guaranteeing the pool (and the listener
-  /// replenished from it) always recover. A `Close` whose socket is already
-  /// `!is_open()` (the clean both-FIN case) bypasses this map and returns
-  /// straight to the pool.
-  pub closing: HashMap<C, Instant>,
+  /// The deadline bounds the wait: a link layer such as smoltcp sets no TCP
+  /// timeout by default, so a peer that vanishes mid-FIN would keep the socket
+  /// `is_open()` forever. When a `Draining` entry passes its deadline the reap
+  /// escalates it to `Aborting` (issuing the RST); an `Aborting` entry past its
+  /// deadline re-issues the abort and counts a [`teardown_overruns`](Self::teardown_overruns).
+  /// The slot is freed only when the driver finally acknowledges the teardown —
+  /// never blindly, since a driver whose socket is owned by an async worker
+  /// cannot be dispossessed by the engine.
+  pub retiring: HashMap<C, Retiring>,
+  /// The current (or last) occupancy generation of each connection handle.
+  ///
+  /// The engine advances a slot's generation each time it takes the slot out of
+  /// the pool for a fresh `listen` / `connect`, and stamps that generation onto
+  /// the retire (`retiring`) so a teardown acknowledgement is matched to the
+  /// exact occupancy it completes. A slot with no entry has never been occupied;
+  /// its first occupancy uses [`SlotGen::START`]. Bounded by the pool size.
+  pub slot_gen: HashMap<C, SlotGen>,
+  /// Diagnostic count of `Aborting`-phase deadline expiries — a retired occupancy
+  /// whose teardown the driver has still not acknowledged a full `close_timeout`
+  /// after the abort was issued. A non-zero value witnesses a residual socket pin
+  /// (e.g. an embassy worker future the engine cannot dispossess); it never
+  /// causes the engine to free a slot whose teardown is unacknowledged.
+  pub teardown_overruns: u64,
   /// Monotonic count of inbound reliable connections accepted on the listener.
   ///
   /// Incremented once per passive open handed to the machine. It is a diagnostic
@@ -338,16 +369,31 @@ pub struct ReliablePlane<C> {
 
 impl<C> ReliablePlane<C> {
   /// Create an empty reliable plane: no pool entries, no connections, no
-  /// listener, no closing slots. Slots are added by the driver immediately
+  /// listener, no retiring slots. Slots are added by the driver immediately
   /// after.
   pub fn new() -> Self {
     Self {
       pool: Pool::new(),
       connections: HashMap::new(),
       listener: None,
-      closing: HashMap::new(),
+      retiring: HashMap::new(),
+      slot_gen: HashMap::new(),
+      teardown_overruns: 0,
       accepted_inbound: 0,
     }
+  }
+
+  /// Number of retired occupancies still in the graceful-close ([`RetirePhase::Draining`])
+  /// phase — the analog of the pre-ledger "closing" count. Slots aborted (or
+  /// escalated to [`RetirePhase::Aborting`]) are excluded: a graceful close parks
+  /// here awaiting the peer, whereas an abort reclaims as soon as its RST egress
+  /// is acknowledged.
+  pub fn draining_count(&self) -> usize {
+    self
+      .retiring
+      .values()
+      .filter(|r| r.phase == RetirePhase::Draining)
+      .count()
   }
 
   /// Number of reliable exchanges currently in [`ConnState::HalfClosed`]: their

--- a/memberlist-embedded/src/reliable/tests.rs
+++ b/memberlist-embedded/src/reliable/tests.rs
@@ -11,41 +11,25 @@ fn peer(port: u16) -> SocketAddr {
 type Conn = u32;
 
 #[test]
-fn take_where_skips_not_ready_slots_without_reordering() {
-  // Model an async-teardown driver: only some pooled slots are reset (ready).
-  // `take_where` must return a ready slot and leave the not-ready ones in the
-  // pool, in order, so they become takeable the instant they reset.
+fn take_is_lifo_over_reusable_slots() {
+  // The free-list holds only reusable slots by construction (a slot mid-teardown
+  // lives in `retiring`, not here), so `take` is a plain LIFO pop and `is_empty`
+  // / `free_len` track the length.
   let mut pool = Pool::<Conn>::new();
-  pool.push(10); // ready
-  pool.push(11); // NOT ready (still resetting)
-  pool.push(12); // ready
-
-  // Newest-first scan: 12 is ready, take it.
-  let ready = |c: &Conn| *c != 11;
-  assert_eq!(pool.take_where(ready), Some(12));
-  // 10 is the next ready one (11 is skipped, not removed).
-  assert_eq!(pool.take_where(ready), Some(10));
-  // Only the not-ready slot remains; `take_where` now finds nothing ready even
-  // though the pool is non-empty.
-  assert_eq!(pool.free_len(), 1);
-  assert!(!pool.is_empty());
-  assert_eq!(pool.take_where(ready), None);
-  // Once it resets, it becomes takeable.
-  assert_eq!(pool.take_where(|_| true), Some(11));
   assert!(pool.is_empty());
-}
+  assert_eq!(pool.take(), None, "an empty pool yields None");
 
-#[test]
-fn any_where_reports_only_ready_slots() {
-  let mut pool = Pool::<Conn>::new();
-  assert!(!pool.any_where(|_| true), "empty pool has no ready slot");
-  pool.push(1);
-  pool.push(2);
-  // No slot is ready (all still resetting): the pool is non-empty but
-  // `any_where` is false — the end-of-tick invariant must not flag this.
-  assert!(!pool.any_where(|_| false));
-  // At least one ready slot flips it true.
-  assert!(pool.any_where(|c| *c == 2));
+  pool.push(10);
+  pool.push(11);
+  pool.push(12);
+  assert_eq!(pool.free_len(), 3);
+  assert!(!pool.is_empty());
+
+  // Newest-first (LIFO), matching a driver's socket reuse order.
+  assert_eq!(pool.take(), Some(12));
+  assert_eq!(pool.take(), Some(11));
+  assert_eq!(pool.take(), Some(10));
+  assert!(pool.is_empty());
 }
 
 #[test]

--- a/memberlist-embedded/src/stream_io.rs
+++ b/memberlist-embedded/src/stream_io.rs
@@ -12,6 +12,50 @@ pub enum StreamIoError {
   Busy,
 }
 
+/// A generation tag identifying ONE occupancy of a pooled connection slot — the
+/// span from the engine acquiring the slot (a [`listen`](StreamIo::listen) /
+/// [`connect`](StreamIo::connect)) to the completion of that occupancy's teardown
+/// ([`teardown_done`](StreamIo::teardown_done) returning `true`).
+///
+/// The engine assigns a fresh generation each time it takes a slot out of the
+/// pool and NEVER advances a slot to its next generation before it has observed
+/// [`teardown_done`](StreamIo::teardown_done) for the current one, so at most one
+/// generation of a given slot is ever live. A driver keeps the tag only to answer
+/// [`teardown_done`](StreamIo::teardown_done): it stamps the occupancy on the
+/// gen-carrying calls and reports completion for the matching generation, so a
+/// stale/mismatched query is inert.
+///
+/// The counter is a `u32` compared only for equality and wraps on overflow; an
+/// ABA collision needs `2^32` completed-and-unobserved occupancies of one slot,
+/// impossible under the engine's block-on-acknowledgement rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SlotGen(u32);
+
+impl SlotGen {
+  /// The first generation of any slot's first occupancy.
+  pub const START: Self = Self(0);
+
+  /// The generation following this one (wrapping).
+  #[inline]
+  pub const fn next(self) -> Self {
+    Self(self.0.wrapping_add(1))
+  }
+
+  /// The raw counter value, for a driver's diagnostics.
+  #[inline]
+  pub const fn get(self) -> u32 {
+    self.0
+  }
+}
+
+impl Default for SlotGen {
+  /// The default generation is [`START`](SlotGen::START).
+  #[inline]
+  fn default() -> Self {
+    Self::START
+  }
+}
+
 /// Non-blocking pooled reliable-stream I/O, keyed by an opaque per-socket handle.
 ///
 /// A driver supplies this over a fixed pool of already-ticked reliable-stream
@@ -32,37 +76,43 @@ pub trait StreamIo {
   /// The number of connection slots currently free in the pool.
   fn free_count(&self) -> usize;
 
-  /// Whether slot `c`, currently in the free pool, is fully reset and safe to
-  /// reuse for a fresh [`listen`](StreamIo::listen) / [`connect`](StreamIo::connect).
+  /// Whether the teardown of occupancy `g` of slot `c` is complete — the socket
+  /// is back in a state where a fresh [`listen`](StreamIo::listen) /
+  /// [`connect`](StreamIo::connect) cannot clobber a pending teardown or suppress
+  /// a pending RST/FIN — so the engine may free the slot and mint its next
+  /// occupancy. This is the sole reuse gate; a slot is returned to the pool only
+  /// once this reports `true`.
+  ///
+  /// It is a pure, non-blocking query. A mismatched or unknown generation MUST
+  /// report `false`: the engine only ever queries the occupancy it is retiring,
+  /// and a stale query (a slot already reused under a later generation) must
+  /// never be mistaken for a completed teardown.
   ///
   /// A driver whose [`abort`](StreamIo::abort) / [`close`](StreamIo::close)
-  /// completes synchronously (so the socket is back in a clean Closed state the
-  /// moment the call returns — e.g. the smoltcp driver) always reports `true`,
-  /// the default. A driver whose teardown is ASYNCHRONOUS — it posts the
-  /// abort/close to a worker that resets the socket on a later wake (the
-  /// embassy-net driver) — reports `false` until that worker has actually reset
-  /// the socket and cleared its bridge state, so the engine never re-`listen`s /
-  /// re-`connect`s a slot whose previous connection is still tearing down (which
-  /// would clobber the pending abort and leak the prior connection's state into
-  /// the reused slot). The engine consults this before reusing any pooled slot;
-  /// a not-yet-ready slot is skipped this tick and retried once the worker has
-  /// finished its reset.
-  fn reuse_ready(&self, _c: Self::Conn) -> bool {
-    true
-  }
+  /// completes on a later stack tick reports `false` until that teardown has
+  /// actually finished — e.g. the smoltcp driver reports `false` for a socket
+  /// aborted this tick whose RST has not yet egressed (`Closed` with its remote
+  /// tuple still set), so the engine never reuses the handle before the reset
+  /// packet reaches the wire; the embassy-net driver reports `false` until its
+  /// per-slot worker has reset the socket and acknowledged the occupancy. A
+  /// driver whose teardown is fully synchronous can report `true` as soon as the
+  /// socket is `Closed`.
+  fn teardown_done(&self, c: Self::Conn, g: SlotGen) -> bool;
 
-  /// Begin listening for an inbound connection on `port` using slot `c`.
-  fn listen(&mut self, c: Self::Conn, port: u16) -> Result<(), StreamIoError>;
+  /// Begin listening for an inbound connection on `port` using slot `c` for
+  /// occupancy `g`.
+  fn listen(&mut self, c: Self::Conn, port: u16, g: SlotGen) -> Result<(), StreamIoError>;
 
   /// The remote address of a connection accepted on slot `c`, or `None` until a handshake completes.
   fn accepted_peer(&self, c: Self::Conn) -> Option<SocketAddr>;
 
-  /// Begin dialing `remote` from `local_port` using slot `c`.
+  /// Begin dialing `remote` from `local_port` using slot `c` for occupancy `g`.
   fn connect(
     &mut self,
     c: Self::Conn,
     remote: SocketAddr,
     local_port: u16,
+    g: SlotGen,
   ) -> Result<(), StreamIoError>;
 
   /// Whether slot `c` is established and currently writable.
@@ -120,9 +170,13 @@ pub trait StreamIo {
   /// smoltcp returns `tcp::Socket::send_queue`.
   fn send_queue(&self, c: Self::Conn) -> usize;
 
-  /// Gracefully close slot `c` (send a FIN; let buffered data flush).
-  fn close(&mut self, c: Self::Conn);
+  /// Gracefully close occupancy `g` of slot `c` (send a FIN; let buffered data
+  /// flush). The occupancy is not reusable until [`teardown_done`](StreamIo::teardown_done)
+  /// reports `true` for `g`.
+  fn close(&mut self, c: Self::Conn, g: SlotGen);
 
-  /// Abort slot `c` immediately (reset the connection, discarding buffered data).
-  fn abort(&mut self, c: Self::Conn);
+  /// Abort occupancy `g` of slot `c` immediately (reset the connection,
+  /// discarding buffered data). The occupancy is not reusable until
+  /// [`teardown_done`](StreamIo::teardown_done) reports `true` for `g`.
+  fn abort(&mut self, c: Self::Conn, g: SlotGen);
 }

--- a/memberlist-smoltcp/src/memberlist/mod.rs
+++ b/memberlist-smoltcp/src/memberlist/mod.rs
@@ -1737,31 +1737,30 @@ where
       self.engine.pump(now, &mut gossip, &mut stream)
     };
 
-    // 2b. Re-arm a listener the inactivity timeout just reaped. When an
-    // unauthenticated half-open (a `SynReceived` whose final ACK is withheld) — or
-    // a stalled established exchange — sits idle past the socket timeout, step 1's
-    // stack tick drives that socket to `Closed`. The engine keeps its handle
-    // installed as the listener (it swaps the slot out only on a completed accept,
-    // and never re-arms a socket the link layer closed underneath it), so without
-    // this the single direct-smoltcp listener would stay `Closed` and the node
-    // would accept no further inbound reliable streams — turning the bounded reap
-    // back into a permanent black-hole. Re-`listen` in place restores it: the
-    // handle is unchanged, so the engine's listener bookkeeping still holds, and
-    // the timeout — preserved across `reset()` — reaps the next half-open too,
-    // keeping the DoS bounded to one timeout window. A socket mid-handshake
-    // (`SynReceived`, still `is_open()`) or a healthy `Listen` is left untouched;
-    // only a reaped (`!is_open()`, i.e. `Closed`) listener is re-armed. This is the
-    // smoltcp analog of the per-slot self-heal the embassy-net worker performs
-    // after its own `set_timeout` fires.
-    if let Some(listener) = self.engine.listener() {
-      let port = self.engine.port();
-      let sock = self.sockets.get_mut::<tcp::Socket>(listener);
-      if !sock.is_open() {
-        // Ignoring Err: `listen` fails only on port 0 (rejected at construction) or
-        // an already-open socket (excluded by the `!is_open()` guard); neither can
-        // occur here.
-        let _ = sock.listen(port);
-      }
+    // 2b. Re-arm a listener the inactivity timeout just reaped, routing it through
+    // the engine's occupancy ledger. When an unauthenticated half-open (a
+    // `SynReceived` whose final ACK is withheld) — or a stalled established exchange
+    // — sits idle past the socket timeout, step 1's stack tick drives that socket to
+    // `Closed`. The engine keeps its handle installed as the listener (it swaps the
+    // slot out only on a completed accept, and never re-arms a socket the link layer
+    // closed underneath it), so without this the single direct-smoltcp listener
+    // would stay `Closed` and the node would accept no further inbound reliable
+    // streams — turning the bounded reap back into a permanent black-hole.
+    //
+    // `rearm_reaped_listener` expresses the reap as an occupancy RETIRE + REACQUIRE
+    // (abort → `Aborting` → the reap frees it once the RST egress is acknowledged →
+    // re-`listen` a fresh occupancy), NOT a raw in-place re-listen. That is what
+    // closes #161 for the listener too: the reaping stack tick already emitted
+    // the abort RST (its tuple is cleared), so the retired occupancy is acknowledged
+    // and the listener re-armed THIS poll; re-`listen`ing in place a socket whose
+    // RST had NOT yet egressed would `reset()` it and suppress that RST. A socket
+    // mid-handshake (`SynReceived`, still `is_open()`) or a healthy `Listen` is left
+    // untouched. This is the smoltcp analog of the per-slot self-heal the embassy-net
+    // worker performs after its own `set_timeout` fires.
+    {
+      let sockets = RefCell::new(&mut self.sockets);
+      let mut stream = SmoltcpStream::new(&mut self.iface, &sockets);
+      self.engine.rearm_reaped_listener(now, &mut stream);
     }
 
     // 3. Fold the smoltcp stack's next scheduled event into the engine's returned

--- a/memberlist-smoltcp/src/stream_io/mod.rs
+++ b/memberlist-smoltcp/src/stream_io/mod.rs
@@ -28,7 +28,7 @@
 
 use core::{cell::RefCell, net::SocketAddr};
 
-use memberlist_embedded::{StreamIo, StreamIoError};
+use memberlist_embedded::{SlotGen, StreamIo, StreamIoError};
 use smoltcp::{
   iface::{Interface, SocketHandle, SocketSet},
   socket::tcp,
@@ -73,7 +73,26 @@ impl StreamIo for SmoltcpStream<'_, '_> {
     0
   }
 
-  fn listen(&mut self, c: Self::Conn, port: u16) -> Result<(), StreamIoError> {
+  fn teardown_done(&self, c: Self::Conn, _g: SlotGen) -> bool {
+    // The occupancy generation is ignored: this synchronous driver reads the
+    // socket's TCP state directly, and the engine only ever queries the slot it is
+    // retiring. Reusable iff the socket is not open AND not a `Closed` socket whose
+    // remote tuple is still set.
+    //
+    // smoltcp `abort()` sets the state to `Closed` but KEEPS the remote tuple; the
+    // next `dispatch` emits the single RST and only THEN clears the tuple
+    // (`socket/tcp.rs`: the Closed-state RST arm, then `if self.state == Closed {
+    // self.tuple = None }`). So `Closed && remote_endpoint().is_some()` is exactly
+    // "an abort whose RST has not yet egressed" — NOT reusable, or re-`listen` /
+    // re-`connect` would `reset()` the socket and suppress the pending RST (#161).
+    // A clean `TimeWait` (state != Closed) has no RST pending and IS reusable, as is
+    // a freshly-reset `Closed` socket with no tuple. Verified against smoltcp 0.13.1.
+    let set = self.sockets.borrow();
+    let sock = set.get::<tcp::Socket>(c);
+    !sock.is_open() && !(sock.state() == tcp::State::Closed && sock.remote_endpoint().is_some())
+  }
+
+  fn listen(&mut self, c: Self::Conn, port: u16, _g: SlotGen) -> Result<(), StreamIoError> {
     // `listen()` fails on port 0 (`Unaddressable`) or an already-open socket
     // (`InvalidState`). Map both to a non-fatal error rather than panicking; the
     // engine's listener paths only ever pass a non-zero port and a freshly-reset
@@ -114,6 +133,7 @@ impl StreamIo for SmoltcpStream<'_, '_> {
     c: Self::Conn,
     remote: SocketAddr,
     local_port: u16,
+    _g: SlotGen,
   ) -> Result<(), StreamIoError> {
     // smoltcp's `connect` needs the interface context to resolve the local
     // endpoint. The interface is a separate field from the socket set, so the
@@ -222,11 +242,11 @@ impl StreamIo for SmoltcpStream<'_, '_> {
     self.sockets.borrow().get::<tcp::Socket>(c).send_queue()
   }
 
-  fn close(&mut self, c: Self::Conn) {
+  fn close(&mut self, c: Self::Conn, _g: SlotGen) {
     self.sockets.borrow_mut().get_mut::<tcp::Socket>(c).close();
   }
 
-  fn abort(&mut self, c: Self::Conn) {
+  fn abort(&mut self, c: Self::Conn, _g: SlotGen) {
     self.sockets.borrow_mut().get_mut::<tcp::Socket>(c).abort();
   }
 }

--- a/memberlist-smoltcp/src/stream_io/tests.rs
+++ b/memberlist-smoltcp/src/stream_io/tests.rs
@@ -118,12 +118,13 @@ fn established() -> (
   {
     let cell_b = RefCell::new(&mut set_b);
     let mut sb = SmoltcpStream::new(&mut if_b, &cell_b);
-    sb.listen(hb, 7946).expect("listen");
+    sb.listen(hb, 7946, SlotGen::START).expect("listen");
   }
   {
     let cell_a = RefCell::new(&mut set_a);
     let mut sa = SmoltcpStream::new(&mut if_a, &cell_a);
-    sa.connect(ha, remote_b, local_a.port()).expect("connect");
+    sa.connect(ha, remote_b, local_a.port(), SlotGen::START)
+      .expect("connect");
   }
 
   // Pump both stacks until A is send-capable (the handshake settled).
@@ -162,6 +163,98 @@ fn recv_finished(node: &mut (Interface, SocketSet<'static>, LoopDevice, SocketHa
   let cell = RefCell::new(&mut node.1);
   let view = SmoltcpStream::new(&mut node.0, &cell);
   view.recv_finished(node.3)
+}
+
+/// `teardown_done` of the `SmoltcpStream` view over `node`'s socket for gen `g`.
+fn teardown_done(
+  node: &mut (Interface, SocketSet<'static>, LoopDevice, SocketHandle),
+  g: SlotGen,
+) -> bool {
+  let cell = RefCell::new(&mut node.1);
+  let view = SmoltcpStream::new(&mut node.0, &cell);
+  view.teardown_done(node.3, g)
+}
+
+/// #161: after `abort`, the handle is NOT reusable (`teardown_done` reports
+/// `false`) until a stack poll has dispatched the RST — so a same-pump
+/// reallocation cannot suppress the pending reset by re-`listen`/`connect`ing the
+/// handle (which `reset()`s the socket and drops the queued RST). Once the RST has
+/// egressed (the remote tuple is cleared) the handle becomes reusable.
+///
+/// Mutation anchor: weaken the gate to `!is_open()` (dropping the RST-pending
+/// term) and the pre-poll assertion below flips — a same-pump reuse would then be
+/// allowed while the RST is still queued.
+#[test]
+fn abort_then_immediate_reallocation_waits_for_rst_egress() {
+  let (mut a, _b) = established();
+
+  // A aborts its established socket: smoltcp sets `Closed` but KEEPS the remote
+  // tuple until the next dispatch emits the single RST.
+  {
+    let cell = RefCell::new(&mut a.1);
+    let mut view = SmoltcpStream::new(&mut a.0, &cell);
+    view.abort(a.3, SlotGen::START);
+  }
+  assert_eq!(
+    a.1.get::<tcp::Socket>(a.3).state(),
+    tcp::State::Closed,
+    "abort moves the socket to Closed"
+  );
+  assert!(
+    a.1.get::<tcp::Socket>(a.3).remote_endpoint().is_some(),
+    "the aborted socket keeps its remote tuple until the RST egresses"
+  );
+  assert!(
+    !teardown_done(&mut a, SlotGen::START),
+    "an aborted handle is NOT reusable until its RST has egressed (#161)"
+  );
+
+  // Poll A's stack until the RST is dispatched and the tuple cleared.
+  for i in 0..20i64 {
+    a.0
+      .poll(SmolInstant::from_millis(100 + i), &mut a.2, &mut a.1);
+    if a.1.get::<tcp::Socket>(a.3).remote_endpoint().is_none() {
+      break;
+    }
+  }
+  assert!(
+    a.1.get::<tcp::Socket>(a.3).remote_endpoint().is_none(),
+    "the RST egress clears the remote tuple"
+  );
+  assert!(
+    teardown_done(&mut a, SlotGen::START),
+    "once the RST has egressed the handle is reusable"
+  );
+}
+
+/// Control: a cleanly-closed socket — both FINs exchanged, no RST pending — IS
+/// reusable at once. The reuse gate withholds only a socket whose abort RST has not
+/// yet egressed, never a graceful close that reached TimeWait / Closed.
+#[test]
+fn cleanly_closed_socket_is_reusable() {
+  let (mut a, mut b) = established();
+
+  // Both sides close their write halves gracefully, then settle the FIN handshake.
+  {
+    let cell = RefCell::new(&mut a.1);
+    let mut view = SmoltcpStream::new(&mut a.0, &cell);
+    view.close(a.3, SlotGen::START);
+  }
+  {
+    let cell = RefCell::new(&mut b.1);
+    let mut view = SmoltcpStream::new(&mut b.0, &cell);
+    view.close(b.3, SlotGen::START);
+  }
+  settle(&mut a, &mut b, 100);
+
+  assert!(
+    !a.1.get::<tcp::Socket>(a.3).is_open(),
+    "a cleanly-closed socket has left the open states"
+  );
+  assert!(
+    teardown_done(&mut a, SlotGen::START),
+    "a cleanly-closed socket (no RST pending) is reusable at once"
+  );
 }
 
 /// A graceful peer FIN is reported as a clean EOF: after B `close()`s its write

--- a/memberlist-smoltcp/tests/reliable_pool.rs
+++ b/memberlist-smoltcp/tests/reliable_pool.rs
@@ -881,13 +881,19 @@ fn listener_keeps_first_claim_on_freed_socket_over_pending_dial() {
     let _ = n.poll(clk.now(), &mut dn);
     let _ = p.poll(clk.now(), &mut dp);
 
-    // The contended poll: `p`'s inbound has just been accepted. The listener it
-    // consumed must be present again (re-established from `d1`'s freed socket)
-    // while `d2` is STILL deferred — the freed socket went to the listener, not
-    // the dial. Under the buggy order the dial would have taken it: the pending
-    // count would be zero here and the listener absent.
-    if n.accepted_inbound_count() >= 1 {
-      listener_reclaimed_freed_socket = n.listener_present() && n.pending_dial_count() >= 1;
+    // The contended reclaim: `p`'s inbound has been accepted (its accept consumed
+    // the listener), and the listener is re-established from `d1`'s freed socket
+    // while `d2` is STILL deferred — the freed socket went to the listener, not the
+    // dial. The `d1` socket's abort now retires through the ledger and is reclaimed
+    // only once its reset RST has egressed (#161), one poll after the bridge
+    // elapses, so the accept and the reclaim need not fall in the SAME poll; wait
+    // until BOTH the accept has happened AND the listener is present, then witness
+    // that `d2` never stole the one free socket (it is still `PendingDial`). Under
+    // the buggy listener-last order the dial drains before the listener replenishes,
+    // so the listener would be permanently absent here and this loop would spin out
+    // — caught by the assertion below and the second-accept corroboration.
+    if n.accepted_inbound_count() >= 1 && n.listener_present() {
+      listener_reclaimed_freed_socket = n.pending_dial_count() >= 1;
       first_accept_after_contention = n.accepted_inbound_count();
       break;
     }


### PR DESCRIPTION
## #162 X6 (stage 1/4) — generation-tagged slot-teardown protocol for the embedded reliable plane

First of four staged PRs implementing the X6 teardown-acknowledgement architecture (cross-model authority design). This stage is the **protocol foundation** — a behavior-preserving re-plumb with exactly one intended behavior change (smoltcp RST-before-reuse, closing #161 F3). The engine policy fixes (#159 F1/F2/F6) and the embassy worker redesign (#160 F1/F2) follow as stages B and C.

### The problem
The shared reliable-socket abstraction had no teardown-completion signal: `StreamIo::close()`/`abort()` returned `()`, and reuse was gated by an unversioned boolean (`reuse_ready`, defaulting to `true` — the #161 F3 trap). The engine pool assumed a teardown acknowledgement that the two drivers provide in opposite, both-wrong ways (smoltcp: not at all → RST suppression; embassy: not promptly → slot pinning).

### The protocol
- **`SlotGen(u32)`** identifies one slot *occupancy* (engine-assigned at pool acquire → teardown completion). Tagging the occupancy, not the teardown verb, makes the completion ack correct for driver-initiated deaths (a dial failure or peer RST) without the driver consuming an engine teardown verb.
- **`StreamIo` trait**: `listen`/`connect`/`close`/`abort` gain `g: SlotGen`; a new **`teardown_done(c, g) -> bool`** is the sole reuse gate (a mismatched generation returns `false`); **`reuse_ready` is deleted**.
- **Engine ledger**: `ReliablePlane` replaces the `closing` map with `retiring: HashMap<C, Retiring{generation, deadline, phase}>` (`Draining`/`Aborting`) plus `slot_gen` and a `teardown_overruns` diagnostic. `Pool::take_where`/`any_where` are deleted (the pool holds only free slots by construction). A slot is **never** returned to the pool while its teardown is unacknowledged; `reap_retiring` frees on `teardown_done`, and on a deadline **escalates** (Draining→Aborting→re-abort, bumping `teardown_overruns`) — it **never blind-frees**, because an async worker still owns the socket (the real preemption fix is stage C).

### Behavior
Behavior-preserving except:
- **smoltcp (closes #161 F3):** `teardown_done = !is_open() && !(state()==Closed && remote_endpoint().is_some())` — verified against smoltcp 0.13.1 (abort keeps the tuple until a later `dispatch` emits the RST and clears it). A same-pump abort-then-reallocate now **waits for the RST to egress** before the handle is reused (previously the reuse could suppress the RST). The ML-LIFE-01 listener re-arm is migrated onto the ledger.
- **embassy (visible pins, by design):** `worker.rs` is **byte-identical** (stage C owns the worker). The ledger's "never free a slot with teardown pending" means a worker-pinned slot (e.g. a dead on-link dial whose ARP never resolves — a pre-existing worker limitation stage C fixes) now shows in `retiring`/`teardown_overruns` instead of being masked as "free". `teardown_done` is derived as `reset_done && generation == g` to keep `worker.rs` untouched.
