### PR TITLE
fix(embassy): X6 stage 3/4 — abort-preemptive worker with bounded single-drain teardown (#160 F1/F2)

### DIFF
--- a/memberlist-embassy/src/mailbox/mod.rs
+++ b/memberlist-embassy/src/mailbox/mod.rs
@@ -153,4 +153,25 @@ impl Mailbox {
     // socket back to a clean Closed state, so the slot is now reuse-ready.
     self.reset_done = true;
   }
+
+  /// Consume the directive a worker arm just acted on — clearing [`command`] to
+  /// [`Command::Idle`] ONLY IF it still equals `acted`.
+  ///
+  /// A worker handshake/close arm reads its directive, performs the socket op, then
+  /// hands control to code that re-reads `command`. Between the read and this clear
+  /// the engine may have posted a NEW directive (an `Abort` retiring the slot at the
+  /// exchange deadline, or a `Close`→`Abort` escalation) with the slot's wake
+  /// latched. An unconditional `command = Idle` would ERASE that pending directive,
+  /// orphaning an established/closing socket the engine can no longer reach — the
+  /// slot pins. Comparing first leaves a differing directive SET, so the next
+  /// command match honors it (aborts + resets); only the exact directive this arm
+  /// acted on is cleared. [`Command`] is `Eq`, so the comparison is a direct match.
+  pub(crate) fn consume_command(&mut self, acted: Command) {
+    if self.command == acted {
+      self.command = Command::Idle;
+    }
+  }
 }
+
+#[cfg(test)]
+mod tests;

--- a/memberlist-embassy/src/mailbox/tests.rs
+++ b/memberlist-embassy/src/mailbox/tests.rs
@@ -1,0 +1,70 @@
+use super::{Command, Mailbox};
+use core::net::SocketAddr;
+
+fn sa(last: u8) -> SocketAddr {
+  SocketAddr::from(([169, 254, 0, last], 7946))
+}
+
+/// `consume_command` clears ONLY the directive the worker arm acted on. With no
+/// concurrently-posted directive, each handshake/close arm's command is consumed
+/// to `Idle`.
+#[test]
+fn consume_command_clears_the_acted_directive() {
+  let mut mb = Mailbox::new(64, 64);
+
+  // Accept arm: acted on `Listen(port)`, nothing posted since ⇒ cleared.
+  mb.command = Command::Listen(7946);
+  mb.consume_command(Command::Listen(7946));
+  assert_eq!(mb.command, Command::Idle);
+
+  // Dial-success arm: acted on `Dial(remote)` ⇒ cleared.
+  mb.command = Command::Dial(sa(2));
+  mb.consume_command(Command::Dial(sa(2)));
+  assert_eq!(mb.command, Command::Idle);
+
+  // Established Close-consume: acted on `Close` ⇒ cleared.
+  mb.command = Command::Close;
+  mb.consume_command(Command::Close);
+  assert_eq!(mb.command, Command::Idle);
+}
+
+/// A directive the engine posted AFTER the worker read the one it acted on (an
+/// `Abort` retiring the slot, or a `Close`→`Abort` escalation) must SURVIVE the
+/// consume: `command` no longer equals the acted directive, so the next command
+/// match still tears the slot down instead of the arm erasing it into an orphan.
+#[test]
+fn consume_command_preserves_a_concurrently_posted_directive() {
+  // Accept-success racing an abort: the abort must not be erased.
+  let mut mb = Mailbox::new(64, 64);
+  mb.command = Command::Abort;
+  mb.consume_command(Command::Listen(7946));
+  assert_eq!(
+    mb.command,
+    Command::Abort,
+    "an abort posted while the accept completed must survive the consume"
+  );
+
+  // Dial-success racing an abort.
+  mb.command = Command::Abort;
+  mb.consume_command(Command::Dial(sa(2)));
+  assert_eq!(
+    mb.command,
+    Command::Abort,
+    "an abort posted while the connect completed must survive the consume"
+  );
+
+  // Close-consume racing an abort escalation (Draining→Aborting).
+  mb.command = Command::Abort;
+  mb.consume_command(Command::Close);
+  assert_eq!(
+    mb.command,
+    Command::Abort,
+    "an abort escalation while closing must survive the consume"
+  );
+
+  // A dial that is being re-targeted: the acted `Dial` differs from a freshly
+  // posted `Dial` to another remote, so the new one survives.
+  mb.command = Command::Dial(sa(3));
+  mb.consume_command(Command::Dial(sa(2)));
+  assert_eq!(mb.command, Command::Dial(sa(3)));
+}

--- a/memberlist-embassy/src/memberlist/mod.rs
+++ b/memberlist-embassy/src/memberlist/mod.rs
@@ -356,6 +356,24 @@ where
     ))?;
     let socket_timeout = embassy_time::Duration::from_ticks(socket_ticks);
 
+    // Bound each worker's best-effort teardown RST flush (see the worker's
+    // `drain_teardown`). embassy-net's `flush` stays pending while a `Closed` socket
+    // still holds its remote tuple, which for an ARP-unresolvable on-link peer never
+    // clears — so an unbounded teardown flush would pin the slot forever. The bound
+    // must be strictly LESS than the engine's first retiring deadline, which is
+    // `close_timeout` (the engine's `retire` arms `now + close_timeout` and
+    // `reap_retiring` counts a `teardown_overruns` when an abort's teardown is still
+    // unacknowledged a full `close_timeout` on): a slot's teardown must be
+    // acknowledged before that deadline escalates. Half the close timeout leaves a
+    // full `close_timeout / 2` of margin for the command-wake → flush-abandon →
+    // mailbox-reset → engine-reap latency, so `teardown_done` reliably precedes
+    // escalation and `teardown_overruns` stays 0. Converted into the embassy-time tick
+    // domain exactly as `socket_timeout` above (a sub-tick close timeout floors to a
+    // zero bound, which is still strictly below the deadline — teardown just proceeds
+    // to the local reset at once).
+    let teardown_ticks = duration_to_ticks(cfg.close_timeout / 2, embassy_time::TICK_HZ as u128);
+    let teardown_timeout = embassy_time::Duration::from_ticks(teardown_ticks);
+
     // Run the engine's advertise-independent config preflight BEFORE resolving the
     // advertise address or binding the gossip socket. An invalid port, gossip MTU,
     // close timeout, or encryption/checksum keyring fails here deterministically —
@@ -458,6 +476,9 @@ where
       // a slot (and, via the reuse gate, the pool) indefinitely. Already converted +
       // validated in the embassy-time tick domain above.
       socket_timeout,
+      // Bounds every worker's best-effort teardown RST flush (derived strictly below
+      // the engine's retiring deadline above) so a dead on-link dial cannot pin a slot.
+      teardown_timeout,
       // The driver-side free-list is the `StreamIo` pool mirror; the engine owns
       // and drives its own pool, so this starts empty (and stays unused — see
       // `EmbassyStream`'s pool methods).

--- a/memberlist-embassy/src/runner.rs
+++ b/memberlist-embassy/src/runner.rs
@@ -69,6 +69,12 @@ pub struct Runner<'a, I, const N: usize, R = memberlist_proto::SmallRng> {
   /// worker applies to its `TcpSocket` so a blocking connect/write/flush/read to an
   /// unresponsive peer cannot wedge it.
   pub(crate) socket_timeout: embassy_time::Duration,
+  /// Bound (in the embassy-time tick domain) on each worker's best-effort teardown
+  /// RST flush, so a dead on-link peer whose RST cannot egress cannot pin a slot. Set
+  /// strictly below the engine's retiring deadline at construction so a slot's
+  /// teardown is acknowledged before the engine escalates (see the worker's
+  /// `drain_teardown`).
+  pub(crate) teardown_timeout: embassy_time::Duration,
   pub(crate) free: Vec<SlotId>,
 }
 
@@ -91,6 +97,7 @@ where
       mailboxes,
       cmd_wakes,
       socket_timeout,
+      teardown_timeout,
       mut free,
     } = self;
 
