### PR TITLE
fix(embedded): drain backpressured closes, hard-cap the close deadline, surface transport faults (#162 X6 stage 2/4)

### DIFF
--- a/memberlist-embassy/src/mailbox.rs
+++ b/memberlist-embassy/src/mailbox.rs
@@ -52,9 +52,17 @@ pub(crate) struct Mailbox {
   /// Whether the slot's connection has completed its handshake (worker set on a
   /// successful `connect` / `accept`). Mirrors `StreamIo::is_established`.
   pub established: bool,
-  /// Whether the slot is still usable (`false` once the connection is
-  /// closed/aborted/reset or a dial failed). The engine reaps a slot whose
-  /// `open` is `false` via `StreamIo::is_open`.
+  /// Whether the slot is still open — "not yet closed", per the
+  /// [`StreamIo::is_open`](memberlist_embedded::StreamIo::is_open) contract. Set
+  /// `true` SYNCHRONOUSLY when the engine commits a `Dial` (its
+  /// [`EmbassyStream::connect`](crate::stream_io::EmbassyStream), so the same-pump
+  /// fault check sees a dialing slot as open, matching smoltcp's SynSent) and when an
+  /// accept completes with a peer; cleared to `false` only on a real close / abort /
+  /// reset / peer-RST or a genuine dial failure. The engine reaps a slot whose `open`
+  /// is `false` via `StreamIo::is_open`; a still-`Dialing` slot reporting `!open` is
+  /// exactly the dial-failure signal the engine reads. Independent of
+  /// [`established`](Self::established), which stays `false` until the handshake
+  /// completes, so reporting `open` while dialing never makes the slot send-capable.
   pub open: bool,
   /// The remote address of an accepted/connected peer, set by the worker ONLY
   /// once established with a known `remote_endpoint`. Mirrors smoltcp's accept

--- a/memberlist-embassy/src/stream_io/mod.rs
+++ b/memberlist-embassy/src/stream_io/mod.rs
@@ -170,6 +170,22 @@ impl StreamIo for EmbassyStream<'_> {
     // ephemeral local port from the stack (`get_local_port`), so the engine's
     // requested local port has no effect here. (smoltcp threaded it through; the
     // embassy-net stack owns ephemeral-port selection.)
+    //
+    // Mark the slot `open` SYNCHRONOUSLY here, as the engine commits the dial — not
+    // only later, when the worker picks the `Dial` up. Per the `StreamIo` contract
+    // `is_open` means "not yet closed", and the engine reads `is_open` WITHIN THE SAME
+    // synchronous pump that issues this dial: its `pump_inbound_reliable` fault check
+    // treats a `Dialing` connection reporting `!is_open` as a dial FAILURE. embassy-net
+    // dials asynchronously, so the worker cannot flip `open` until a later wake — one
+    // pump too late, after that one-shot fault check has already reaped the healthy
+    // dial. Setting `open` at the commit point (mirroring the smoltcp driver, whose
+    // synchronous `connect` enters SynSent = `is_open` immediately) makes
+    // `Dialing && !is_open` mean ONLY a genuine dial failure. This sets ONLY `open`:
+    // `established` stays `false` until the worker's handshake completes, so the engine
+    // still does not promote or send on the not-yet-connected socket (`is_established`
+    // reads `established`, `may_send` reads `established && <ring has room>`). A real
+    // dial failure clears `open` again in the worker's failure arm.
+    self.slots[c.0].borrow_mut().open = true;
     self.post_gen(c, Command::Dial(remote), g);
     Ok(())
   }

--- a/memberlist-embassy/src/stream_io/tests.rs
+++ b/memberlist-embassy/src/stream_io/tests.rs
@@ -147,18 +147,41 @@ fn listen_posts_for_a_valid_port_and_rejects_port_zero() {
 }
 
 /// `connect` posts a `Dial` to the slot regardless of the engine's requested
-/// local port (embassy-net owns ephemeral-port selection).
+/// local port (embassy-net owns ephemeral-port selection), and marks the slot
+/// `open` SYNCHRONOUSLY (the dial is committed) WITHOUT marking it `established`:
+/// so the engine's same-pump `is_open` fault check sees a healthy dial, while
+/// `is_established` / `may_send` stay false until the worker actually connects.
 #[test]
 fn connect_posts_a_dial() {
   let (mb, wakes) = slots(1, 64);
   let mut free = Vec::new();
   let mut view = EmbassyStream::new(&mb, &wakes, &mut free);
 
+  // A fresh slot is not yet open.
+  assert!(!view.is_open(SlotId(0)), "a fresh slot is not open");
+
   view
     .connect(SlotId(0), sa(2), 1234, SlotGen::START)
     .expect("connect posts");
   assert_eq!(mb[0].borrow().command, Command::Dial(sa(2)));
   assert!(wakes[0].signaled());
+  // Committing the dial reports the slot open immediately — the "not yet closed"
+  // signal the engine's dial-failure check reads in the SAME pump that issues the
+  // dial (the worker's async connect cannot flip it in time).
+  assert!(
+    view.is_open(SlotId(0)),
+    "committing a dial marks the slot open synchronously"
+  );
+  // But NOT established / send-capable: the handshake has not completed, so the
+  // engine must neither promote nor send on the not-yet-connected socket.
+  assert!(
+    !view.is_established(SlotId(0)),
+    "a committed-but-unconnected dial is not yet established"
+  );
+  assert!(
+    !view.may_send(SlotId(0)),
+    "a committed-but-unconnected dial is not yet send-capable"
+  );
 }
 
 /// The established-state predicates read straight from the mailbox: an

--- a/memberlist-embassy/src/worker.rs
+++ b/memberlist-embassy/src/worker.rs
@@ -139,7 +139,11 @@ pub(crate) async fn run_slot(
       Command::Dial(remote) => {
         // The slot is now in use; it is no longer reuse-ready until `reset_socket`
         // runs (see the `Listen` arm). Clear it before the connect await so the
-        // engine cannot reuse this slot mid-teardown.
+        // engine cannot reuse this slot mid-teardown. `open` is already `true` here:
+        // the engine's synchronous `EmbassyStream::connect` set it when it committed
+        // this dial (so the same-pump `is_open` fault check sees a dialing slot as
+        // open, not as a failed dial — see that method), and the worker leaves it set
+        // through the handshake, clearing it only on the failure/abort arms below.
         mb.borrow_mut().reset_done = false;
         // `connect(remote)` spans the handshake; on success the slot is established
         // and open. Race it against the command wake so a `Close`/`Abort` (the
@@ -158,6 +162,10 @@ pub(crate) async fn run_slot(
               let mut m = mb.borrow_mut();
               m.accepted_peer = peer;
               m.established = true;
+              // `open` was already set at the engine's dial commit and stays set; the
+              // completed handshake promotes `established`, the post-connect send
+              // signal the engine gates `may_send` / `is_established` on. Re-assert it
+              // (idempotent) so this success arm mirrors the accept arm above.
               m.open = true;
               m.command = Command::Idle;
               m.sock_send_queue = socket.send_queue();

--- a/memberlist-embedded/src/config/mod.rs
+++ b/memberlist-embedded/src/config/mod.rs
@@ -35,16 +35,24 @@ pub struct Options {
   /// planes, since a datagram and a stream socket on the same port number are
   /// independent).
   pub port: u16,
-  /// Maximum time a gracefully-closing reliable connection may stay parked
-  /// before it is force-aborted and returned to the pool.
+  /// Maximum time EACH PHASE of a reliable connection's teardown may stay parked
+  /// before it is force-aborted and its slot returned to the pool.
+  ///
+  /// It is a HARD CAP applied per phase — the pre-FIN drain (`Closing`), the FIN
+  /// handshake (the `Draining` retire), and the RST egress (the `Aborting`
+  /// retire) — and is set once per phase, never re-armed by peer progress. So a
+  /// graceful teardown completes or is force-aborted within at most two windows
+  /// (plus one more for the RST egress), and NO peer behaviour — including an
+  /// indefinitely-slow but progressing ACK trickle — can extend any window.
   ///
   /// A link layer such as smoltcp applies no TCP timeout by default, so a peer
-  /// that vanishes during the FIN handshake (FinWait/LastAck) keeps the
-  /// connection open indefinitely and its slot never returns to the free-list —
-  /// permanently shrinking the pool and the listener replenished from it.
-  /// Bounding the close guarantees recovery. A healthy close completes well
-  /// before this and is reclaimed the moment it reaches `Closed`; the timeout
-  /// only governs the vanished-peer case.
+  /// that vanishes during the FIN handshake (FinWait/LastAck) — or one that keeps
+  /// trickling ACKs to defer the pre-FIN drain forever — would otherwise keep the
+  /// connection open indefinitely and its slot never returns to the free-list,
+  /// permanently shrinking the pool and the listener replenished from it. The hard
+  /// cap guarantees recovery. A healthy close completes well before this and is
+  /// reclaimed the moment its teardown is acknowledged; the timeout only governs
+  /// the vanished-, stalled-, or trickling-peer case.
   pub close_timeout: Duration,
   /// CIDR peer-admission policy. Filters inbound gossip by datagram source and
   /// inbound reliable connections by peer address at the transport boundary, AND

--- a/memberlist-embedded/src/engine/mod.rs
+++ b/memberlist-embedded/src/engine/mod.rs
@@ -1570,46 +1570,52 @@ where
   /// exchange deadline, a dial/label/encryption failure) is signalled separately by
   /// `StreamAction::Abort` → `abort_exchange`, which discards rather than drains. The
   /// connection is removed (dropping ALL of its per-exchange state at once — the
-  /// parked `out` bytes, the deferred `fin_pending` FIN, and the `eof_delivered`
-  /// flag) ONLY on a path that completes the teardown this tick; a graceful close
-  /// with bytes still to deliver is instead deferred (see the drain branch below).
-  /// The socket (if one was assigned) is handled by its TCP state:
+  /// parked `out` bytes, the deferred `fin_pending` FIN, and the `eof_delivered` /
+  /// `error_delivered` flags) ONLY on a path that completes the teardown this tick; a
+  /// graceful close with bytes still to deliver is instead deferred (see the drain
+  /// branch below). Every terminal path routes the socket through the occupancy ledger
+  /// ([`retire`](Self::retire)), never straight to the pool, so a slot rejoins `pool`
+  /// only once the driver acknowledges its teardown. The branch is chosen by the
+  /// socket's ESTABLISHMENT (`is_established`), NOT its writability (`may_send`): an
+  /// established connection under full outbound-ring backpressure reads `!may_send` yet
+  /// must still DRAIN gracefully, never RST. The cases:
   ///
   /// - `!is_open()` (Closed / TimeWait) — both FINs already exchanged (the clean
   ///   `BothClosed` case where our graceful FIN went out in `flush_pending_shutdowns`
-  ///   and the peer's FIN was pumped in): remove the connection and return the handle
-  ///   straight to the pool, no close handshake left to wait on.
+  ///   and the peer's FIN was pumped in), or the socket was already aborted: remove the
+  ///   connection and retire the handle (`Aborting` — the teardown is already terminal,
+  ///   so no graceful FIN drain remains to wait on). `retire`'s immediate completion
+  ///   check frees a synchronous driver's already-closed socket this tick.
   /// - `is_open()` after a graceful half-close (the connection was in
   ///   [`ConnState::HalfClosed`]): our FIN is already in flight, so `out` can no
-  ///   longer be flushed (the tx half is closed). Remove the connection and park the
-  ///   handle in `closing` with a `now + close_timeout` deadline; the reap pass
-  ///   reclaims it once it reaches Closed, or force-`abort()`s it at the deadline so a
-  ///   vanished peer cannot leak the socket.
-  /// - send-capable (`Established` / `CloseWait`) with outbound bytes still
-  ///   undelivered (`!out.is_empty()` OR `send_queue() != 0`) — a push/pull reply (or
-  ///   request) larger than the tx ring whose remainder is parked in `out` from
-  ///   partial-write backpressure, or still in the tx ring awaiting ACK. Issuing the
-  ///   FIN now would truncate it: `close()` only FINs after the bytes already IN the
-  ///   tx ring, never the remainder still in `out`, and an `abort()` would RST over a
-  ///   partial frame — collapsing the reliable push/pull to a gossip-only sync (or
-  ///   losing the reply entirely). Instead transition the connection to
-  ///   [`ConnState::Closing`] with a `now + close_timeout` deadline and KEEP it
-  ///   mapped, so `pump_outbound_reliable` keeps flushing `out` into the tx ring;
-  ///   `flush_closing` emits the terminal FIN and detaches the socket only once `out`
-  ///   is empty and the tx ring is fully acknowledged, or force-aborts at the deadline
-  ///   if the peer never drains it.
-  /// - send-capable with nothing left to deliver (`out` empty AND `send_queue() == 0`)
+  ///   longer be flushed (the tx half is closed). Remove the connection and retire the
+  ///   handle (`Draining`) with a `now + close_timeout` deadline; the reap pass
+  ///   reclaims it once its teardown is acknowledged, or force-`abort()`s it at the
+  ///   deadline so a peer that vanished mid-FIN cannot leak the socket.
+  /// - established with outbound bytes still undelivered (`!out.is_empty()` OR
+  ///   `send_queue() != 0`) — a push/pull reply (or request) larger than the tx ring
+  ///   whose remainder is parked in `out` from partial-write backpressure (or a full
+  ///   ring), or still in the tx ring awaiting ACK. Issuing the FIN now would truncate
+  ///   it: `close()` only FINs after the bytes already IN the tx ring, never the
+  ///   remainder still in `out`, and an `abort()` would RST over a partial frame —
+  ///   collapsing the reliable push/pull to a gossip-only sync (or losing the reply
+  ///   entirely). Instead transition the connection to [`ConnState::Closing`] with a
+  ///   `now + close_timeout` deadline (set ONCE — a HARD CAP, never re-armed) and KEEP
+  ///   it mapped, so `pump_outbound_reliable` keeps flushing `out` into the tx ring;
+  ///   `flush_closing` emits the terminal FIN and retires the socket only once `out` is
+  ///   empty and the tx ring is fully acknowledged, or force-aborts at the deadline if
+  ///   the peer never drains it.
+  /// - established with nothing left to deliver (`out` empty AND `send_queue() == 0`)
   ///   — an acceptor in `CloseWait` whose reply already reached the wire, or an
   ///   `Established` one-shot teardown with an empty tx ring. There is nothing to
   ///   drain: emit the graceful FIN immediately (`close()` → LastAck / FinWait1,
-  ///   giving the peer a clean EOF so its initiator commits the response) and park the
-  ///   handle in `closing` for the reap pass.
-  /// - any other `is_open()` state with no prior half-close (an abrupt `Close` — a
-  ///   failed dial, an admission-rejected exchange, a never-promoted bridge in
-  ///   SynSent): `abort()` (TCP RST) sets the state to Closed in one step, so the
-  ///   handle returns to the pool at once with no close handshake and the failed
-  ///   exchange's stale tx bytes are discarded rather than flushed — there is nothing
-  ///   to deliver over a connection the peer never established.
+  ///   giving the peer a clean EOF so its initiator commits the response) and retire
+  ///   the handle (`Draining`) for the reap pass.
+  /// - never established (an abrupt `Close` over a `Dialing` socket still in SynSent
+  ///   that the peer never established): `abort()` (TCP RST) sets the state to Closed
+  ///   in one step; retire the handle (`Aborting`), freed once the RST egress is
+  ///   acknowledged, and the stale tx bytes are discarded rather than flushed — there
+  ///   is nothing to deliver over a connection the peer never established.
   ///
   /// A connection still in `PendingDial` (its bridge timed out before a slot freed)
   /// has no socket: removing it is the whole teardown, so a retired exchange is never
@@ -1642,19 +1648,26 @@ where
     let was_half_closed = conn.state == ConnState::HalfClosed;
     let out_pending = !conn.out_is_empty();
 
-    // Read the socket's send/recv capability and tx-ring depth once.
+    // Branch on ESTABLISHMENT, not writability. `is_established` is "the handshake
+    // completed" regardless of tx-ring room; `may_send` is `established && writable`,
+    // so an established connection under FULL outbound-ring backpressure reads
+    // `!may_send` and would wrongly fall through to the abrupt-RST branch below. A
+    // graceful close of an established connection must DRAIN, never RST under ordinary
+    // backpressure — the egress pump keeps flushing `out` into the tx ring as it frees.
     let is_open = stream.is_open(c);
-    let may_send = stream.may_send(c);
+    let established = stream.is_established(c);
     let tx_unacked = stream.send_queue(c);
 
     let g = self.current_slot_gen(c);
     if !is_open {
-      // `!is_open()` is exactly `Closed | TimeWait`: both FINs already exchanged (or
-      // the socket was already aborted). Retire (Draining) and run the immediate
-      // completion check — a clean close is acknowledged at once and freed this
-      // tick, no close handshake left to wait on.
+      // `!is_open()` is exactly `Closed | TimeWait`: both FINs already exchanged, or
+      // the socket was already aborted. The teardown is already terminal — there is no
+      // graceful FIN drain still in flight to wait on (that is the `was_half_closed`
+      // case below) — so retire it as `Aborting`, excluded from the graceful-drain
+      // count, and run the immediate completion check; a synchronous driver
+      // acknowledges the already-closed socket at once and frees the slot this tick.
       self.plane.connections.remove(&eid);
-      self.retire(c, g, RetirePhase::Draining, now, stream);
+      self.retire(c, g, RetirePhase::Aborting, now, stream);
     } else if was_half_closed {
       // Our graceful FIN is in flight but the peer has not finished the close. Do NOT
       // close()/abort() now: the FIN was already sent and the tx half is closed, so
@@ -1663,30 +1676,29 @@ where
       // acknowledged, or force-aborts it at the deadline if the peer vanished mid-FIN.
       self.plane.connections.remove(&eid);
       self.retire(c, g, RetirePhase::Draining, now, stream);
-    } else if may_send && (out_pending || tx_unacked != 0) {
-      // Send-capable (Established / CloseWait) with outbound bytes the peer has NOT yet
-      // received — parked in `out` (partial-write backpressure) and/or still
-      // unacknowledged in the tx ring. FIN-ing now truncates the reply: `close()`
-      // flushes only what is already in the tx ring, never the `out` remainder, and
-      // `abort()` would RST over a partial frame. Defer the close: transition to
-      // `Closing` (KEEP the connection mapped) with a deadline so
-      // `pump_outbound_reliable` keeps draining `out` into the tx ring; the FIN + socket
-      // detach happen in `flush_closing` once everything is delivered, or the deadline
-      // force-aborts a permanently-backpressured / vanished peer.
+    } else if established && (out_pending || tx_unacked != 0) {
+      // Established (send half open, possibly CloseWait) with outbound bytes the peer
+      // has NOT yet received — parked in `out` (partial-write backpressure, INCLUDING a
+      // full outbound ring that reads `!may_send`) and/or still unacknowledged in the tx
+      // ring. FIN-ing now truncates the reply: `close()` flushes only what is already in
+      // the tx ring, never the `out` remainder, and `abort()` would RST over a partial
+      // frame. Defer the close: transition to `Closing` (KEEP the connection mapped) with
+      // a deadline so `pump_outbound_reliable` keeps draining `out` into the tx ring as it
+      // frees; the FIN + socket detach happen in `flush_closing` once everything is
+      // delivered, or the deadline force-aborts a permanently-backpressured / vanished
+      // peer.
       if let Some(conn) = self.plane.connections.get_mut(&eid) {
         conn.state = ConnState::Closing;
+        // Set the close deadline ONCE, here at `Closing` entry; `flush_closing` never
+        // re-arms it, so `close_timeout` is a HARD CAP on the pre-FIN drain — no peer
+        // behaviour, including a progressing ACK trickle, can extend the window.
         conn.close_deadline = Some(now + self.cfg.close_timeout);
-        // Seed the drain-progress mark with the current undelivered count (parked `out`
-        // + unacked tx ring). `flush_closing` re-arms `close_deadline` each tick the
-        // count shrinks, so `close_timeout` bounds a STALL, not the total drain — a
-        // slow-but-progressing peer is never truncated.
-        conn.close_drain_mark = conn.out_bytes() + tx_unacked;
         // A still-pending Shutdown FIN is subsumed by the Closing drain's own terminal
         // FIN; clear it so `flush_pending_shutdowns` does not also act.
         conn.fin_pending = false;
       }
-    } else if may_send {
-      // Send-capable with nothing left to deliver (`out` empty AND tx ring fully
+    } else if established {
+      // Established with nothing left to deliver (`out` empty AND tx ring fully
       // acknowledged): an acceptor whose reply already reached the wire, or an
       // Established one-shot teardown with an empty ring. Emit the graceful FIN
       // immediately — `close()` (CloseWait → LastAck, Established → FinWait1) sends our
@@ -1696,14 +1708,14 @@ where
       stream.close(c, g);
       self.retire(c, g, RetirePhase::Draining, now, stream);
     } else {
-      // Abrupt teardown: a graceful `Close` whose socket is not send-capable and never
-      // half-closed (e.g. a connection still in SynSent / never promoted). FAILED
-      // exchanges no longer reach here — they arrive via `StreamAction::Abort` →
-      // `abort_exchange` — but a graceful `Close` over a socket the peer never
-      // established is handled defensively the same way: RST and retire. `abort()`
-      // moves the socket to Closed and the reap frees the slot once the RST egress is
-      // acknowledged; any stale tx bytes are discarded rather than flushed — there is
-      // nothing to deliver over a connection the peer never established.
+      // Abrupt teardown: a graceful `Close` whose socket never established (still in
+      // SynSent / never promoted — a `Dialing` connection). FAILED exchanges no longer
+      // reach here — they arrive via `StreamAction::Abort` → `abort_exchange` — but a
+      // graceful `Close` over a socket the peer never established is handled defensively
+      // the same way: RST and retire. `abort()` moves the socket to Closed and the reap
+      // frees the slot once the RST egress is acknowledged; any stale tx bytes are
+      // discarded rather than flushed — there is nothing to deliver over a connection the
+      // peer never established.
       self.plane.connections.remove(&eid);
       stream.abort(c, g);
       self.retire(c, g, RetirePhase::Aborting, now, stream);
@@ -1725,34 +1737,37 @@ where
   ///   (`send_queue() == 0`): every byte reached the peer. Emit the terminal FIN
   ///   (`close()`, closing only the transmit half — CloseWait → LastAck or Established
   ///   → FinWait1) so the peer reads a clean EOF and commits the full response, remove
-  ///   the `Connection` (dropping its remaining per-exchange state), and park the
-  ///   detached handle in `closing` with a fresh `now + close_timeout` deadline for the
-  ///   reap pass to reclaim once the close completes.
+  ///   the `Connection` (dropping its remaining per-exchange state), and retire the
+  ///   detached handle (`Draining`) for the reap pass to reclaim once the close
+  ///   completes.
   /// - **Deadline elapsed** — `now >= close_deadline` while bytes are still
-  ///   undelivered (the peer stopped draining the tx ring: permanent backpressure or a
-  ///   vanished peer): force-`abort()` the socket (RST → Closed), remove the
-  ///   `Connection`, and return the handle straight to the pool. The drain is
-  ///   best-effort and bounded; it must never wedge a pooled socket.
+  ///   undelivered (the peer stopped fully draining the tx ring: permanent
+  ///   backpressure, a vanished peer, or an indefinite ACK trickle): force-`abort()`
+  ///   the socket (RST → Closed), remove the `Connection`, and retire the handle
+  ///   (`Aborting`). The drain is best-effort and hard-bounded; it must never wedge a
+  ///   pooled socket. `close_deadline` was set ONCE at `Closing` entry (in `teardown`)
+  ///   and is NEVER re-armed here, so `close_timeout` caps the WHOLE drain — a peer
+  ///   that keeps trickling bytes below the deadline cannot extend it.
   /// - Otherwise the connection is still draining within its deadline — leave it
   ///   mapped for a later tick.
   ///
   /// The `Closing` deadline is folded into `pump()`'s returned wakeup (alongside the
-  /// `closing`-map deadlines) so a deadline-driven caller wakes in time to run this
+  /// `retiring`-ledger deadlines) so a deadline-driven caller wakes in time to run this
   /// abort backstop by `close_timeout`.
   fn flush_closing<S>(&mut self, now: Instant, stream: &mut S)
   where
     S: StreamIo<Conn = C>,
   {
     // Classify each Closing connection without holding the `connections` borrow across
-    // the mutating socket / pool / retiring-ledger calls below.
+    // the mutating socket / pool / retiring-ledger calls below. Exactly two terminal
+    // outcomes — the drain completed, or its hard-cap deadline elapsed; a connection
+    // still draining within its (fixed) deadline is left mapped for a later tick.
     enum ClosingAction<C> {
-      /// Drained: emit the FIN and retire (Draining) the handle.
+      /// Fully drained: emit the FIN and retire (Draining) the handle.
       Fin(C),
-      /// No drain progress for the full `close_timeout`: abort and retire.
+      /// The `close_timeout` hard cap elapsed with bytes still undelivered: abort and
+      /// retire.
       Abort(C),
-      /// The drain made progress this tick (the peer acked bytes): re-arm the idle
-      /// deadline with the new undelivered mark.
-      Progress(usize),
     }
 
     let mut actions: MediumVec<(ExchangeId, ClosingAction<C>)> = MediumVec::new();
@@ -1764,21 +1779,19 @@ where
       // CloseWait before the close); skip defensively if not.
       let Some(c) = conn.socket else { continue };
       // Undelivered = bytes still parked in `out` plus bytes in the tx ring the peer has
-      // not yet acked. It only ever shrinks during a close (no new bytes are queued once
-      // Closing), and shrinks ONLY when the peer acks — so a shrink is the peer-liveness
-      // signal. `close_timeout` therefore bounds the time since the peer last acked (a
-      // stall), not the total drain duration: a slow-but-progressing peer re-arms the
-      // deadline every tick it acks.
+      // not yet acked. `close_deadline` was set ONCE at `Closing` entry and is never
+      // re-armed here, so `close_timeout` is a HARD CAP on the whole pre-FIN drain: no
+      // peer behaviour — not even a progressing ACK trickle — can extend the window.
       let undelivered = conn.out_bytes() + stream.send_queue(c);
       if undelivered == 0 {
         actions.push((eid, ClosingAction::Fin(c)));
-      } else if undelivered < conn.close_drain_mark {
-        actions.push((eid, ClosingAction::Progress(undelivered)));
       } else if conn.close_deadline.is_some_and(|d| now >= d) {
-        // No progress for the full `close_timeout`: the peer stalled / vanished. Give up
-        // on the remainder and reclaim the socket so the pool cannot wedge.
+        // The drain did not complete within `close_timeout`: the peer stalled, vanished,
+        // or is trickling ACKs indefinitely. Give up on the remainder and reclaim the
+        // socket so the pool cannot wedge.
         actions.push((eid, ClosingAction::Abort(c)));
       }
+      // Otherwise still draining within the deadline: leave it mapped for a later tick.
     }
 
     for (eid, outcome) in actions {
@@ -1792,20 +1805,12 @@ where
           self.retire(c, g, RetirePhase::Draining, now, stream);
         }
         ClosingAction::Abort(c) => {
-          // Idle deadline elapsed: RST and retire (Aborting); the reap frees the slot
-          // once the RST egress is acknowledged.
+          // Hard-cap deadline elapsed: RST and retire (Aborting); the reap frees the
+          // slot once the RST egress is acknowledged.
           self.plane.connections.remove(&eid);
           let g = self.current_slot_gen(c);
           stream.abort(c, g);
           self.retire(c, g, RetirePhase::Aborting, now, stream);
-        }
-        ClosingAction::Progress(mark) => {
-          // Re-arm the idle deadline from `now`; keep the connection mapped so the egress
-          // pump keeps draining.
-          if let Some(conn) = self.plane.connections.get_mut(&eid) {
-            conn.close_drain_mark = mark;
-            conn.close_deadline = Some(now + self.cfg.close_timeout);
-          }
         }
       }
     }
@@ -1932,13 +1937,17 @@ where
   /// `Established`.
   ///
   /// A connection is created `Dialing` (slot assigned, SynSent) and stays so while the
-  /// three-way handshake is in flight. Once the socket can send (`may_send()` —
-  /// Established, and also CloseWait if the peer FIN'd before we did), the connection is
-  /// writable: its parked `out` flushes and a deferred FIN may fire. Recording that as
+  /// three-way handshake is in flight. Once the handshake completes (`is_established()`
+  /// — Established, and also CloseWait if the peer FIN'd before we did), its parked
+  /// `out` flushes and a deferred FIN may fire. Recording that as
   /// `ConnState::Established` makes the FIN gate in `flush_pending_shutdowns` a precise
   /// `state == Established` check rather than re-deriving readiness from the socket, and
-  /// keeps `ConnState` an honest reflection of the lifecycle. `PendingDial` connections
-  /// (no socket) and ones already `Established`/`HalfClosed` are left as-is.
+  /// keeps `ConnState` an honest reflection of the lifecycle. Promotion keys on
+  /// ESTABLISHMENT, not writability (`may_send`): a fresh dial's tx ring is empty at the
+  /// instant it establishes, so `is_established` and `may_send` coincide here — but
+  /// `is_established` records the lifecycle fact directly and cannot be masked by a
+  /// (here impossible) full ring. `PendingDial` connections (no socket) and ones already
+  /// `Established`/`HalfClosed` are left as-is.
   fn promote_established<S>(&mut self, stream: &mut S)
   where
     S: StreamIo<Conn = C>,
@@ -1949,7 +1958,7 @@ where
       .iter()
       .filter(|(_, c)| c.state == ConnState::Dialing)
       .filter_map(|(&eid, c)| c.socket.map(|h| (eid, h)))
-      .filter(|&(_, h)| stream.may_send(h))
+      .filter(|&(_, h)| stream.is_established(h))
       .map(|(eid, _)| eid)
       .collect();
     for eid in promote {
@@ -2009,9 +2018,12 @@ where
         c.fin_pending && c.state == ConnState::Established && c.out_is_empty()
       })
       .filter_map(|(&eid, c)| c.socket.map(|h| (eid, h)))
-      // …and the socket's tx ring is fully drained and acknowledged, so every push/pull
-      // byte reached the peer before the FIN.
-      .filter(|&(_, h)| stream.may_send(h) && stream.send_queue(h) == 0)
+      // …and the socket is established with its tx ring fully drained and acknowledged,
+      // so every push/pull byte reached the peer before the FIN. The gate keys on
+      // `is_established`, not `may_send`: paired with `send_queue(h) == 0` (a fully-acked
+      // ring, so it has room) the two coincide, but `is_established` states the
+      // handshake-complete requirement directly rather than inferring it from writability.
+      .filter(|&(_, h)| stream.is_established(h) && stream.send_queue(h) == 0)
       .collect();
 
     for (eid, c) in ready {
@@ -2698,6 +2710,21 @@ where
   /// `Connection::eof_delivered` gates it so the bridge FSM receives a single
   /// half-close signal.
   ///
+  /// A socket that instead died WITHOUT a graceful peer FIN — a received RST, or an
+  /// async driver's worker resetting the slot — is a transport FAULT, distinct from the
+  /// clean EOF above. On a no-data read where `recv_finished` is false but
+  /// [`StreamIo::is_open`] has gone false, this surfaces the fault to the machine
+  /// exactly once (gated by `Connection::error_delivered`): a `Dialing` connection whose
+  /// dial never established routes to [`StreamEndpoint::handle_dial_failed`], and an
+  /// established exchange to [`StreamEndpoint::handle_transport_error`] — NEVER the
+  /// benign `handle_transport_data` EOF, which the FSM would map to a *successful*
+  /// one-way `UserMessage` completion. The one exception is the benign completed tail
+  /// (`eof_delivered` already set, `out` empty, tx ring fully acked): the `!is_open` of a
+  /// cleanly-finished exchange whose own `BothClosed → Close` is already due, which must
+  /// NOT be failed. Surfacing the fault here fails the owning bridge THIS pump, so the
+  /// same pump's `drain_stream_actions` reaps the resulting `StreamAction::Abort` rather
+  /// than the exchange lingering until its stream/bridge deadline.
+  ///
   /// A connection still in `PendingDial` has no slot, so it is skipped (there is
   /// nothing to receive on a dial that has not even been issued).
   ///
@@ -2728,6 +2755,16 @@ where
       .filter_map(|(&eid, c)| c.socket.map(|h| (eid, h)))
       .collect();
 
+    // How a socket that died WITHOUT a graceful peer FIN is surfaced to the machine —
+    // which entry point depends on whether the dial ever established. Classified under a
+    // short `connections` borrow, then dispatched once that borrow is released.
+    enum TransportFault {
+      /// A `Dialing` socket died before its handshake completed: an async dial failure.
+      DialFailed,
+      /// An established exchange's socket was reset mid-flight: connection lost.
+      Lost,
+    }
+
     for (eid, c) in pairs {
       // Drain the socket: read all buffered bytes, then observe a drained peer FIN.
       //
@@ -2747,14 +2784,60 @@ where
               .handle_transport_data(eid, &buf[..n], false, now);
           }
           _ => {
-            // No data this tick (`Some(0)` or `None`). Deliver the peer FIN exactly once
-            // when the receive half is gracefully closed and drained.
+            // No data this tick (`Some(0)` or `None`). Two non-data conditions matter:
+            // a graceful peer FIN (deliver the one-shot EOF), or a socket that died
+            // WITHOUT one — a RST or an async worker's reset — which is a transport FAULT
+            // to surface once so the owning bridge fails THIS pump instead of lingering
+            // until its ~stream-timeout deadline.
             if stream.recv_finished(c) {
+              // Peer graceful FIN with the rx buffer drained: deliver exactly one EOF.
               if let Some(conn) = self.plane.connections.get_mut(&eid) {
                 if !conn.eof_delivered {
                   conn.eof_delivered = true;
                   self.endpoint.handle_transport_data(eid, &[], true, now);
                 }
+              }
+            } else if !stream.is_open(c) {
+              // The socket is closed but the peer did NOT gracefully FIN (`recv_finished`
+              // is false): a received RST, or an async driver's worker resetting the slot.
+              // Surface it to the machine as a transport FAULT — NOT a benign
+              // `handle_transport_data` EOF, which the FSM maps to a *successful* one-way
+              // UserMessage completion — exactly once, gated by the `error_delivered`
+              // latch. The failed bridge's next tick queues `StreamAction::Abort`, which
+              // `drain_stream_actions` reaps in this SAME pump (removing the connection and
+              // retiring the slot via the occupancy ledger), so teardown stays
+              // machine-directed with no driver-side compensation. Classify under a short
+              // borrow, then dispatch once the `connections` borrow is released.
+              let fault = if let Some(conn) = self.plane.connections.get_mut(&eid) {
+                if conn.error_delivered {
+                  // Already surfaced for this connection: one-shot.
+                  None
+                } else {
+                  conn.error_delivered = true;
+                  if conn.state == ConnState::Dialing {
+                    // The dial never established: a genuine async dial failure. Feeding it
+                    // as a benign EOF would FALSELY complete a UserMessage send as success.
+                    Some(TransportFault::DialFailed)
+                  } else if conn.eof_delivered && conn.out_is_empty() && stream.send_queue(c) == 0 {
+                    // Benign completed tail: the peer's EOF was already delivered, `out` is
+                    // empty, and the tx ring is fully acked — the LastAck→Closed window of a
+                    // cleanly-finished exchange whose own `BothClosed → Close` is already
+                    // due. The socket going `!is_open` here is the normal end of a
+                    // SUCCESSFUL exchange, so do NOT fail it; the machine's own Close reaps
+                    // it.
+                    None
+                  } else {
+                    // An established exchange lost its transport mid-flight.
+                    Some(TransportFault::Lost)
+                  }
+                }
+              } else {
+                None
+              };
+              match fault {
+                Some(TransportFault::DialFailed) => self.endpoint.handle_dial_failed(eid, now),
+                Some(TransportFault::Lost) => self.endpoint.handle_transport_error(eid, now),
+                None => {}
               }
             }
             break;

--- a/memberlist-embedded/src/engine/tests.rs
+++ b/memberlist-embedded/src/engine/tests.rs
@@ -976,6 +976,11 @@ struct SockState {
   /// `send` of more than this many bytes leaves the remainder parked in the
   /// connection's `out` queue. `usize::MAX` accepts the whole buffer.
   send_cap: usize,
+  /// The outbound ring is full, so the socket is momentarily NOT writable even
+  /// though it is established: `may_send` (writability-gated) reads false while
+  /// `is_established` stays true. Models the F1 backpressure divergence. Off by
+  /// default, so existing tests keep `may_send == is_established`.
+  ring_full: bool,
 }
 
 impl SockState {
@@ -988,6 +993,7 @@ impl SockState {
       tx_unacked: 0,
       accepted: None,
       send_cap: usize::MAX,
+      ring_full: false,
     }
   }
 }
@@ -1099,7 +1105,10 @@ impl StreamIo for ProgRel {
 
   fn may_send(&self, c: u32) -> bool {
     let s = self.sock(c);
-    s.established && s.open
+    // Writability-gated: established AND the outbound ring has room. `ring_full`
+    // models an established connection whose tx ring is momentarily full, so
+    // `may_send` reads false while `is_established` stays true — the F1 divergence.
+    s.established && s.open && !s.ring_full
   }
 
   fn may_recv(&self, c: u32) -> bool {
@@ -2731,9 +2740,9 @@ fn send_many_to_cidr_blocked_destination_emits_no_datagram() {
 /// The drain-before-close path: B accepts a join push/pull but its reply tx is
 /// held unacknowledged when its bridge gracefully closes, so `teardown` parks the
 /// connection in `Closing` (KEEPING it mapped) instead of FIN-ing immediately;
-/// `flush_closing` then drains it — re-arming on partial progress and finally
-/// emitting the terminal FIN once the tx is fully acked, reclaiming the slot. A
-/// graceful close must never truncate an unacknowledged reply.
+/// `flush_closing` keeps it mapped while it drains and finally emits the terminal
+/// FIN once the tx is fully acked, reclaiming the slot. A graceful close must never
+/// truncate an unacknowledged reply.
 #[test]
 fn closing_drain_defers_fin_until_tx_acked_then_reclaims_slot() {
   let mut link = LinkPair::new(&[10, 11], &[20, 21]);
@@ -2768,8 +2777,9 @@ fn closing_drain_defers_fin_until_tx_acked_then_reclaims_slot() {
     "the draining connection still pins its slot before the tx is acked"
   );
 
-  // Partially ack: the undelivered count shrinks, so `flush_closing` takes the
-  // Progress branch (re-arm) and keeps the connection mapped.
+  // Partially ack: the undelivered count shrinks but is still non-zero and the
+  // (fixed, never re-armed) deadline has not elapsed, so `flush_closing` leaves the
+  // connection mapped and keeps draining.
   link.ack_b(1);
   link.step(now);
   while link.b.poll_event().is_some() {}
@@ -3365,5 +3375,455 @@ fn a_never_activated_occupancy_round_trips_through_the_ledger() {
     engine.pool_free_count(),
     1,
     "the reclaimed slot is back in the pool"
+  );
+}
+
+// --- #159 F1/F2/F6: engine teardown / close-deadline / inbound-fault policy ---
+
+/// Drive an outbound reliable user-message to `Established` on slot 0 (listener on
+/// slot 1), returning the engine, the mock, the clock, and the exchange's
+/// `ExchangeId`. The tx ring is held non-empty (`tx_unacked = 8`) so the machine's
+/// write-half Shutdown FIN stays withheld — keeping the connection `Established`
+/// (not `HalfClosed`) so a caller can drive the teardown / drain / inbound-fault
+/// paths from a known state.
+fn established_outbound(
+  payload: &'static [u8],
+) -> (
+  Engine<SmolStr, u32>,
+  ProgRel,
+  Instant,
+  memberlist_proto::streams::ExchangeId,
+) {
+  let (mut engine, now) = engine_with_stream_timeout(Duration::from_secs(30));
+  engine.plane_mut().pool.push(0);
+  engine.set_listener(1);
+  let mut stream = ProgRel::new(&[0, 1]);
+
+  let to = node_addr(7100);
+  engine
+    .send_reliable(to, bytes::Bytes::from_static(payload), now)
+    .expect("send_reliable queues the exchange");
+
+  let mut gossip = NoGossip;
+  // Tick 1: Connect → dial slot 0 (SynSent).
+  engine.pump(now, &mut gossip, &mut stream);
+  // Complete the handshake but hold the tx ring non-empty, so the deferred-FIN gate
+  // (`send_queue == 0`) never fires and the connection stays Established.
+  stream.sock_mut(0).established = true;
+  stream.sock_mut(0).tx_unacked = 8;
+  // Tick 2: promote Dialing → Established; the request bytes flush.
+  engine.pump(now, &mut gossip, &mut stream);
+
+  let eid = *engine
+    .plane_mut()
+    .connections
+    .keys()
+    .next()
+    .expect("exactly one outbound connection");
+  assert_eq!(
+    engine.plane_mut().connections.get(&eid).map(|c| c.state),
+    Some(ConnState::Established),
+    "the exchange must reach Established with its FIN withheld (held tx)"
+  );
+  (engine, stream, now, eid)
+}
+
+/// F1: a graceful `Close` of an ESTABLISHED connection under FULL outbound-ring
+/// backpressure (`may_send` false, `is_established` true) must DRAIN — enter
+/// `Closing` and later emit its FIN once the ring frees — never RST. Before the
+/// fix the `!may_send` gate sent it down the abrupt-abort branch.
+#[test]
+fn backpressured_established_close_drains_not_aborts() {
+  let (mut engine, mut stream, now, eid) = established_outbound(b"reply-in-flight");
+
+  // Model a FULL outbound ring: the socket is established but not writable, with
+  // bytes still unacknowledged in the tx ring.
+  stream.sock_mut(0).ring_full = true;
+  assert!(
+    !StreamIo::may_send(&stream, 0) && StreamIo::is_established(&stream, 0),
+    "the socket must be established but NOT writable (the F1 divergence)"
+  );
+
+  // The graceful Close arrives now. With the fix it DRAINS (Closing), not RST.
+  engine.teardown(eid, now, &mut stream);
+
+  assert!(
+    !stream.aborted.contains(&0),
+    "a backpressured established close must NOT abort/RST"
+  );
+  {
+    let conn = engine
+      .plane_mut()
+      .connections
+      .get(&eid)
+      .expect("the connection stays mapped to drain");
+    assert_eq!(
+      conn.state,
+      ConnState::Closing,
+      "a backpressured established close must enter Closing to drain, not abort"
+    );
+    assert!(
+      conn.close_deadline.is_some(),
+      "the Closing drain arms its hard-cap deadline"
+    );
+  }
+
+  // The ring frees and the tx drains: `flush_closing` now emits the terminal FIN.
+  stream.sock_mut(0).ring_full = false;
+  stream.sock_mut(0).tx_unacked = 0;
+  engine.flush_closing(now, &mut stream);
+  assert!(
+    stream.closed.contains(&0),
+    "once drained, the graceful close emits a FIN (close), never an abort"
+  );
+  assert!(!stream.aborted.contains(&0), "the drained close never RSTs");
+  assert!(
+    engine.plane_mut().connections.get(&eid).is_none(),
+    "the drained connection is removed after its terminal FIN"
+  );
+}
+
+/// F1 control: a never-established (`Dialing`) connection whose graceful `Close`
+/// arrives still ABORTS (the peer never established a wire, so there is nothing to
+/// drain). This is the abrupt-abort branch the F1 divergence must NOT capture.
+#[test]
+fn unestablished_dialing_close_aborts_not_drains() {
+  let (mut engine, now) = engine_with_stream_timeout(Duration::from_secs(30));
+  engine.plane_mut().pool.push(0);
+  engine.set_listener(1);
+  let mut stream = ProgRel::new(&[0, 1]);
+
+  let to = node_addr(7101);
+  engine
+    .send_reliable(to, bytes::Bytes::from_static(b"never-established"), now)
+    .expect("send_reliable queues the exchange");
+
+  let mut gossip = NoGossip;
+  // One pump: Connect dials slot 0 (the socket opens, SynSent) but the handshake
+  // never completes — the connection stays `Dialing`.
+  engine.pump(now, &mut gossip, &mut stream);
+  let eid = *engine
+    .plane_mut()
+    .connections
+    .keys()
+    .next()
+    .expect("one dialing connection");
+  assert_eq!(
+    engine.plane_mut().connections.get(&eid).map(|c| c.state),
+    Some(ConnState::Dialing),
+    "the connection must still be Dialing (handshake incomplete)"
+  );
+
+  engine.teardown(eid, now, &mut stream);
+  assert!(
+    stream.aborted.contains(&0),
+    "a never-established close aborts (RST), it does not drain"
+  );
+  assert!(
+    !stream.closed.contains(&0),
+    "a never-established close never emits a graceful FIN"
+  );
+  assert!(
+    engine.plane_mut().connections.get(&eid).is_none(),
+    "the aborted connection is removed"
+  );
+}
+
+/// F2: an ACK trickle (undelivered bytes shrinking by 1 each tick) must NOT extend
+/// the `Closing` drain deadline. The deadline is set ONCE at `Closing` entry and
+/// never re-armed, so a permanently-trickling peer is force-aborted at the ORIGINAL
+/// deadline rather than deferring the close forever.
+#[test]
+fn ack_trickle_cannot_extend_closing_past_one_window() {
+  let (mut engine, mut stream, now, eid) = established_outbound(b"held-reply");
+
+  // Park a known undelivered count and take the graceful close into `Closing`.
+  stream.sock_mut(0).tx_unacked = 5;
+  engine.teardown(eid, now, &mut stream);
+  let deadline = engine
+    .plane_mut()
+    .connections
+    .get(&eid)
+    .expect("the connection parks in Closing")
+    .close_deadline
+    .expect("the Closing drain arms a deadline");
+
+  // Trickle: the peer acks 1 byte per tick. Each `flush_closing` at an advancing
+  // clock (still before the deadline) makes progress but must NOT re-arm the
+  // deadline — the fix removed the progress re-arm entirely.
+  let mut t = now;
+  for acked in 1..=4u32 {
+    t += Duration::from_secs(1);
+    stream.sock_mut(0).tx_unacked = 5 - acked as usize; // 4, 3, 2, 1
+    engine.flush_closing(t, &mut stream);
+    let d = engine
+      .plane_mut()
+      .connections
+      .get(&eid)
+      .expect("still draining within the deadline")
+      .close_deadline
+      .expect("deadline still present");
+    assert_eq!(
+      d, deadline,
+      "an ACK trickle must NOT re-arm the close deadline (hard cap)"
+    );
+  }
+
+  // One undelivered byte remains. Advance PAST the original deadline: the drain is
+  // force-aborted at that (never-extended) instant, proving the trickle bought no
+  // extra time.
+  let past = deadline + Duration::from_secs(1);
+  engine.flush_closing(past, &mut stream);
+  assert!(
+    stream.aborted.contains(&0),
+    "the still-draining connection is force-aborted at its ORIGINAL deadline"
+  );
+  assert!(
+    engine.plane_mut().connections.get(&eid).is_none(),
+    "the force-aborted Closing connection is removed"
+  );
+}
+
+/// F2: `close_deadline` is set exactly once at `Closing` entry and is never moved
+/// by a later `flush_closing` pass, even when the drain makes progress.
+#[test]
+fn close_deadline_set_once() {
+  let (mut engine, mut stream, now, eid) = established_outbound(b"reply");
+
+  stream.sock_mut(0).tx_unacked = 3;
+  engine.teardown(eid, now, &mut stream);
+  let deadline = engine
+    .plane_mut()
+    .connections
+    .get(&eid)
+    .expect("Closing")
+    .close_deadline
+    .expect("deadline set once at Closing entry");
+  assert_eq!(
+    deadline,
+    now + crate::DEFAULT_CLOSE_TIMEOUT,
+    "the deadline is now + close_timeout"
+  );
+
+  // A progress tick (undelivered shrinks) at a later clock must leave the deadline
+  // untouched.
+  stream.sock_mut(0).tx_unacked = 1;
+  engine.flush_closing(now + Duration::from_secs(3), &mut stream);
+  assert_eq!(
+    engine
+      .plane_mut()
+      .connections
+      .get(&eid)
+      .expect("still Closing")
+      .close_deadline,
+    Some(deadline),
+    "progress must not re-arm the deadline"
+  );
+}
+
+/// F6: a socket that dies mid-exchange (`!is_open`, no graceful FIN) is surfaced to
+/// the machine as a transport error THIS pump — the bridge fails, its `Abort`
+/// action is drained, and `abort_exchange` removes+retires the slot within the same
+/// pump — instead of the exchange lingering until its ~stream-timeout deadline.
+#[test]
+fn mid_exchange_rst_terminalizes_within_one_pump() {
+  use memberlist_proto::event::{Event, ExchangeKind, ExchangeStatus};
+
+  let (mut engine, mut stream, now, eid) = established_outbound(b"mid-exchange");
+  // Drain any setup events.
+  while engine.poll_event().is_some() {}
+
+  // A mid-exchange RST: the socket closes WITHOUT a graceful peer FIN.
+  stream.sock_mut(0).open = false; // is_open → false
+  // peer_fin stays false, so recv_finished is false — this is a fault, not an EOF.
+
+  // A SINGLE pump at the (un-advanced) clock: the stream deadline (now + 30s) has
+  // NOT elapsed, so the ONLY way the exchange fails this pump is the F6 fault path.
+  let mut gossip = NoGossip;
+  engine.pump(now, &mut gossip, &mut stream);
+
+  let mut failed = false;
+  while let Some(ev) = engine.poll_event() {
+    if let Event::ExchangeCompleted(ec) = ev {
+      if ec.kind() == ExchangeKind::UserMessage && ec.outcome() == ExchangeStatus::Failed {
+        failed = true;
+      }
+    }
+  }
+  assert!(
+    failed,
+    "a mid-exchange RST must fail the exchange within one pump, not at the stream deadline"
+  );
+  assert!(
+    engine.plane_mut().connections.get(&eid).is_none(),
+    "the failed exchange's connection is removed the same pump (abort_exchange)"
+  );
+  assert!(
+    stream.aborted.contains(&0),
+    "abort_exchange RST-resets the slot"
+  );
+  assert_eq!(
+    engine.pool_free_count() + engine.listener_present() as usize,
+    2,
+    "the reset slot is reclaimed, never leaked"
+  );
+}
+
+/// F6: a `Dialing` connection whose socket dies before the handshake completes
+/// (`!is_open`, never established) routes through `handle_dial_failed` — failing the
+/// exchange within one pump rather than reading a benign EOF as a false success.
+#[test]
+fn async_dial_failure_calls_handle_dial_failed() {
+  use memberlist_proto::event::{Event, ExchangeKind, ExchangeStatus};
+
+  let (mut engine, now) = engine_with_stream_timeout(Duration::from_secs(30));
+  engine.plane_mut().pool.push(0);
+  engine.set_listener(1);
+  let mut stream = ProgRel::new(&[0, 1]);
+
+  let to = node_addr(7102);
+  engine
+    .send_reliable(to, bytes::Bytes::from_static(b"dial-fails"), now)
+    .expect("send_reliable queues the exchange");
+
+  let mut gossip = NoGossip;
+  // One pump: Connect dials slot 0 (opens, SynSent); the connection is `Dialing`.
+  engine.pump(now, &mut gossip, &mut stream);
+  let eid = *engine
+    .plane_mut()
+    .connections
+    .keys()
+    .next()
+    .expect("one dialing connection");
+  assert_eq!(
+    engine.plane_mut().connections.get(&eid).map(|c| c.state),
+    Some(ConnState::Dialing),
+    "the connection must be Dialing (handshake not yet complete)"
+  );
+  while engine.poll_event().is_some() {}
+
+  // The async dial fails: the socket dies while still Dialing (never established).
+  stream.sock_mut(0).open = false;
+
+  // One pump: the F6 fault path routes a Dialing `!is_open` through
+  // `handle_dial_failed`, failing the exchange this pump.
+  engine.pump(now, &mut gossip, &mut stream);
+  let mut failed = false;
+  while let Some(ev) = engine.poll_event() {
+    if let Event::ExchangeCompleted(ec) = ev {
+      if ec.kind() == ExchangeKind::UserMessage && ec.outcome() == ExchangeStatus::Failed {
+        failed = true;
+      }
+    }
+  }
+  assert!(
+    failed,
+    "an async dial failure must fail the exchange within one pump (handle_dial_failed)"
+  );
+  assert!(
+    engine.plane_mut().connections.get(&eid).is_none(),
+    "the dial-failed exchange's connection is removed the same pump"
+  );
+}
+
+/// F6: the benign completed tail — the peer's EOF was already delivered, `out` is
+/// empty, and the tx ring is fully acked — must NOT be surfaced as a transport
+/// error even though the socket has gone `!is_open`. That `!is_open` is the normal
+/// LastAck→Closed end of a SUCCESSFUL exchange whose own `Close` is already due;
+/// failing it would falsely turn a success into a failure.
+#[test]
+fn benign_completed_tail_does_not_false_fail() {
+  use memberlist_proto::event::{Event, ExchangeStatus};
+
+  let (mut engine, mut stream, now, eid) = established_outbound(b"benign-tail");
+
+  // Put the connection into the benign completed-tail window: EOF already delivered,
+  // our FIN sent (HalfClosed, so not Dialing), `out` empty, tx ring fully acked.
+  {
+    let conn = engine
+      .plane_mut()
+      .connections
+      .get_mut(&eid)
+      .expect("the exchange connection");
+    conn.eof_delivered = true;
+    conn.state = ConnState::HalfClosed;
+    assert!(
+      conn.out_is_empty(),
+      "the benign tail has no parked out bytes"
+    );
+  }
+  stream.sock_mut(0).tx_unacked = 0; // send_queue == 0
+  stream.sock_mut(0).open = false; // !is_open
+  stream.sock_mut(0).peer_fin = false; // recv_finished is false (past FIN-wait, Closed)
+  while engine.poll_event().is_some() {}
+
+  // The inbound pump observes `!is_open` on the still-mapped connection but must
+  // recognise the benign tail and NOT surface a transport error.
+  engine.pump_inbound_reliable(now, &mut stream);
+
+  let mut any_failed = false;
+  while let Some(ev) = engine.poll_event() {
+    if let Event::ExchangeCompleted(ec) = ev {
+      if ec.outcome() == ExchangeStatus::Failed {
+        any_failed = true;
+      }
+    }
+  }
+  assert!(
+    !any_failed,
+    "the benign completed tail must NOT be surfaced as a transport failure"
+  );
+  let conn = engine
+    .plane_mut()
+    .connections
+    .get(&eid)
+    .expect("the benign tail is not torn down by the inbound pump");
+  assert!(
+    conn.error_delivered,
+    "the !is_open observation still latches error_delivered (one-shot), even benign"
+  );
+}
+
+/// F6: `error_delivered` is a one-shot latch — the first `!is_open` observation
+/// surfaces the fault and sets the latch, so a second inbound pump over the (still
+/// mapped) connection does not re-surface it.
+#[test]
+fn error_delivered_is_one_shot() {
+  let (mut engine, mut stream, now, eid) = established_outbound(b"one-shot");
+  while engine.poll_event().is_some() {}
+
+  // Mid-exchange RST.
+  stream.sock_mut(0).open = false;
+
+  // Call the inbound pump directly (so `drain_stream_actions` does not remove the
+  // connection): the first observation surfaces the fault and latches.
+  engine.pump_inbound_reliable(now, &mut stream);
+  assert!(
+    engine
+      .plane_mut()
+      .connections
+      .get(&eid)
+      .expect("still mapped (no action drain)")
+      .error_delivered,
+    "the first !is_open observation latches error_delivered"
+  );
+  while engine.poll_event().is_some() {}
+
+  // A second inbound pump over the still-mapped, still-`!is_open` connection is a
+  // no-op for the fault path (latch set) — it neither clears the latch nor surfaces
+  // another completion.
+  engine.pump_inbound_reliable(now, &mut stream);
+  assert!(
+    engine
+      .plane_mut()
+      .connections
+      .get(&eid)
+      .expect("still mapped")
+      .error_delivered,
+    "the latch stays set across pumps (one-shot)"
+  );
+  assert!(
+    engine.poll_event().is_none(),
+    "a latched connection surfaces no further fault"
   );
 }

--- a/memberlist-embedded/src/reliable/mod.rs
+++ b/memberlist-embedded/src/reliable/mod.rs
@@ -151,8 +151,9 @@ pub enum ConnState {
 /// This is the whole per-exchange state. Tearing the exchange down is removing
 /// the `Connection` from [`ReliablePlane::connections`], which drops the
 /// connection handle, the parked `out` bytes, the deferred-FIN flag, the close
-/// drain deadline, and the EOF-delivered flag together — no separate per-field
-/// purges to keep in sync. The only teardown that defers that removal is a
+/// drain deadline, and the EOF-/transport-error-delivered flags together — no
+/// separate per-field purges to keep in sync. The only teardown that defers that
+/// removal is a
 /// graceful close with bytes still to deliver: it parks in [`ConnState::Closing`]
 /// until the egress pump has flushed them, then removes the whole `Connection`.
 pub struct Connection<C> {
@@ -177,22 +178,25 @@ pub struct Connection<C> {
   /// The peer's FIN/EOF has been delivered to the machine. Gates the
   /// exactly-once empty-EOF `handle_transport_data` call.
   pub eof_delivered: bool,
+  /// A transport fault — the socket died WITHOUT a graceful peer FIN (a received
+  /// RST, or an async driver's worker resetting the slot) — has been surfaced to
+  /// the machine. Mirrors [`eof_delivered`](Self::eof_delivered): the inbound
+  /// pump sets it the first time it observes `!is_open` on a still-mapped
+  /// connection, so the machine's `handle_transport_error` / `handle_dial_failed`
+  /// fires at most once per connection rather than on every subsequent pump. A
+  /// reset is a transport FAILURE, not the clean EOF `eof_delivered` gates, so
+  /// the two latches are independent.
+  pub error_delivered: bool,
   /// Backstop deadline for the [`ConnState::Closing`] drain. `Some` only while
   /// the connection is `Closing`: it is the instant by which the buffered
-  /// outbound bytes must have been delivered and the terminal FIN emitted. If the
-  /// peer never drains the tx ring (permanent backpressure / vanished peer) the
-  /// drain check force-aborts the socket and reclaims it at this instant so the
-  /// pool cannot wedge. Folded into the engine's returned wakeup alongside the
-  /// `closing`-map deadlines so a deadline-driven caller honors it.
+  /// outbound bytes must have been delivered and the terminal FIN emitted. It is
+  /// set ONCE when the connection enters `Closing` and is NEVER re-armed, so it is
+  /// a hard cap on the pre-FIN drain: a peer that has not fully drained the tx
+  /// ring by this instant — permanent backpressure, a vanished peer, or an
+  /// indefinitely-slow ACK trickle — is force-aborted and its slot reclaimed, so
+  /// the pool cannot wedge. Folded into the engine's returned wakeup alongside the
+  /// `retiring`-ledger deadlines so a deadline-driven caller honors it.
   pub close_deadline: Option<Instant>,
-  /// The undelivered byte count (`out` bytes + the socket's tx `send_queue`) at
-  /// the last drain-progress observation, meaningful only while `Closing`. The
-  /// drain check re-arms `close_deadline` whenever the count shrinks, making
-  /// `close_timeout` a NO-PROGRESS (idle) bound rather than a total-duration cap:
-  /// a slow-but-progressing peer (reading the response over more than
-  /// `close_timeout`) is never force-aborted, while a stalled / vanished peer
-  /// (no progress for the full `close_timeout`) still is.
-  pub close_drain_mark: usize,
 }
 
 impl<C> Connection<C> {
@@ -205,8 +209,8 @@ impl<C> Connection<C> {
       out: VecDeque::new(),
       fin_pending: false,
       eof_delivered: false,
+      error_delivered: false,
       close_deadline: None,
-      close_drain_mark: 0,
     }
   }
 
@@ -221,8 +225,8 @@ impl<C> Connection<C> {
       out: VecDeque::new(),
       fin_pending: false,
       eof_delivered: false,
+      error_delivered: false,
       close_deadline: None,
-      close_drain_mark: 0,
     }
   }
 
@@ -236,8 +240,8 @@ impl<C> Connection<C> {
       out: VecDeque::new(),
       fin_pending: false,
       eof_delivered: false,
+      error_delivered: false,
       close_deadline: None,
-      close_drain_mark: 0,
     }
   }
 

--- a/memberlist-embedded/src/reliable/tests.rs
+++ b/memberlist-embedded/src/reliable/tests.rs
@@ -40,6 +40,7 @@ fn dialing_connection_has_socket_and_dialing_state() {
   assert!(c.out_is_empty());
   assert!(!c.fin_pending);
   assert!(!c.eof_delivered);
+  assert!(!c.error_delivered);
 }
 
 #[test]
@@ -110,6 +111,30 @@ fn eof_delivered_flag_models_deliver_once() {
   // Second observation: already latched, so suppress.
   let second = !c.eof_delivered;
   assert!(!second, "second EOF observation must be suppressed");
+}
+
+#[test]
+fn error_delivered_flag_models_deliver_once() {
+  // The inbound pump surfaces a mid-exchange transport fault (a socket that died
+  // without a graceful FIN — a RST) exactly once by flipping this latch on first
+  // observation; a second `!is_open` observation must find it already set. It is
+  // independent of `eof_delivered`: a reset is a failure, not a clean EOF.
+  let mut c = Connection::<Conn>::accepted(peer(7946), 6);
+  assert!(!c.error_delivered);
+  // First observation: not yet delivered, so surface the fault and latch.
+  let first = !c.error_delivered;
+  c.error_delivered = true;
+  assert!(first, "first transport-fault observation must surface");
+  // Second observation: already latched, so suppress.
+  let second = !c.error_delivered;
+  assert!(
+    !second,
+    "second transport-fault observation must be suppressed"
+  );
+  assert!(
+    !c.eof_delivered,
+    "the transport-fault latch is independent of the EOF latch"
+  );
 }
 
 #[test]

--- a/memberlist-smoltcp/tests/reliable_pool.rs
+++ b/memberlist-smoltcp/tests/reliable_pool.rs
@@ -1088,28 +1088,36 @@ fn oversized_push_pull_response_is_not_truncated_by_close() {
   );
 }
 
-/// A graceful close whose drain takes LONGER than `close_timeout` in total but
-/// makes progress every tick (a slow-but-continuously-reading peer) must NOT be
-/// truncated: `close_timeout` is a NO-PROGRESS (idle) bound, not a total-drain
-/// cap.
+/// A graceful close whose drain takes LONGER than `close_timeout` in total is
+/// HARD-CAPPED at `close_timeout`, even when the peer makes progress every tick (a
+/// slow-but-continuously-reading peer): `close_timeout` is a TOTAL-DRAIN cap, set
+/// once at `Closing` entry and never re-armed, NOT a no-progress (idle) bound that
+/// a steady ack trickle can extend indefinitely.
 ///
 /// A replies with a large membership snapshot over a tiny tx ring, so the drain
-/// spans many ticks; `close_timeout` is set FAR below the total drain time. B
-/// reads continuously (every tick acks more), so the drain never stalls. With a
-/// total-duration cap the `Closing` connection would be force-aborted partway
-/// (truncating the reply, leaving B short of the full snapshot); with the idle
-/// timeout the deadline re-arms on each ack and the close completes.
+/// spans many ticks; `close_timeout` is set FAR below the total drain time. B reads
+/// continuously (every tick acks more), so the drain never idles — yet because the
+/// cap does not re-arm on progress, A's `Closing` connection is force-aborted
+/// partway. That truncates the oversized reply, and a partial push/pull frame
+/// decodes to nothing, so B never commits the snapshot and does NOT converge.
+///
+/// This is the driver-level counterpart of the engine's
+/// `ack_trickle_cannot_extend_closing_past_one_window`. Its control is
+/// `oversized_push_pull_response_is_not_truncated_by_close`, which runs the same
+/// oversized-reply construction with the DEFAULT (generous) `close_timeout` and DOES
+/// converge — so the non-convergence here is attributable to the tight cap, not to a
+/// truncation on the ordinary close path.
 #[test]
-fn slow_but_progressing_close_is_not_capped_by_close_timeout() {
+fn slow_but_progressing_close_is_hard_capped_by_close_timeout() {
   const BUDGET: u32 = 4000;
   const STREAM_TIMEOUT_MS: u64 = 4000;
   const NEVER: Duration = Duration::from_secs(3600);
   // A large snapshot over a tiny tx ring → a drain that spans far more ticks than
-  // `close_timeout`.
+  // `close_timeout`, so the total-drain cap force-aborts it mid-drain.
   const INJECTED_PEERS: usize = 120;
   const A_TX_RING: usize = 256;
-  // 50 ms = 5 ticks. The drain spans dozens of ticks, so a total cap would abort
-  // mid-drain; the idle timeout re-arms every tick B acks.
+  // 50 ms = 5 ticks. The drain spans dozens of ticks, so the hard cap fires long
+  // before it completes; a continuously-reading B cannot extend it (no idle re-arm).
   const CLOSE_TIMEOUT_MS: u64 = 50;
   const TICK_MS: u64 = 10;
 
@@ -1165,7 +1173,6 @@ fn slow_but_progressing_close_is_not_capped_by_close_timeout() {
 
   let expected = 1 + a_members_before;
   let mut converged = false;
-  let mut ticks = 0u32;
   for _ in 0..BUDGET {
     let _ = a.poll(clk.now(), &mut da);
     let _ = b.poll(clk.now(), &mut db);
@@ -1173,27 +1180,29 @@ fn slow_but_progressing_close_is_not_capped_by_close_timeout() {
       converged = true;
       break;
     }
-    ticks += 1;
     clk.advance_ms(TICK_MS);
   }
 
   assert!(
-    converged,
-    "B converged to only {} of {} members: the graceful close was force-aborted \
-     mid-drain because `close_timeout` ({} ms) was treated as a total-drain cap \
-     rather than a no-progress idle bound — even though B read continuously and \
-     the drain never stalled.",
+    !converged,
+    "B converged to {} of {} members: A's graceful close was NOT hard-capped. A \
+     slow-but-progressing drain must be force-aborted at `close_timeout` ({} ms) — \
+     truncating the oversized reply — not allowed to re-arm the deadline on each ack \
+     and run to completion.",
     b.num_members(),
     expected,
     CLOSE_TIMEOUT_MS,
   );
-  // The drain genuinely spanned far more than `close_timeout` (so a total cap
-  // WOULD have fired): the total elapsed exceeds it by a wide margin.
-  assert!(
-    u64::from(ticks) * TICK_MS > CLOSE_TIMEOUT_MS * 3,
-    "the drain finished too fast ({} ticks) to exercise the idle-vs-total \
-     distinction; raise the snapshot size or lower close_timeout",
-    ticks,
+  // The truncated push/pull reply decodes to nothing, so B learns neither A nor any
+  // injected peer from it and stays a lone member — proving the cap DROPPED the reply
+  // remainder rather than merely delaying it (the control test, with a generous
+  // `close_timeout`, converges to all `expected` members from the same construction).
+  assert_eq!(
+    b.num_members(),
+    1,
+    "B should remain a lone member after the hard-capped close truncated A's reply \
+     (a partial push/pull frame decodes to nothing), but it has {}.",
+    b.num_members(),
   );
 }
 


### PR DESCRIPTION
## #162 X6 (stage 2/4) — engine teardown/close/inbound policy (#159 F1/F2/F6)

Second of four staged PRs for the X6 teardown architecture (stacked on #213). Three engine-policy fixes in `memberlist-embedded`, built on PR A's generation-tagged ledger, plus one F6-required embassy contract fix.

### F1 — teardown branches on establishment, not writability
`teardown` gated the graceful-drain branch on `may_send`. Embassy's `may_send` is `established && outbound_ring_has_room`, so an **Established connection under full outbound-ring backpressure** failed the gate and took the abrupt-RST branch — a graceful close became an RST under ordinary backpressure. Fixed to branch on `is_established`, so a backpressured established close now **drains** (`Closing`) instead of RST'ing. The `may_send → is_established` switch in `promote_established`/`flush_pending_shutdowns` is behavior-neutral (`send_queue == 0` implies ring room).

### F2 — hard cap on the close deadline (ruling)
`flush_closing` re-armed `close_deadline` every tick undelivered bytes shrank, so an ACK trickle extended the drain forever — contradicting the config doc's "**maximum**". Fixed to a hard cap: `close_deadline` is set once at `Closing` entry and **never re-armed**; deleted `Connection::close_drain_mark` and the progress/re-arm arm (`flush_closing` is now two arms: drained→FIN, deadline→abort). The `close_timeout` doc is rewritten to per-phase hard-cap semantics — the pre-FIN drain, the FIN handshake, and RST egress are each bounded, and no peer behavior (including a progressing trickle) can extend any window. The smoltcp `slow_but_progressing_close_*` test is inverted to assert the cap at the driver level.

### F6 — surface transport faults promptly
`pump_inbound_reliable` never consulted `is_open`, so a RST'd exchange sat until the ~10s stream deadline. Fixed with a one-shot `error_delivered` latch: `!is_open` on a `Dialing` conn → `handle_dial_failed`; otherwise (unless the benign completed tail) → `handle_transport_error` (the machine's documented mid-exchange-RST path). The machine fails the bridge, queues `Abort`, and the same pump's `abort_exchange` retires the slot via the ledger — machine-directed, no driver compensation. A mid-exchange RST or async dial failure now terminalizes in **one pump**.

### F6-required embassy contract fix
F6 reads `Dialing + !is_open` as a dial failure, but embassy reported `is_open = true` only *after* `connect().await` succeeded — so a normally-dialing conn was `!is_open` and F6 killed every dial. Because the pump is **synchronous** (the F6 check precedes the dial-issue in the same pump; the worker's `open` set is one pump behind and the latch is one-shot), the fix sets `open = true` **synchronously** in the engine-side `StreamIo::connect` view before posting the Dial — honoring the `is_open = "not yet closed"` contract (mirroring smoltcp's SynSent). **Safety-verified:** `is_open` reads `mb.open` (changed); `is_established` reads `mb.established` (untouched, post-connect); `may_send` reads `established && ring-room` (untouched) — so during dialing `is_open=true, is_established=false, may_send=false`, and the engine never sends on or promotes a not-yet-connected socket. This is the minimal contract fix only; the full embassy worker redesign (#160 F1/F2) is stage C.