@@ -111,6 +118,7 @@ where
         &cmd_wakes[i],
         &shared.pump_wake,
         socket_timeout,
+        teardown_timeout,
       )
     });
 

--- a/memberlist-embassy/src/worker.rs
+++ b/memberlist-embassy/src/worker.rs
@@ -121,7 +121,7 @@ pub(crate) async fn run_slot(
             // The pump must observe the new accept so `check_listener` maps it.
             pump_wake.signal(());
             if peer.is_some() {
-              run_established(socket, mb, cmd_wake, pump_wake, teardown_timeout).await;
+              run_established(socket, mb, cmd_wake, pump_wake).await;
             }
             reset_socket(socket, mb, teardown_timeout).await;
             pump_wake.signal(());
@@ -133,11 +133,13 @@ pub(crate) async fn run_slot(
           }
           Either::Second(()) => {
             // A new command arrived mid-accept; abandon the listen and re-read it.
-            // `abort()` returns the socket to Closed so the next command's
-            // accept/connect starts cleanly. Bound the RST egress so a peer that
-            // never receives it cannot pin the worker here (see `drain_teardown`).
+            // `abort()` moves the socket to `Closed`. Do NOT drain here: this iteration
+            // does not reach `reset_socket`, so the socket's RST egress is bounded once
+            // at the eventual `reset_socket` (if the next command is `Close`/`Abort`) or
+            // simply discarded when the next `connect`/`accept` re-initializes the
+            // socket via smoltcp's `reset()` — draining here would double the teardown
+            // budget for a mid-accept-then-close.
             socket.abort();
-            drain_teardown(socket, teardown_timeout).await;
           }
         }
       }
@@ -181,7 +183,7 @@ pub(crate) async fn run_slot(
             }
             // The pump must observe the established slot to promote its exchange.
             pump_wake.signal(());
-            run_established(socket, mb, cmd_wake, pump_wake, teardown_timeout).await;
+            run_established(socket, mb, cmd_wake, pump_wake).await;
             reset_socket(socket, mb, teardown_timeout).await;
             pump_wake.signal(());
           }
@@ -233,7 +235,6 @@ async fn run_established(
   mb: &RefCell<Mailbox>,
   cmd_wake: &SlotWake,
   pump_wake: &SlotWake,
-  teardown_timeout: Duration,
 ) {
   // Half-close state machine. A push/pull exchange is a full-duplex request/reply
   // over ONE connection that BOTH sides half-close: the requester writes its
@@ -284,10 +285,11 @@ async fn run_established(
       }
       Command::Abort => {
         socket.abort();
-        // Bound the RST egress: a peer that never receives it (e.g. an
-        // ARP-unresolvable on-link target) must not pin the worker here. The slot is
-        // reset next regardless (see `drain_teardown`).
-        drain_teardown(socket, teardown_timeout).await;
+        // `abort()` moves the socket to `Closed`; its RST egress is bounded ONCE at
+        // the caller's following `reset_socket` (the sole teardown drain). Do NOT drain
+        // here: a second bounded drain would double the teardown budget, so a
+        // non-egressing RST would wait ~the full `close_timeout` before the slot resets
+        // — which the engine's retiring deadline beats, ticking `teardown_overruns`.
         {
           let mut m = mb.borrow_mut();
           m.open = false;
@@ -518,6 +520,17 @@ async fn drain_teardown(socket: &mut TcpSocket<'_>, timeout: Duration) {
 /// wait for it beyond `teardown_timeout` — a dead on-link peer's RST never egresses,
 /// and an unbounded wait would pin this slot forever (see `drain_teardown`). The
 /// mailbox reset clears every per-connection field (preserving ring capacities).
+///
+/// This is the SOLE bounded teardown drain, so every teardown path drains AT MOST
+/// once. Every terminal path routes through here exactly once: accept success/err,
+/// dial success/err/preempt, a `Close`/`Abort` on an unestablished slot, and every
+/// `run_established` return (its `Close` completion, transport-error, and `Abort`
+/// arms). The `Abort` arm and the accept-preempt deliberately `abort()` WITHOUT their
+/// own drain and rely on this single one — a second bounded drain on the same teardown
+/// would double the budget, letting a non-egressing RST overrun the engine's retiring
+/// deadline. The accept-preempt is the one terminal `abort()` that does not reach here
+/// on its iteration; it needs no drain (the next `connect`/`accept` re-initializes the
+/// socket via smoltcp `reset()`, or a subsequent `Close`/`Abort` routes back here).
 async fn reset_socket(
   socket: &mut TcpSocket<'_>,
   mb: &RefCell<Mailbox>,

--- a/memberlist-embassy/src/worker.rs
+++ b/memberlist-embassy/src/worker.rs
@@ -109,7 +109,11 @@ pub(crate) async fn run_slot(
               m.accepted_peer = peer;
               m.established = peer.is_some();
               m.open = peer.is_some();
-              m.command = Command::Idle;
+              // Consume the `Listen` this arm acted on WITHOUT erasing a directive the
+              // engine posted while the handshake completed (see `consume_command`): a
+              // concurrent `Abort`/`Close` survives for the established loop to honor,
+              // rather than being erased into an orphaned, engine-unreachable socket.
+              m.consume_command(Command::Listen(port));
               m.sock_send_queue = socket.send_queue();
             }
             // The pump must observe the new accept so `check_listener` maps it.
@@ -167,7 +171,11 @@ pub(crate) async fn run_slot(
               // signal the engine gates `may_send` / `is_established` on. Re-assert it
               // (idempotent) so this success arm mirrors the accept arm above.
               m.open = true;
-              m.command = Command::Idle;
+              // Consume the `Dial` this arm acted on without erasing a directive posted
+              // while the connect completed (see `consume_command`): a concurrent
+              // `Abort`/`Close` survives for `run_established` to honor instead of
+              // orphaning the freshly-established slot.
+              m.consume_command(Command::Dial(remote));
               m.sock_send_queue = socket.send_queue();
             }
             // The pump must observe the established slot to promote its exchange.
@@ -262,7 +270,11 @@ async fn run_established(
           we_finned = true;
           {
             let mut m = mb.borrow_mut();
-            m.command = Command::Idle;
+            // Consume the `Close` without erasing a concurrent `Abort` escalation
+            // (Draining→Aborting; see `consume_command`): it survives for the next
+            // command match to abort + reset rather than half-closing a socket the
+            // engine wanted torn down.
+            m.consume_command(Command::Close);
             m.sock_send_queue = socket.send_queue();
           }
           pump_wake.signal(());
@@ -300,15 +312,22 @@ async fn run_established(
       };
       if drained {
         // Ignoring Err: a reset during the final flush just means the peer already
-        // tore down; our FIN is moot then and the slot is reset regardless.
-        let _ = socket.flush().await;
-        {
-          let mut m = mb.borrow_mut();
-          m.open = false;
-          m.sock_send_queue = 0;
+        // tore down; our FIN is moot then and the slot is reset regardless. Race the
+        // flush against the command wake so a peer that never ACKs our FIN cannot pin
+        // the worker here forever: an `Abort` then pre-empts it (`Either::Second` →
+        // re-check the mailbox), and `reset_socket`'s local RST completes the teardown.
+        match select(socket.flush(), cmd_wake.wait()).await {
+          Either::First(_) => {
+            {
+              let mut m = mb.borrow_mut();
+              m.open = false;
+              m.sock_send_queue = 0;
+            }
+            pump_wake.signal(());
+            return;
+          }
+          Either::Second(()) => continue,
         }
-        pump_wake.signal(());
-        return;
       }
     }
 
@@ -332,8 +351,17 @@ async fn run_established(
         let m = mb.borrow();
         m.outbound.iter().copied().collect()
       };
-      match socket.write(&chunk).await {
-        Ok(written) => {
+      // Race the write against the command wake so an engine `Abort` (or a benign
+      // send/recv pulse) pre-empts a peer-stalled write instead of parking the worker
+      // in `write` forever while a black-holed peer keeps the socket nominally active
+      // (refreshing the inactivity backstop). `Either::Second` means only "re-check the
+      // mailbox": embassy writes are single-commit poll futures, so dropping a
+      // still-pending one loses no bytes, and the top-of-loop command match then honors
+      // any real `Close`/`Abort` while a mere pulse re-drains. `select` polls the write
+      // first, so a write making progress still resolves as `Either::First` even with a
+      // pulse latched — only a genuinely-blocked write yields.
+      match select(socket.write(&chunk), cmd_wake.wait()).await {
+        Either::First(Ok(written)) => {
           {
             let mut m = mb.borrow_mut();
             for _ in 0..written {
@@ -343,15 +371,19 @@ async fn run_established(
           }
           // Ignoring Err: a reset mid-flush means the connection is gone; the read
           // below observes it and tears the slot down. Re-sync the send queue from
-          // the socket regardless.
-          let _ = socket.flush().await;
+          // the socket regardless. Race the flush too — a peer that never ACKs must
+          // not pin the worker here past an `Abort`; `Either::Second` re-checks the
+          // mailbox and the command match tears the slot down.
+          if let Either::Second(()) = select(socket.flush(), cmd_wake.wait()).await {
+            continue;
+          }
           {
             let mut m = mb.borrow_mut();
             m.sock_send_queue = socket.send_queue();
           }
           pump_wake.signal(());
         }
-        Err(_) => {
+        Either::First(Err(_)) => {
           {
             let mut m = mb.borrow_mut();
             m.open = false;
@@ -360,6 +392,7 @@ async fn run_established(
           pump_wake.signal(());
           return;
         }
+        Either::Second(()) => continue,
       }
       // Loop to re-read the command (the engine may now Close) and re-drain.
       continue;

--- a/memberlist-embassy/src/worker.rs
+++ b/memberlist-embassy/src/worker.rs
@@ -19,6 +19,7 @@ use core::cell::RefCell;
 
 use embassy_futures::select::{Either, select};
 use embassy_net::tcp::TcpSocket;
+use embassy_time::{Duration, Timer};
 
 use crate::{
   mailbox::{Command, Mailbox},
@@ -61,7 +62,8 @@ pub(crate) async fn run_slot(
   mb: &RefCell<Mailbox>,
   cmd_wake: &SlotWake,
   pump_wake: &SlotWake,
-  socket_timeout: embassy_time::Duration,
+  socket_timeout: Duration,
+  teardown_timeout: Duration,
 ) -> ! {
   // Bound EVERY blocking socket await (connect / write / flush / read) so a peer
   // that stops responding cannot wedge this worker: embassy-net aborts the socket
@@ -119,24 +121,23 @@ pub(crate) async fn run_slot(
             // The pump must observe the new accept so `check_listener` maps it.
             pump_wake.signal(());
             if peer.is_some() {
-              run_established(socket, mb, cmd_wake, pump_wake).await;
+              run_established(socket, mb, cmd_wake, pump_wake, teardown_timeout).await;
             }
-            reset_socket(socket, mb).await;
+            reset_socket(socket, mb, teardown_timeout).await;
             pump_wake.signal(());
           }
           Either::First(Err(_)) => {
             // Listen failed (e.g. the socket was not in a clean state). Reset and
             // retry on the next loop.
-            reset_socket(socket, mb).await;
+            reset_socket(socket, mb, teardown_timeout).await;
           }
           Either::Second(()) => {
             // A new command arrived mid-accept; abandon the listen and re-read it.
             // `abort()` returns the socket to Closed so the next command's
-            // accept/connect starts cleanly.
+            // accept/connect starts cleanly. Bound the RST egress so a peer that
+            // never receives it cannot pin the worker here (see `drain_teardown`).
             socket.abort();
-            // Ignoring Err: a best-effort RST flush on a socket with no peer is a
-            // no-op; the reset below re-clears the mailbox regardless.
-            let _ = socket.flush().await;
+            drain_teardown(socket, teardown_timeout).await;
           }
         }
       }
@@ -180,8 +181,8 @@ pub(crate) async fn run_slot(
             }
             // The pump must observe the established slot to promote its exchange.
             pump_wake.signal(());
-            run_established(socket, mb, cmd_wake, pump_wake).await;
-            reset_socket(socket, mb).await;
+            run_established(socket, mb, cmd_wake, pump_wake, teardown_timeout).await;
+            reset_socket(socket, mb, teardown_timeout).await;
             pump_wake.signal(());
           }
           Either::First(Err(_)) => {
@@ -195,7 +196,7 @@ pub(crate) async fn run_slot(
             }
             // The pump must observe `open == false` to reap the failed dial.
             pump_wake.signal(());
-            reset_socket(socket, mb).await;
+            reset_socket(socket, mb, teardown_timeout).await;
           }
           Either::Second(()) => {
             // A command arrived mid-connect (the engine posted `Abort`, retiring this
@@ -203,7 +204,7 @@ pub(crate) async fn run_slot(
             // the next command starts cleanly, and wake the pump so it observes the
             // slot is reuse-ready (`reset_done`) and can dispatch any deferred dial —
             // without this the dial-churn would stall (freed slots never re-observed).
-            reset_socket(socket, mb).await;
+            reset_socket(socket, mb, teardown_timeout).await;
             pump_wake.signal(());
           }
         }
@@ -211,7 +212,7 @@ pub(crate) async fn run_slot(
       // A Close/Abort posted to an un-established slot has nothing to tear down;
       // clear it and park again.
       Command::Close | Command::Abort => {
-        reset_socket(socket, mb).await;
+        reset_socket(socket, mb, teardown_timeout).await;
       }
       // Idle: park until the engine posts a command. Re-read after the wake.
       Command::Idle => {
@@ -232,6 +233,7 @@ async fn run_established(
   mb: &RefCell<Mailbox>,
   cmd_wake: &SlotWake,
   pump_wake: &SlotWake,
+  teardown_timeout: Duration,
 ) {
   // Half-close state machine. A push/pull exchange is a full-duplex request/reply
   // over ONE connection that BOTH sides half-close: the requester writes its
@@ -282,9 +284,10 @@ async fn run_established(
       }
       Command::Abort => {
         socket.abort();
-        // Ignoring Err: abort flush waits for the RST to be sent; failure means
-        // it is already gone. The slot is reset next regardless.
-        let _ = socket.flush().await;
+        // Bound the RST egress: a peer that never receives it (e.g. an
+        // ARP-unresolvable on-link target) must not pin the worker here. The slot is
+        // reset next regardless (see `drain_teardown`).
+        drain_teardown(socket, teardown_timeout).await;
         {
           let mut m = mb.borrow_mut();
           m.open = false;
@@ -479,17 +482,48 @@ async fn run_established(
   }
 }
 
+/// Best-effort bounded flush of a torn-down socket's RST, then proceed regardless.
+///
+/// A teardown site `abort()`s the socket (moving it to `Closed`) and then wants the
+/// RST to egress before the socket is reused. But embassy-net's `flush` stays PENDING
+/// while a `Closed` socket still holds its remote tuple, and that tuple clears only
+/// once the RST actually leaves the interface — which never happens for an
+/// ARP-unresolvable on-link peer (the SYN/RST cannot be framed without the peer's link
+/// address). An UNBOUNDED flush there would pin this worker — and thus its pool slot —
+/// forever, so a pre-trust peer that floods dials at dead on-link addresses could
+/// exhaust the reliable pool permanently. Racing the flush against a dedicated timer
+/// bounds every teardown to `timeout`: a reachable peer's RST still egresses (the flush
+/// resolves first), and a dead peer's simply does not — the slot frees either way.
+///
+/// The timer is DEDICATED (an [`embassy_time::Timer`]), NOT the multiplexed command
+/// wake the send flushes race, so a benign concurrent `send`/`recv` pulse cannot cut a
+/// teardown short — only real elapsed time does. `timeout` is derived at construction
+/// to be strictly less than the engine's retiring deadline, so the slot's teardown is
+/// acknowledged before the engine escalates (keeping `teardown_overruns` at 0). After
+/// an abandoned wait the socket stays `Closed` with its stale tuple/queued RST, which
+/// the next `connect`/`accept` discards when smoltcp re-initializes the control block —
+/// so reuse is safe.
+async fn drain_teardown(socket: &mut TcpSocket<'_>, timeout: Duration) {
+  // Ignoring Err/timeout: the RST is best-effort — a dead peer never receives it, and
+  // the socket is reset to a clean, reusable state regardless.
+  let _ = select(socket.flush(), Timer::after(timeout)).await;
+}
+
 /// Return the socket to a clean Closed state and reset the mailbox for the slot's
 /// next reuse.
 ///
 /// `abort()` is idempotent on an already-closed socket and guarantees the socket
-/// leaves any half-open/closing state so the next `accept`/`connect` starts
-/// fresh; the subsequent `flush` lets a pending RST go out. The mailbox reset
-/// clears every per-connection field (preserving ring capacities).
-async fn reset_socket(socket: &mut TcpSocket<'_>, mb: &RefCell<Mailbox>) {
+/// leaves any half-open/closing state so the next `accept`/`connect` starts fresh;
+/// the subsequent bounded flush lets a pending RST egress WHEN IT CAN, but does not
+/// wait for it beyond `teardown_timeout` — a dead on-link peer's RST never egresses,
+/// and an unbounded wait would pin this slot forever (see `drain_teardown`). The
+/// mailbox reset clears every per-connection field (preserving ring capacities).
+async fn reset_socket(
+  socket: &mut TcpSocket<'_>,
+  mb: &RefCell<Mailbox>,
+  teardown_timeout: Duration,
+) {
   socket.abort();
-  // Ignoring Err: flushing the RST on an already-dead socket is a no-op; the
-  // socket is returned to Closed either way.
-  let _ = socket.flush().await;
+  drain_teardown(socket, teardown_timeout).await;
   mb.borrow_mut().reset();
 }

--- a/memberlist-embassy/tests/lifecycle.rs
+++ b/memberlist-embassy/tests/lifecycle.rs
@@ -641,6 +641,10 @@ fn established_abort_with_non_egressing_rst_recovers() {
 
   let free_a_at_start = ml_a.pool_free_count();
   block_on(async {
+    // Set once the raw peer's `accept` resolves — a wire-confirmed handshake (A's dial
+    // established) that the framing gate must not close before. A single-threaded `Cell`
+    // shared by the peer task (writer) and the gate (reader) under one `block_on`.
+    let peer_accepted = core::cell::Cell::new(false);
     // The non-reading peer: accept A's dial, then hold the socket open forever without
     // ever reading, so A's worker parks in the established send.
     let peer = async {
@@ -649,6 +653,10 @@ fn established_abort_with_non_egressing_rst_recovers() {
         .accept(7946)
         .await
         .expect("the raw peer accepts A's dial");
+      // Signal the wire-confirmed handshake: A sent the final ACK (the peer received it),
+      // so A's `connect` resolves with no further frames and its worker enters
+      // `run_established`. The gate may now close to strand only the later abort's RST.
+      peer_accepted.set(true);
       core::future::pending::<()>().await;
     };
 
@@ -656,12 +664,29 @@ fn established_abort_with_non_egressing_rst_recovers() {
       // Let the raw peer reach its `accept` before A dials it.
       Timer::after(Duration::from_millis(50)).await;
 
-      // Close A's framing gate AFTER the (sub-millisecond, local) handshake has
-      // established the connection but BEFORE the exchange elapses at `stream_timeout`
-      // (300 ms) and the engine posts `Abort` — so the abort's RST cannot be framed and
-      // its teardown flush must fall back on the worker's dedicated teardown timer.
+      // Close A's framing gate only once the connection is CONFIRMED established, so the
+      // stalled abort deterministically hits `run_established`'s established
+      // `Command::Abort` arm (the single-drain site under test) rather than the
+      // dial-preempt path — which is single-drain even on the pre-fix worker and would let
+      // the buggy code false-pass. The raw peer's `accept` resolving proves the handshake
+      // completed on the wire, so A's worker is (entering) `run_established`; closing the
+      // gate here therefore strands only the later teardown RST, not the handshake. Bound
+      // the wait and ASSERT establishment so a scheduling anomaly that never establishes
+      // fails LOUDLY instead of silently taking the dialing path and passing. The bound is
+      // well under `stream_timeout` (300 ms), so the gate always closes before the engine
+      // posts `Abort`.
       let gate = async {
-        Timer::after(Duration::from_millis(120)).await;
+        let established = select(
+          until(|| peer_accepted.get()),
+          Timer::after(Duration::from_millis(200)),
+        )
+        .await;
+        assert!(
+          matches!(established, Either::First(())),
+          "the raw peer never accepted A's dial within the establishment bound: the \
+           reliable connection did not establish, so the abort could not reach \
+           run_established's established Abort arm (the single-drain site under test)"
+        );
         a_frame.set(false);
         core::future::pending::<()>().await
       };

--- a/memberlist-embassy/tests/lifecycle.rs
+++ b/memberlist-embassy/tests/lifecycle.rs
@@ -142,19 +142,28 @@ async fn drive<T>(
   }
 }
 
-/// Build one node with a short `stream_timeout` so dead dials reap quickly.
-fn node<'a>(
+/// A short engine close-timeout for the dead-on-link recovery tests. The worker
+/// bounds each teardown RST flush to `close_timeout / 2` (see the worker's
+/// `drain_teardown`), so a short close-timeout keeps a dead dial's slot recovering
+/// quickly — well within the test budget — while its teardown still completes before
+/// the engine's retiring deadline (`close_timeout`), keeping `teardown_overruns` at 0.
+const FAST_CLOSE_TIMEOUT: core::time::Duration = core::time::Duration::from_millis(500);
+
+/// Build one node with a short `stream_timeout` (so dead dials reap quickly) and the
+/// given driver [`Options`].
+fn node_with_opts<'a>(
   stack: Stack<'a>,
   bufs: &'a mut NodeBufs,
   id: &str,
   last: u8,
   seed: u64,
+  opts: Options,
 ) -> (Memberlist<SmolStr, SocketAddr>, Runner<'a, SmolStr, POOL>) {
   let (udp, tcp) = build_sockets(stack, bufs);
   // `SocketAddrResolver` resolves synchronously, so drive the now-async
   // constructor to completion inline — this helper stays sync.
   block_on(Memberlist::new_with_rng::<_, POOL>(
-    Options::new(),
+    opts,
     TransformOptions::default(),
     EndpointOptions::new(SmolStr::new(id), addr(last, 7946))
       // Short stream timeout: a dead dial fails (and its slot is reaped) quickly so
@@ -167,6 +176,17 @@ fn node<'a>(
     SmallRng::seed_from_u64(seed),
   ))
   .expect("build node")
+}
+
+/// Build one node with default driver options and a short `stream_timeout`.
+fn node<'a>(
+  stack: Stack<'a>,
+  bufs: &'a mut NodeBufs,
+  id: &str,
+  last: u8,
+  seed: u64,
+) -> (Memberlist<SmolStr, SocketAddr>, Runner<'a, SmolStr, POOL>) {
+  node_with_opts(stack, bufs, id, last, seed, Options::new())
 }
 
 /// Wait until `cond()` holds, polling on a short timer; panics via the outer
@@ -262,23 +282,17 @@ fn abort_reuse_does_not_carry_stale_state() {
   });
 }
 
-/// Repeated dial/abort churn must not LEAK a reliable slot: every dead dial's
-/// slot must stay accounted for — either back in the free-list once its worker has
-/// reset the socket, or held in the engine's `retiring` ledger while its teardown
-/// is still pending — so `pool_free_count + retiring_count` recovers to the
-/// construction dial-slot count. A slot reused before its reset (the bug the
-/// generation-tagged teardown protocol closes) would zombie-leak, appearing in
-/// NEITHER, dropping the accounted total below construction.
-///
-/// A dead ON-LINK dial whose ARP never resolves pins its worker in the socket
-/// teardown (the embassy-net RST cannot egress, a pre-existing worker limitation):
-/// that slot's teardown never completes, so it stays VISIBLE in `retiring` (and its
-/// deadline eventually ticks `teardown_overruns`) rather than — as before this
-/// protocol — being returned to the pool and counted as free while its socket was
-/// still a zombie. The engine never reuses such a pinned slot in EITHER regime; the
-/// ledger merely makes the residual pin visible instead of masking it in the free
-/// count. The load-bearing property here is that NO slot is lost (the accounted
-/// total holds) and the listener self-heals.
+/// Repeated dial/abort churn must fully RECOVER the reliable pool, not merely avoid
+/// leaking it. A dead ON-LINK dial whose ARP never resolves stalls in SYN-sent; the
+/// exchange elapses at `stream_timeout` and the engine aborts + retires the slot. The
+/// teardown RST likewise cannot egress, so the worker bounds its teardown flush with a
+/// dedicated timer (`close_timeout / 2`) that frees the slot rather than pinning it.
+/// After the churn quiesces every dial slot must be back in the free-list (nothing
+/// left in the `retiring` ledger), the listener must self-heal, and no teardown may
+/// have overrun the engine's retiring deadline (`teardown_overruns == 0`). A slot
+/// reused before its worker reset would zombie-leak (absent from both free and
+/// retiring); an unbounded teardown flush would pin a dead dial's slot in `retiring`
+/// forever — both would fail the recovery assertions here.
 #[test]
 fn pool_does_not_wedge_under_dial_abort_churn() {
   let (dev_a, dev_b) = pair();
@@ -289,7 +303,14 @@ fn pool_does_not_wedge_under_dial_abort_churn() {
 
   let mut bufs_a = NodeBufs::new();
   let mut bufs_b = NodeBufs::new();
-  let (ml_a, run_a) = node(stack_a, &mut bufs_a, "a", 1, 1);
+  let (ml_a, run_a) = node_with_opts(
+    stack_a,
+    &mut bufs_a,
+    "a",
+    1,
+    1,
+    Options::new().with_close_timeout(FAST_CLOSE_TIMEOUT),
+  );
   let (_ml_b, run_b) = node(stack_b, &mut bufs_b, "b", 2, 2);
 
   let free_at_start = ml_a.pool_free_count();
@@ -300,38 +321,128 @@ fn pool_does_not_wedge_under_dial_abort_churn() {
 
   block_on(async {
     let op = async {
-      // Hammer the pool: many waves of dead dials, each exhausting and recycling the
-      // dial sockets. The listener must also self-heal across the churn.
-      for wave in 0..8u8 {
+      // Hammer the pool: many waves of dead on-link dials, each exhausting and
+      // recycling the dial sockets. The listener must also self-heal across the churn.
+      for wave in 0..6u8 {
         churn_join(&ml_a, &[dead(100 + wave), dead(120 + wave)]).await;
         // Let the dead bridges elapse and their slots reap before the next wave.
         Timer::after(Duration::from_millis(120)).await;
       }
-      // After the churn quiesces, every dial slot must be accounted for — free or
-      // visibly retiring, none leaked — and the listener must still be present
-      // (self-healed). A dial still mid-flight (in a Dialing connection) leaves the
-      // accounted total transiently below construction, so wait for it to settle.
+      // After the churn quiesces every dial slot must return to the free-list — none
+      // left pinned in `retiring` — and the listener must still be present
+      // (self-healed). A dial still mid-flight (a Dialing connection) or a teardown
+      // still draining leaves the pool transiently short, so wait for it to settle.
       until(|| {
-        ml_a.pool_free_count() + ml_a.retiring_count() >= free_at_start && ml_a.listener_present()
+        ml_a.pool_free_count() >= free_at_start
+          && ml_a.retiring_count() == 0
+          && ml_a.listener_present()
       })
       .await;
       (
         ml_a.pool_free_count(),
         ml_a.retiring_count(),
+        ml_a.teardown_overruns(),
         ml_a.listener_present(),
       )
     };
-    let (free, retiring, listener) = drive(op, run_a, run_b, &mut net_a, &mut net_b).await;
+    let (free, retiring, overruns, listener) =
+      drive(op, run_a, run_b, &mut net_a, &mut net_b).await;
     assert_eq!(
-      free + retiring,
-      free_at_start,
-      "the reliable pool leaked under dial/abort churn: only {free} free + {retiring} \
-       retiring of {free_at_start} dial slots are accounted for (a slot reused before \
-       its worker reset would appear in neither)"
+      free, free_at_start,
+      "the reliable pool did not fully recover after the dial/abort churn: {free} free \
+       of {free_at_start} dial slots (a slot reused before its worker reset, or an \
+       unbounded teardown flush pinning a dead on-link dial, would strand it)"
+    );
+    assert_eq!(
+      retiring, 0,
+      "a slot was left pinned in the retiring ledger after the churn quiesced ({retiring})"
+    );
+    assert_eq!(
+      overruns, 0,
+      "a teardown overran the engine's retiring deadline during the churn ({overruns})"
     );
     assert!(
       listener,
       "the listener was not re-established after the churn"
+    );
+  });
+}
+
+/// A pre-trust peer that floods dials at DEAD on-link addresses (ARP never resolves,
+/// so neither the SYN nor the teardown RST can egress) must not be able to
+/// PERMANENTLY pin the reliable pool. Each such dial stalls in SYN-sent, the exchange
+/// elapses at `stream_timeout`, and the engine aborts + retires the slot — but the
+/// worker's teardown flush, which would otherwise wait for an RST that never egresses,
+/// is bounded by a dedicated timer (`close_timeout / 2`). So every touched slot LEAVES
+/// the retiring ledger within that bound, the free pool is restored, and — because the
+/// bound is strictly below the engine's retiring deadline — no teardown overruns it
+/// (`teardown_overruns == 0`). Without the bound each dead dial pins its slot forever
+/// and the pool is exhausted after `POOL` dials — an unbounded remote slot-exhaustion
+/// DoS — and this test hangs to the wall-clock cap.
+#[test]
+fn dead_on_link_dial_flood_recovers_every_slot() {
+  let (dev_a, dev_b) = pair();
+  let mut res_a = StackResources::<{ POOL + 2 }>::new();
+  let mut res_b = StackResources::<{ POOL + 2 }>::new();
+  let (stack_a, mut net_a) = build_stack(dev_a, &mut res_a, 1, 0x1111_2222);
+  let (stack_b, mut net_b) = build_stack(dev_b, &mut res_b, 2, 0x3333_4444);
+
+  let mut bufs_a = NodeBufs::new();
+  let mut bufs_b = NodeBufs::new();
+  let (ml_a, run_a) = node_with_opts(
+    stack_a,
+    &mut bufs_a,
+    "a",
+    1,
+    1,
+    Options::new().with_close_timeout(FAST_CLOSE_TIMEOUT),
+  );
+  let (_ml_b, run_b) = node(stack_b, &mut bufs_b, "b", 2, 2);
+
+  let free_at_start = ml_a.pool_free_count();
+  assert!(
+    free_at_start >= 1,
+    "expected a non-empty pool at construction"
+  );
+
+  block_on(async {
+    let op = async {
+      // Saturate EVERY dial slot with dead on-link targets, then require the whole pool
+      // to recover before the next wave — so each wave proves every dial slot both took
+      // a dead teardown AND left the retiring ledger within the teardown bound.
+      for wave in 0..4u8 {
+        churn_join(
+          &ml_a,
+          &[dead(140 + wave), dead(150 + wave), dead(160 + wave)],
+        )
+        .await;
+        until(|| ml_a.pool_free_count() >= free_at_start && ml_a.retiring_count() == 0).await;
+        assert_eq!(
+          ml_a.teardown_overruns(),
+          0,
+          "a teardown overran the engine's retiring deadline during wave {wave}"
+        );
+      }
+      (
+        ml_a.pool_free_count(),
+        ml_a.retiring_count(),
+        ml_a.teardown_overruns(),
+      )
+    };
+    let (free, retiring, overruns) = drive(op, run_a, run_b, &mut net_a, &mut net_b).await;
+    assert_eq!(
+      free, free_at_start,
+      "the reliable pool did not fully recover after the dead on-link dial flood: \
+       {free} free of {free_at_start} (an unbounded teardown flush pins each dead \
+       dial's slot forever)"
+    );
+    assert_eq!(
+      retiring, 0,
+      "a slot was left pinned in the retiring ledger after the flood ({retiring})"
+    );
+    assert_eq!(
+      overruns, 0,
+      "a teardown overran the engine's retiring deadline during the flood ({overruns})"
     );
   });
 }

--- a/memberlist-embassy/tests/lifecycle.rs
+++ b/memberlist-embassy/tests/lifecycle.rs
@@ -48,6 +48,22 @@ fn dead(last: u8) -> SocketAddr {
   SocketAddr::new(IpAddr::V4(Ipv4Addr::new(169, 254, 1, last)), 7946)
 }
 
+/// A pseudo-random, incompressible payload of `n` bytes (xorshift64), so the
+/// framed reliable message is not shrunk below the peer's receive window by the
+/// compression transform — the worker's established send is forced to stall
+/// against a non-draining peer.
+fn incompressible(n: usize) -> bytes::Bytes {
+  let mut x: u64 = 0x9E37_79B9_7F4A_7C15;
+  let mut v = Vec::with_capacity(n);
+  for _ in 0..n {
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    v.push(x as u8);
+  }
+  bytes::Bytes::from(v)
+}
+
 /// All the owned buffers one node's sockets borrow. Declared in the test frame so
 /// the sockets (and the `Memberlist`/`Runner` that hold them) can borrow them for
 /// the whole `block_on`.
@@ -382,6 +398,83 @@ fn silent_peer_does_not_wedge_the_pool() {
   });
 }
 
+/// An engine `Abort` must PREEMPT an in-flight ESTABLISHED send. A raw, non-reading
+/// peer accepts A's reliable dial and then never drains: its receive window closes
+/// while its stack keeps ACKing, so A's worker parks in an established `write`/`flush`
+/// with the socket still "active" (the inactivity timeout is refreshed indefinitely).
+/// When the exchange elapses at `stream_timeout` (300 ms) the engine posts `Abort`;
+/// the worker must PREEMPT the parked send on that wake, reset the socket, and free
+/// the slot — so the send resolves as an error and the pool recovers.
+///
+/// This is the load-bearing regression: before the fix the worker awaited the send
+/// DIRECTLY (unraced), so a posted `Abort` was not observed until the far longer
+/// per-socket inactivity timeout (15 s) — which exceeds this test's 5 s budget, so a
+/// regression HANGS to the timeout rather than freeing the slot. Racing each
+/// peer-dependent send against the command wake is what bounds it to one wake.
+#[test]
+fn abort_preempts_a_stalled_established_send() {
+  let (dev_a, dev_b) = pair();
+  let mut res_a = StackResources::<{ POOL + 2 }>::new();
+  let mut res_b = StackResources::<{ POOL + 2 }>::new();
+  let (stack_a, mut net_a) = build_stack(dev_a, &mut res_a, 1, 0x1111_2222);
+  let (stack_b, mut net_b) = build_stack(dev_b, &mut res_b, 2, 0x3333_4444);
+
+  let mut bufs_a = NodeBufs::new();
+  let (ml_a, run_a) = node(stack_a, &mut bufs_a, "a", 1, 1);
+
+  // A deliberately-small receive buffer for the non-reading peer: it fills fast (the
+  // peer never reads), shutting the window so A's established send stalls well before
+  // the payload drains.
+  let mut peer_rx = [0u8; 512];
+  let mut peer_tx = [0u8; 512];
+
+  let free_a_at_start = ml_a.pool_free_count();
+  block_on(async {
+    // The non-reading peer: accept A's dial, then hold the socket open forever without
+    // EVER reading. Its stack keeps ACKing (so A's socket stays active), but the
+    // receive window stays shut — A's worker parks in the established send.
+    let peer = async {
+      let mut sock = TcpSocket::new(stack_b, &mut peer_rx, &mut peer_tx);
+      sock
+        .accept(7946)
+        .await
+        .expect("the raw peer accepts A's dial");
+      core::future::pending::<()>().await;
+    };
+
+    let op = async {
+      // Let the raw peer reach its `accept` before A dials it.
+      Timer::after(Duration::from_millis(50)).await;
+      // A large, incompressible payload guarantees the framed request exceeds the
+      // peer's shut window, so the worker stalls in the WRITE/FLUSH (not merely the
+      // reply read). The send must resolve as an error once the abort preempts it.
+      let r = ml_a
+        .send_reliable(addr(2, 7946), incompressible(16 * 1024))
+        .await;
+      assert!(
+        r.is_err(),
+        "a send to a non-draining peer must fail once the abort preempts it, not hang"
+      );
+      // The preempted slot resets and returns to the pool.
+      until(|| ml_a.pool_free_count() >= free_a_at_start).await;
+      ml_a.pool_free_count()
+    };
+
+    // Drive A's memberlist, both stacks, and the raw peer, raced against the op and
+    // the wall-clock cap. (A bespoke drive: the peer is a raw socket, not a second
+    // memberlist node, so the shared `drive` helper does not fit.)
+    let infra = select(select(net_a.run(), net_b.run()), select(run_a.run(), peer));
+    let free = match select(op, select(infra, Timer::after(TEST_TIMEOUT))).await {
+      Either::First(v) => v,
+      Either::Second(_) => panic!("abort_preempts_a_stalled_established_send timed out"),
+    };
+    assert_eq!(
+      free, free_a_at_start,
+      "A's reliable pool did not recover after the stalled send was preempted"
+    );
+  });
+}
+
 /// A peer RESET mid reliable-send must NOT be reported as a successful completion.
 /// The worker maps a `read()` error (a RST) to `open = false` WITHOUT latching
 /// `peer_fin`, so `recv_finished` never reports a clean EOF for the reset — the
@@ -420,6 +513,92 @@ fn peer_reset_is_not_reported_as_send_success() {
       result.is_err(),
       "a reliable send whose connection never completed (reset / vanished peer) \
        must resolve as a FAILURE, not a false success: {result:?}"
+    );
+  });
+}
+
+/// Distinct reliable-plane terminal paths each return their slot to the pool exactly
+/// once. A graceful CLOSE (a completed exchange to a live peer) and a dial FAILURE (a
+/// routable peer with no listener RSTs the SYN, so the slot resets cleanly), driven
+/// repeatedly and interleaved, must each terminalize without leaking a slot (the free
+/// count would stay BELOW construction) and without double-freeing one (it would rise
+/// ABOVE construction). So the pool must recover to EXACTLY its construction count
+/// after every permutation, and the node stays healthy (its listener self-heals,
+/// membership holds) throughout.
+#[test]
+fn every_connect_close_abort_permutation_terminalizes() {
+  let (dev_a, dev_b) = pair();
+  let mut res_a = StackResources::<{ POOL + 2 }>::new();
+  let mut res_b = StackResources::<{ POOL + 2 }>::new();
+  let (stack_a, mut net_a) = build_stack(dev_a, &mut res_a, 1, 0x1111_2222);
+  let (stack_b, mut net_b) = build_stack(dev_b, &mut res_b, 2, 0x3333_4444);
+
+  let mut bufs_a = NodeBufs::new();
+  let mut bufs_b = NodeBufs::new();
+  let (ml_a, run_a) = node(stack_a, &mut bufs_a, "a", 1, 1);
+  let (ml_b, run_b) = node(stack_b, &mut bufs_b, "b", 2, 2);
+
+  let free_at_start = ml_a.pool_free_count();
+  block_on(async {
+    let op = async {
+      ml_b
+        .join(
+          &SocketAddrResolver,
+          &[MaybeResolved::Resolved(addr(1, 7946))],
+        )
+        .await
+        .expect("join from a running node");
+      until(|| ml_a.num_members() == 2 && ml_b.num_members() == 2).await;
+
+      for i in 0..3u8 {
+        // CONNECT → graceful CLOSE: a live exchange completes and its slot reaps.
+        ml_a
+          .send_reliable(addr(2, 7946), bytes::Bytes::from_static(b"alive"))
+          .await
+          .expect("a reliable send to a live peer completes");
+        until(|| ml_a.pool_free_count() >= free_at_start).await;
+        assert_eq!(
+          ml_a.pool_free_count(),
+          free_at_start,
+          "a graceful close neither leaked nor double-freed its slot (i={i})"
+        );
+
+        // CONNECT → dial FAILURE: a dial to a routable peer with no listener on the
+        // port is RST'd, so the dial fails fast and its slot resets CLEANLY (the RST
+        // egresses — B answers ARP — unlike an on-link black hole that pins teardown).
+        assert!(
+          ml_a
+            .send_reliable(
+              addr(2, 9000 + u16::from(i)),
+              bytes::Bytes::from_static(b"nobody")
+            )
+            .await
+            .is_err(),
+          "a reliable send to a routable peer with no listener must fail (i={i})"
+        );
+        until(|| ml_a.pool_free_count() >= free_at_start).await;
+        assert_eq!(
+          ml_a.pool_free_count(),
+          free_at_start,
+          "a dial abort neither leaked nor double-freed its slot (i={i})"
+        );
+      }
+
+      (
+        ml_a.pool_free_count(),
+        ml_a.num_members(),
+        ml_a.listener_present(),
+      )
+    };
+    let (free, members, listener) = drive(op, run_a, run_b, &mut net_a, &mut net_b).await;
+    assert_eq!(
+      free, free_at_start,
+      "the pool did not fully recover after the connect/close/abort permutations"
+    );
+    assert_eq!(members, 2, "membership must hold across the permutations");
+    assert!(
+      listener,
+      "the listener must stay present across the permutations"
     );
   });
 }

--- a/memberlist-embassy/tests/lifecycle.rs
+++ b/memberlist-embassy/tests/lifecycle.rs
@@ -18,7 +18,7 @@ use embassy_net::{
   tcp::TcpSocket,
   udp::{PacketMetadata, UdpSocket},
 };
-use embassy_time::{Duration, Timer};
+use embassy_time::{Duration, Instant, Timer};
 use futures::executor::block_on;
 use memberlist_embassy::{
   AddressResolver, EndpointOptions, InitError, MaybeResolved, Memberlist, Options, Runner,
@@ -582,6 +582,148 @@ fn abort_preempts_a_stalled_established_send() {
     assert_eq!(
       free, free_a_at_start,
       "A's reliable pool did not recover after the stalled send was preempted"
+    );
+  });
+}
+
+/// An ESTABLISHED abort whose RST cannot egress must recover the slot within ONE
+/// teardown budget (`close_timeout / 2`), never two. The worker bounds the teardown
+/// RST-egress flush exactly ONCE, in `reset_socket`; the established `Command::Abort`
+/// arm therefore `abort()`s WITHOUT its own drain and relies on the caller's single
+/// `reset_socket` drain. Were the abort arm to drain too, a non-egressing RST would
+/// wait a full `close_timeout` (two `close_timeout / 2` bounds back to back) before the
+/// slot resets — which the engine's retiring deadline (`now + close_timeout`, evaluated
+/// on the pump BEFORE the workers) beats, ticking `teardown_overruns`.
+///
+/// A raw peer accepts A's reliable dial and never reads, so A's worker parks in an
+/// established send with the peer's window shut. Once established, A's FRAMING gate is
+/// closed (the device's `transmit` returns `None`), so the abort's RST — issued when
+/// the exchange elapses at `stream_timeout` and the engine posts `Abort` — cannot be
+/// framed and the teardown flush stalls, forcing the worker onto its dedicated teardown
+/// timer (the real-world analog is an established peer whose neighbor entry has expired
+/// and is now unreachable, so the RST cannot be framed). With the single drain the slot
+/// frees within `close_timeout / 2` and no teardown overruns; a second drain in the
+/// abort arm would double that to a full `close_timeout` and overrun the deadline.
+///
+/// This is the load-bearing regression for the single-drain invariant: it requires a
+/// NON-egressing established-abort RST, which the `tx_gate` (deliver-then-drop, so
+/// smoltcp counts the frame sent and the flush resolves) cannot produce — only the
+/// `frame_gate` (a `None` transmit, so the frame stays pending and the flush stalls)
+/// exposes the doubled budget.
+#[test]
+fn established_abort_with_non_egressing_rst_recovers() {
+  let (dev_a, dev_b) = pair();
+  // A cannot frame the abort's RST once this gate is closed (closed after the
+  // connection establishes, so only the teardown RST — not the handshake — is stalled).
+  let a_frame = dev_a.frame_gate();
+  let mut res_a = StackResources::<{ POOL + 2 }>::new();
+  let mut res_b = StackResources::<{ POOL + 2 }>::new();
+  let (stack_a, mut net_a) = build_stack(dev_a, &mut res_a, 1, 0x1111_2222);
+  let (stack_b, mut net_b) = build_stack(dev_b, &mut res_b, 2, 0x3333_4444);
+
+  let mut bufs_a = NodeBufs::new();
+  // A short close-timeout keeps the teardown bound (`close_timeout / 2`) well within
+  // the test budget while still strictly below the engine's retiring deadline.
+  let (ml_a, run_a) = node_with_opts(
+    stack_a,
+    &mut bufs_a,
+    "a",
+    1,
+    1,
+    Options::new().with_close_timeout(FAST_CLOSE_TIMEOUT),
+  );
+
+  // A deliberately-small receive buffer for the non-reading peer: it fills fast so A's
+  // established send stalls (window shut) well before the payload drains, keeping the
+  // exchange open until it elapses at `stream_timeout` and the engine aborts it.
+  let mut peer_rx = [0u8; 512];
+  let mut peer_tx = [0u8; 512];
+
+  let free_a_at_start = ml_a.pool_free_count();
+  block_on(async {
+    // The non-reading peer: accept A's dial, then hold the socket open forever without
+    // ever reading, so A's worker parks in the established send.
+    let peer = async {
+      let mut sock = TcpSocket::new(stack_b, &mut peer_rx, &mut peer_tx);
+      sock
+        .accept(7946)
+        .await
+        .expect("the raw peer accepts A's dial");
+      core::future::pending::<()>().await;
+    };
+
+    let op = async {
+      // Let the raw peer reach its `accept` before A dials it.
+      Timer::after(Duration::from_millis(50)).await;
+
+      // Close A's framing gate AFTER the (sub-millisecond, local) handshake has
+      // established the connection but BEFORE the exchange elapses at `stream_timeout`
+      // (300 ms) and the engine posts `Abort` — so the abort's RST cannot be framed and
+      // its teardown flush must fall back on the worker's dedicated teardown timer.
+      let gate = async {
+        Timer::after(Duration::from_millis(120)).await;
+        a_frame.set(false);
+        core::future::pending::<()>().await
+      };
+      // A large, incompressible payload guarantees the framed request exceeds the peer's
+      // shut window, so the worker is parked in the established send when the abort
+      // arrives — it hits the `Command::Abort` arm, the single-drain site under test.
+      let send = ml_a.send_reliable(addr(2, 7946), incompressible(16 * 1024));
+      let r = match select(send, gate).await {
+        Either::First(r) => r,
+        Either::Second(()) => unreachable!("the framing-gate future never resolves"),
+      };
+      assert!(
+        r.is_err(),
+        "a send to a non-draining peer must fail once the abort preempts it, not hang"
+      );
+
+      // The abort has been issued (the send resolved at the exchange deadline). Time the
+      // slot's recovery from here: a SINGLE teardown drain frees it within one budget
+      // (`close_timeout / 2`); a double drain would take a full `close_timeout`.
+      let aborted_at = Instant::now();
+      until(|| ml_a.pool_free_count() >= free_a_at_start && ml_a.retiring_count() == 0).await;
+      (
+        aborted_at.elapsed(),
+        ml_a.pool_free_count(),
+        ml_a.retiring_count(),
+        ml_a.teardown_overruns(),
+      )
+    };
+
+    // A bespoke drive: the peer is a raw socket, not a second memberlist node, so the
+    // shared `drive` helper does not fit.
+    let infra = select(select(net_a.run(), net_b.run()), select(run_a.run(), peer));
+    let (recovery, free, retiring, overruns) =
+      match select(op, select(infra, Timer::after(TEST_TIMEOUT))).await {
+        Either::First(v) => v,
+        Either::Second(_) => {
+          panic!("established_abort_with_non_egressing_rst_recovers timed out")
+        }
+      };
+    assert_eq!(
+      free, free_a_at_start,
+      "A's reliable pool did not recover after the established abort ({free} of \
+       {free_a_at_start})"
+    );
+    assert_eq!(
+      retiring, 0,
+      "a slot was left pinned in the retiring ledger after the established abort \
+       ({retiring})"
+    );
+    assert_eq!(
+      overruns, 0,
+      "the established abort's teardown overran the engine's retiring deadline \
+       ({overruns}) — a second drain in the abort arm doubles the teardown budget"
+    );
+    // One teardown budget is `close_timeout / 2` (250 ms); allow scheduling and the
+    // 10 ms recovery-poll granularity, but stay well below a full `close_timeout`
+    // (500 ms) so a double-drain regression (which needs the full close_timeout) also
+    // fails this bound, not only the overrun assertion above.
+    assert!(
+      recovery < Duration::from_millis(400),
+      "the slot took {recovery:?} to recover — beyond one teardown budget; a double \
+       drain of the non-egressing RST would take a full close_timeout"
     );
   });
 }

--- a/memberlist-embassy/tests/support/paired_device.rs
+++ b/memberlist-embassy/tests/support/paired_device.rs
@@ -48,6 +48,18 @@ pub struct PairedDevice {
   /// test closes this via [`PairedDevice::tx_gate`] to exercise a worker's socket
   /// inactivity timeout.
   tx_open: Rc<Cell<bool>>,
+  /// When `false`, this device cannot ORIGINATE a transmit at all: `transmit`
+  /// returns `None`, so smoltcp holds every queued packet (a SYN, an ACK, or a
+  /// teardown RST) PENDING instead of emitting it, and a socket `flush` STALLS.
+  /// This differs from `tx_open`, which delivers-then-drops INSIDE `consume` — there
+  /// smoltcp still counts the frame sent, so a `flush` resolves. A closed
+  /// `frame_open` models an interface that cannot frame an outbound packet (e.g. an
+  /// ARP-unresolvable next hop), the exact condition a worker's bounded teardown
+  /// drain exists to cap. embassy-net treats the `None` as tx-exhaustion and parks
+  /// (it does not busy-poll — see its `!tx_exhausted` poll guard). A test closes this
+  /// via [`PairedDevice::frame_gate`] to make an ESTABLISHED abort's RST
+  /// non-egressing.
+  frame_open: Rc<Cell<bool>>,
   mac: [u8; 6],
 }
 
@@ -67,6 +79,7 @@ pub fn pair() -> (PairedDevice, PairedDevice) {
       my_waker: waker_a.clone(),
       peer_waker: waker_b.clone(),
       tx_open: Rc::new(Cell::new(true)),
+      frame_open: Rc::new(Cell::new(true)),
       mac: [0x02, 0, 0, 0, 0, 1],
     },
     PairedDevice {
@@ -75,6 +88,7 @@ pub fn pair() -> (PairedDevice, PairedDevice) {
       my_waker: waker_b,
       peer_waker: waker_a,
       tx_open: Rc::new(Cell::new(true)),
+      frame_open: Rc::new(Cell::new(true)),
       mac: [0x02, 0, 0, 0, 0, 2],
     },
   )
@@ -92,6 +106,18 @@ impl PairedDevice {
   /// stops ACKing) — letting a test exercise a worker's socket inactivity timeout.
   pub fn tx_gate(&self) -> Rc<Cell<bool>> {
     self.tx_open.clone()
+  }
+
+  /// A handle to this device's framing gate. Setting it to `false` makes every
+  /// subsequent `transmit` return `None`, so smoltcp cannot emit a queued packet
+  /// (including a teardown RST): the packet stays PENDING and a socket `flush`
+  /// STALLS, modeling an interface that cannot frame an outbound frame. This is
+  /// distinct from [`PairedDevice::tx_gate`], which delivers-then-drops (smoltcp
+  /// still counts the frame sent, so a `flush` resolves). Used to make an
+  /// ESTABLISHED abort's RST non-egressing so a worker's bounded teardown drain is
+  /// exercised.
+  pub fn frame_gate(&self) -> Rc<Cell<bool>> {
+    self.frame_open.clone()
   }
 }
 
@@ -163,6 +189,13 @@ impl Driver for PairedDevice {
   }
 
   fn transmit(&mut self, _cx: &mut Context<'_>) -> Option<PairedTx> {
+    // A closed framing gate cannot originate a transmit: returning `None` makes
+    // smoltcp hold the queued packet PENDING (so a teardown RST cannot egress and a
+    // socket `flush` stalls), modeling an interface that cannot frame an outbound
+    // frame. embassy-net flags this as tx-exhaustion and parks rather than busy-poll.
+    if !self.frame_open.get() {
+      return None;
+    }
     Some(PairedTx {
       tx: self.tx.clone(),
       peer_waker: self.peer_waker.clone(),


### PR DESCRIPTION
X6 stage 3/4 — the `memberlist-embassy` per-slot worker redesign. Closes the two High remote-DoS findings on the embassy driver (#160 F1, F2) and hardens the reliable-plane teardown so no peer behavior can pin a pool slot. Stacked on #213 (X6 A: generation-tagged teardown protocol) and #214 (X6 B: engine policy), both in `main`.

## What changed

- **#160 F1 — abort-preemptive sends.** The three peer-dependent sends in `run_established` (the outbound write, its post-write flush, and the both-FIN'd final flush) now race the slot's command wake, so an engine `Abort` preempts a send stalled by a black-holed / zero-window peer instead of the worker parking forever. `cmd_wake` is multiplexed (real commands *and* benign new-outbound pulses), so `Either::Second` only re-checks the mailbox — never aborts directly — and because `select` polls the send first, a send making progress still completes.
- **#160 F2 — consume-by-compare.** The handshake/close command clears (`accept`-success, `dial`-success, the `Close` consume) clear the mailbox to `Idle` only if it still equals the directive the arm acted on, so an `Abort` posted while a handshake was completing survives for the next command match rather than being erased into an orphaned, engine-unreachable socket.
- **Bounded teardown.** Each teardown RST-egress flush is bounded by a dedicated timer (`teardown_timeout = close_timeout / 2`) with a local-forget on expiry. Without this, a dead on-link dial (ARP-unresolvable, so the RST can never be framed) left the flush pending forever — embassy-net keeps `flush()` pending while a `Closed` socket retains its remote tuple — and a pre-trust dead-dial flood could exhaust every dial slot permanently.
- **Single-drain teardown.** `reset_socket` is the sole bounded teardown drain, so every teardown path drains at most once. This keeps a non-egressing established abort strictly below the engine's retiring deadline (`close_timeout`), so `teardown_overruns` stays 0.

`teardown_timeout = close_timeout / 2` is derived strictly below the engine's first retiring deadline (`now + close_timeout`), so a slot's teardown is acknowledged before the ledger escalates. Reuse after an abandoned teardown is safe: smoltcp's `connect`/`listen` call `reset()` before establishing, clearing the stale tuple, tx buffer, and any queued RST.
