### PR TITLE
fix(embedded): inline read-capped gossip ingress with one real clock, all feeds before any sweep, and ring-capacity validation (#159 F4, #162 X1)

### DIFF
--- a/memberlist-embassy/src/error/mod.rs
+++ b/memberlist-embassy/src/error/mod.rs
@@ -29,6 +29,19 @@ pub enum InitError {
   /// drain, and a zero-byte outbound ring can never accept a byte from the
   /// engine to write — a silently-dead reliable plane. Both must be non-zero.
   ZeroBridgeRing,
+  /// The supplied gossip UDP socket's receive-packet capacity is not below the
+  /// engine's per-pump gossip read cap
+  /// ([`memberlist_embedded::GOSSIP_READ_CAP`]).
+  ///
+  /// The engine reads at most that many datagrams from this socket per pump and
+  /// applies every one of them at that pump's instant. A ring able to hold as many
+  /// as the cap or more leaves the excess sitting unread — so unobserved and
+  /// un-stamped — across the pump's membership sweep, to be applied only at a later
+  /// pump's instant. The bound is strict rather than inclusive because a ring
+  /// exactly at the cap that happens to be full is indistinguishable from an
+  /// over-cap one, and would cost one spurious re-pump. Size the socket's packet
+  /// metadata buffer below the cap; the capacity found is carried for diagnostics.
+  UdpRxCapacityTooLarge(usize),
   /// The per-socket inactivity timeout is out of the valid range.
   ///
   /// [`Options::socket_timeout`](crate::Options::socket_timeout), as embassy-net installs it
@@ -79,6 +92,13 @@ impl InitError {
   #[inline]
   pub const fn is_zero_bridge_ring(&self) -> bool {
     matches!(self, InitError::ZeroBridgeRing)
+  }
+
+  /// Whether the supplied gossip UDP socket could hold at least as many received
+  /// datagrams as the engine reads per pump.
+  #[inline]
+  pub const fn is_udp_rx_capacity_too_large(&self) -> bool {
+    matches!(self, InitError::UdpRxCapacityTooLarge(_))
   }
 
   /// Whether the per-socket inactivity timeout was out of range.
@@ -143,6 +163,12 @@ impl fmt::Display for InitError {
       InitError::ZeroBridgeRing => {
         f.write_str("tcp_socket_rx_bytes and tcp_socket_tx_bytes must both be non-zero")
       }
+      InitError::UdpRxCapacityTooLarge(n) => write!(
+        f,
+        "the gossip UDP socket holds {n} received datagrams, which must be below the \
+         engine's per-pump gossip read cap ({})",
+        memberlist_embedded::GOSSIP_READ_CAP
+      ),
       InitError::SocketTimeoutOutOfRange(s) => write!(
         f,
         "socket_timeout ({:?}), as installed into smoltcp (floored to whole microseconds \

--- a/memberlist-embassy/src/error/mod.rs
+++ b/memberlist-embassy/src/error/mod.rs
@@ -29,19 +29,6 @@ pub enum InitError {
   /// drain, and a zero-byte outbound ring can never accept a byte from the
   /// engine to write — a silently-dead reliable plane. Both must be non-zero.
   ZeroBridgeRing,
-  /// The supplied gossip UDP socket's receive-packet capacity is not below the
-  /// engine's per-pump gossip read cap
-  /// ([`memberlist_embedded::GOSSIP_READ_CAP`]).
-  ///
-  /// The engine reads at most that many datagrams from this socket per pump and
-  /// applies every one of them at that pump's instant. A ring able to hold as many
-  /// as the cap or more leaves the excess sitting unread — so unobserved and
-  /// un-stamped — across the pump's membership sweep, to be applied only at a later
-  /// pump's instant. The bound is strict rather than inclusive because a ring
-  /// exactly at the cap that happens to be full is indistinguishable from an
-  /// over-cap one, and would cost one spurious re-pump. Size the socket's packet
-  /// metadata buffer below the cap; the capacity found is carried for diagnostics.
-  UdpRxCapacityTooLarge(usize),
   /// The per-socket inactivity timeout is out of the valid range.
   ///
   /// [`Options::socket_timeout`](crate::Options::socket_timeout), as embassy-net installs it
@@ -60,8 +47,11 @@ pub enum InitError {
   /// The shared engine rejected the configuration (see
   /// [`memberlist_embedded::InitError`]): a zero/over-ceiling gossip MTU, a
   /// non-routable or port-mismatched advertise address, a zero port or
-  /// close-timeout, an unusable encryption keyring, or a machine-endpoint init
-  /// failure (including an entropy draw failure).
+  /// close-timeout, a gossip UDP socket whose receive-packet capacity reaches the
+  /// engine's per-pump gossip read cap
+  /// ([`GossipRecvCapacityTooLarge`](memberlist_embedded::InitError::GossipRecvCapacityTooLarge)),
+  /// an unusable encryption keyring, or a machine-endpoint init failure (including
+  /// an entropy draw failure).
   Engine(memberlist_embedded::InitError),
   /// The address resolver failed while resolving the advertise address.
   ///
@@ -92,13 +82,6 @@ impl InitError {
   #[inline]
   pub const fn is_zero_bridge_ring(&self) -> bool {
     matches!(self, InitError::ZeroBridgeRing)
-  }
-
-  /// Whether the supplied gossip UDP socket could hold at least as many received
-  /// datagrams as the engine reads per pump.
-  #[inline]
-  pub const fn is_udp_rx_capacity_too_large(&self) -> bool {
-    matches!(self, InitError::UdpRxCapacityTooLarge(_))
   }
 
   /// Whether the per-socket inactivity timeout was out of range.
@@ -163,12 +146,6 @@ impl fmt::Display for InitError {
       InitError::ZeroBridgeRing => {
         f.write_str("tcp_socket_rx_bytes and tcp_socket_tx_bytes must both be non-zero")
       }
-      InitError::UdpRxCapacityTooLarge(n) => write!(
-        f,
-        "the gossip UDP socket holds {n} received datagrams, which must be below the \
-         engine's per-pump gossip read cap ({})",
-        memberlist_embedded::GOSSIP_READ_CAP
-      ),
       InitError::SocketTimeoutOutOfRange(s) => write!(
         f,
         "socket_timeout ({:?}), as installed into smoltcp (floored to whole microseconds \

--- a/memberlist-embassy/src/error/tests.rs
+++ b/memberlist-embassy/src/error/tests.rs
@@ -29,6 +29,11 @@ fn init_error_variants_display_and_source() {
   assert!(zero_ring.source().is_none());
   assert!(zero_ring.is_zero_bridge_ring());
 
+  let udp_rx = InitError::UdpRxCapacityTooLarge(memberlist_embedded::GOSSIP_READ_CAP);
+  assert!(!udp_rx.to_string().is_empty());
+  assert!(udp_rx.source().is_none());
+  assert!(udp_rx.is_udp_rx_capacity_too_large());
+
   let out_of_range = InitError::SocketTimeoutOutOfRange(SocketTimeoutOutOfRange {
     socket_timeout: Duration::from_secs(1),
     close_timeout: Duration::from_secs(10),

--- a/memberlist-embassy/src/error/tests.rs
+++ b/memberlist-embassy/src/error/tests.rs
@@ -29,11 +29,6 @@ fn init_error_variants_display_and_source() {
   assert!(zero_ring.source().is_none());
   assert!(zero_ring.is_zero_bridge_ring());
 
-  let udp_rx = InitError::UdpRxCapacityTooLarge(memberlist_embedded::GOSSIP_READ_CAP);
-  assert!(!udp_rx.to_string().is_empty());
-  assert!(udp_rx.source().is_none());
-  assert!(udp_rx.is_udp_rx_capacity_too_large());
-
   let out_of_range = InitError::SocketTimeoutOutOfRange(SocketTimeoutOutOfRange {
     socket_timeout: Duration::from_secs(1),
     close_timeout: Duration::from_secs(10),

--- a/memberlist-embassy/src/gossip_io.rs
+++ b/memberlist-embassy/src/gossip_io.rs
@@ -62,4 +62,12 @@ impl GossipIo for EmbassyGossip<'_> {
     // datagram and SWIM recovers on the next gossip round — no error is surfaced.
     let _ = self.0.poll_send_to(bytes, IpEndpoint::from(dest), &mut cx);
   }
+
+  fn recv_capacity(&self) -> usize {
+    // The metadata-slot count of the receive buffer the caller supplied to
+    // `UdpSocket::new`: the number of datagrams embassy-net can leave queued for
+    // the next pump. Read from the socket itself so the declared capacity cannot
+    // drift from the buffer actually installed.
+    self.0.packet_recv_capacity()
+  }
 }

--- a/memberlist-embassy/src/lib.rs
+++ b/memberlist-embassy/src/lib.rs
@@ -52,8 +52,8 @@ pub use time::{EmbassyInstant, now};
 // types — and `ControlError`, the encryption key-rotation error — exist only
 // when their transform backend is built into this crate.
 pub use memberlist_embedded::{
-  AliveDelegate, MAX_RESOLVED_ADDRS_PER_SEED, MaybeOwned, MaybeResolved, MergeDelegate,
-  ResolvedAddrs, TransformOptions, transform::LabelError,
+  AliveDelegate, GOSSIP_READ_CAP, MAX_RESOLVED_ADDRS_PER_SEED, MaybeOwned, MaybeResolved,
+  MergeDelegate, ResolvedAddrs, TransformOptions, transform::LabelError,
 };
 // `ControlError` is the encryption key-rotation error; it exists in the shared
 // core only when an encryption backend is built in.

--- a/memberlist-embassy/src/memberlist/mod.rs
+++ b/memberlist-embassy/src/memberlist/mod.rs
@@ -30,6 +30,7 @@ use memberlist_proto::{
 use crate::{
   config::Options,
   error::{InitError, OpError, SocketTimeoutOutOfRange},
+  gossip_io::EmbassyGossip,
   mailbox::{Command, Mailbox},
   resolver::AddressResolver,
   runner::Runner,
@@ -200,9 +201,6 @@ where
   /// - [`InitError::ZeroBridgeRing`] — a zero
   ///   [`Options::tcp_socket_rx_bytes`](crate::Options::tcp_socket_rx_bytes) /
   ///   [`tcp_socket_tx_bytes`](crate::Options::tcp_socket_tx_bytes).
-  /// - [`InitError::UdpRxCapacityTooLarge`] — the supplied gossip UDP socket can
-  ///   hold at least as many received datagrams as the engine reads per pump
-  ///   ([`memberlist_embedded::GOSSIP_READ_CAP`]).
   /// - [`InitError::SocketTimeoutOutOfRange`] —
   ///   [`Options::socket_timeout`](crate::Options::socket_timeout), as embassy-net installs
   ///   it into smoltcp (floored to whole microseconds at the platform tick rate), is not
@@ -214,8 +212,10 @@ where
   ///   advertise address.
   /// - [`InitError::Engine`] — the shared engine rejected the configuration (zero
   ///   port / close-timeout, a non-routable or port-mismatched advertise address,
-  ///   an over-ceiling gossip MTU, an unusable encryption keyring, or a
-  ///   machine-endpoint init failure).
+  ///   an over-ceiling gossip MTU, a gossip UDP socket whose receive-packet
+  ///   capacity reaches the engine's per-pump gossip read cap
+  ///   ([`memberlist_embedded::GOSSIP_READ_CAP`]), an unusable encryption keyring,
+  ///   or a machine-endpoint init failure).
   /// - [`InitError::Entropy`] — the platform [`getrandom`] backend failed while
   ///   seeding the default gossip RNG.
   ///
@@ -282,9 +282,6 @@ where
   /// - [`InitError::ZeroBridgeRing`] — a zero
   ///   [`Options::tcp_socket_rx_bytes`](crate::Options::tcp_socket_rx_bytes) /
   ///   [`tcp_socket_tx_bytes`](crate::Options::tcp_socket_tx_bytes).
-  /// - [`InitError::UdpRxCapacityTooLarge`] — the supplied gossip UDP socket can
-  ///   hold at least as many received datagrams as the engine reads per pump
-  ///   ([`memberlist_embedded::GOSSIP_READ_CAP`]).
   /// - [`InitError::SocketTimeoutOutOfRange`] —
   ///   [`Options::socket_timeout`](crate::Options::socket_timeout), as embassy-net installs
   ///   it into smoltcp (floored to whole microseconds at the platform tick rate), is not
@@ -296,8 +293,10 @@ where
   ///   advertise address.
   /// - [`InitError::Engine`] — the shared engine rejected the configuration (zero
   ///   port / close-timeout, a non-routable or port-mismatched advertise address,
-  ///   an over-ceiling gossip MTU, an unusable encryption keyring, or a
-  ///   machine-endpoint init failure).
+  ///   an over-ceiling gossip MTU, a gossip UDP socket whose receive-packet
+  ///   capacity reaches the engine's per-pump gossip read cap
+  ///   ([`memberlist_embedded::GOSSIP_READ_CAP`]), an unusable encryption keyring,
+  ///   or a machine-endpoint init failure).
   ///
   /// # Panics
   ///
@@ -334,18 +333,6 @@ where
     }
     if cfg.tcp_socket_rx_bytes == 0 || cfg.tcp_socket_tx_bytes == 0 {
       return Err(InitError::ZeroBridgeRing);
-    }
-    // Keep the caller's gossip rx ring strictly below the engine's per-pump read
-    // cap. The engine reads at most `GOSSIP_READ_CAP` datagrams per pump and
-    // applies every one at that pump's instant; a socket that can hold as many or
-    // more would leave the excess unread across the pump's membership sweep, so a
-    // refutation already sitting in the ring could be applied only after the timer
-    // it refutes had fired. Strict, not inclusive: a ring exactly at the cap that
-    // happens to be full is indistinguishable from an over-cap one and costs a
-    // spurious re-pump.
-    let udp_rx_capacity = udp_socket.packet_recv_capacity();
-    if udp_rx_capacity >= memberlist_embedded::GOSSIP_READ_CAP {
-      return Err(InitError::UdpRxCapacityTooLarge(udp_rx_capacity));
     }
     // The per-socket inactivity timeout is a backstop that must fire strictly AFTER the
     // engine's own deadlines (the reliable-exchange `stream_timeout` and the
@@ -436,8 +423,15 @@ where
     // becomes a typed `InitError::Engine` rather than a panic. The caller-supplied
     // `rng` seeds the machine's gossip RNG: the integrator owns entropy here,
     // exactly as it owns the embassy-net stack's seed.
-    let mut engine: Engine<I, SlotId, R> =
-      Engine::try_new_at(embedded_cfg, transform, ep_cfg, now, rng).map_err(InitError::from)?;
+    let mut engine: Engine<I, SlotId, R> = {
+      // The engine screens the gossip receive ring against its per-pump read cap,
+      // so it is handed a view over the socket just bound — the same view the
+      // runner's pump loop builds each wake. The borrow ends here, before the
+      // socket is moved into the returned runner.
+      let gossip = EmbassyGossip::new(&udp_socket);
+      Engine::try_new_at(embedded_cfg, transform, ep_cfg, now, rng, &gossip)
+    }
+    .map_err(InitError::from)?;
 
     // Seed the engine's reliable-plane pool with every slot id, then dedicate slot
     // 0 to the listener. The engine owns this pool (it reaches it directly, not

--- a/memberlist-embassy/src/memberlist/mod.rs
+++ b/memberlist-embassy/src/memberlist/mod.rs
@@ -200,6 +200,9 @@ where
   /// - [`InitError::ZeroBridgeRing`] — a zero
   ///   [`Options::tcp_socket_rx_bytes`](crate::Options::tcp_socket_rx_bytes) /
   ///   [`tcp_socket_tx_bytes`](crate::Options::tcp_socket_tx_bytes).
+  /// - [`InitError::UdpRxCapacityTooLarge`] — the supplied gossip UDP socket can
+  ///   hold at least as many received datagrams as the engine reads per pump
+  ///   ([`memberlist_embedded::GOSSIP_READ_CAP`]).
   /// - [`InitError::SocketTimeoutOutOfRange`] —
   ///   [`Options::socket_timeout`](crate::Options::socket_timeout), as embassy-net installs
   ///   it into smoltcp (floored to whole microseconds at the platform tick rate), is not
@@ -279,6 +282,9 @@ where
   /// - [`InitError::ZeroBridgeRing`] — a zero
   ///   [`Options::tcp_socket_rx_bytes`](crate::Options::tcp_socket_rx_bytes) /
   ///   [`tcp_socket_tx_bytes`](crate::Options::tcp_socket_tx_bytes).
+  /// - [`InitError::UdpRxCapacityTooLarge`] — the supplied gossip UDP socket can
+  ///   hold at least as many received datagrams as the engine reads per pump
+  ///   ([`memberlist_embedded::GOSSIP_READ_CAP`]).
   /// - [`InitError::SocketTimeoutOutOfRange`] —
   ///   [`Options::socket_timeout`](crate::Options::socket_timeout), as embassy-net installs
   ///   it into smoltcp (floored to whole microseconds at the platform tick rate), is not
@@ -328,6 +334,18 @@ where
     }
     if cfg.tcp_socket_rx_bytes == 0 || cfg.tcp_socket_tx_bytes == 0 {
       return Err(InitError::ZeroBridgeRing);
+    }
+    // Keep the caller's gossip rx ring strictly below the engine's per-pump read
+    // cap. The engine reads at most `GOSSIP_READ_CAP` datagrams per pump and
+    // applies every one at that pump's instant; a socket that can hold as many or
+    // more would leave the excess unread across the pump's membership sweep, so a
+    // refutation already sitting in the ring could be applied only after the timer
+    // it refutes had fired. Strict, not inclusive: a ring exactly at the cap that
+    // happens to be full is indistinguishable from an over-cap one and costs a
+    // spurious re-pump.
+    let udp_rx_capacity = udp_socket.packet_recv_capacity();
+    if udp_rx_capacity >= memberlist_embedded::GOSSIP_READ_CAP {
+      return Err(InitError::UdpRxCapacityTooLarge(udp_rx_capacity));
     }
     // The per-socket inactivity timeout is a backstop that must fire strictly AFTER the
     // engine's own deadlines (the reliable-exchange `stream_timeout` and the

--- a/memberlist-embassy/src/shared/tests.rs
+++ b/memberlist-embassy/src/shared/tests.rs
@@ -1,12 +1,31 @@
 use super::{Shared, advertise_address, is_joined};
 use crate::{error::OpError, stream_io::SlotId};
 use core::{net::SocketAddr, time::Duration};
-use memberlist_embedded::{Engine, Options as EngineConfig, TransformOptions};
+use memberlist_embedded::{
+  Engine, GOSSIP_READ_CAP, GossipIo, Options as EngineConfig, TransformOptions,
+};
 use memberlist_proto::{EndpointOptions, Instant, SeedableRng, SmallRng, event::Event};
 use smol_str::SmolStr;
 
 fn sa(last: u8) -> SocketAddr {
   SocketAddr::from(([169, 254, 0, last], 7946))
+}
+
+/// A gossip view that carries no traffic: these tests exercise the waiter and
+/// event plumbing, never a pump. It exists so the engine constructor can screen a
+/// receive ring, and declares the largest conforming one.
+struct NoGossip;
+
+impl GossipIo for NoGossip {
+  fn recv(&mut self, _buf: &mut [u8]) -> Option<(SocketAddr, usize)> {
+    None
+  }
+
+  fn send(&mut self, _bytes: &[u8], _dest: SocketAddr) {}
+
+  fn recv_capacity(&self) -> usize {
+    GOSSIP_READ_CAP - 1
+  }
 }
 
 /// Build a single-node engine wrapped as `Shared` for the waiter/buffer tests.
@@ -18,6 +37,7 @@ fn shared_node(id: &str, last: u8) -> Shared<SmolStr> {
     EndpointOptions::new(SmolStr::new(id), sa(last)),
     now,
     SmallRng::seed_from_u64(7),
+    &NoGossip,
   );
   Shared::new(engine)
 }
@@ -36,6 +56,7 @@ fn out_of_order_reliable_completions_resolve_their_own_waiter() {
     EndpointOptions::new(SmolStr::new("t"), sa(1)),
     now,
     SmallRng::seed_from_u64(7),
+    &NoGossip,
   );
   let shared: Shared<SmolStr> = Shared::new(engine);
 

--- a/memberlist-embassy/tests/handle.rs
+++ b/memberlist-embassy/tests/handle.rs
@@ -155,13 +155,12 @@ async fn until(mut cond: impl FnMut() -> bool) {
   }
 }
 
-/// A gossip UDP socket that can hold at least as many received datagrams as the
-/// engine reads per pump is rejected at construction. The engine applies every
-/// datagram it pops within the pump that popped it, at most `GOSSIP_READ_CAP` of
-/// them, so a larger socket would leave the excess unread — unobserved and
-/// un-stamped — across the pump's membership sweep. The bound is strict: a socket
-/// sized exactly at the cap is rejected too (an exactly-full ring is
-/// indistinguishable from an over-cap one and costs a spurious re-pump), while the
+/// A gossip UDP socket whose receive-packet capacity reaches the engine's per-pump
+/// work ceiling is rejected at construction. The engine applies every datagram it
+/// pops within the pump that popped it, so the accepted socket capacity IS a
+/// pump's gossip work budget, and `GOSSIP_READ_CAP` is what bounds it. The bound is
+/// strict: a socket sized exactly at the cap is rejected too (a pump takes one
+/// probe pop past the ring's capacity to detect a mid-pump refill), while the
 /// 16-slot socket every other test here uses constructs.
 ///
 /// The rejection comes from the ENGINE, which screens the receive capacity the

--- a/memberlist-embassy/tests/handle.rs
+++ b/memberlist-embassy/tests/handle.rs
@@ -23,8 +23,8 @@ use embassy_net::{
 use embassy_time::{Duration, Timer};
 use futures::executor::block_on;
 use memberlist_embassy::{
-  CompressionOptions, EndpointOptions, MaybeResolved, Memberlist, Options, Runner,
-  SocketAddrResolver, TransformOptions, event::Event, now,
+  CompressionOptions, EndpointOptions, GOSSIP_READ_CAP, InitError, MaybeResolved, Memberlist,
+  Options, Runner, SocketAddrResolver, TransformOptions, event::Event, now,
 };
 use memberlist_proto::{SeedableRng, SmallRng, typed::State};
 use smol_str::SmolStr;
@@ -152,6 +152,80 @@ async fn until(mut cond: impl FnMut() -> bool) {
     }
     Timer::after(Duration::from_millis(10)).await;
   }
+}
+
+/// A gossip UDP socket that can hold at least as many received datagrams as the
+/// engine reads per pump is rejected at construction. The engine applies every
+/// datagram it pops within the pump that popped it, at most `GOSSIP_READ_CAP` of
+/// them, so a larger socket would leave the excess unread — unobserved and
+/// un-stamped — across the pump's membership sweep. The bound is strict: a socket
+/// sized exactly at the cap is rejected too (an exactly-full ring is
+/// indistinguishable from an over-cap one and costs a spurious re-pump), while the
+/// 16-slot socket every other test here uses constructs.
+#[test]
+fn udp_socket_at_or_above_the_gossip_read_cap_rejected() {
+  /// A receive-packet ring sized exactly at the engine's per-pump read cap.
+  struct OverCapBufs {
+    rx_meta: [PacketMetadata; GOSSIP_READ_CAP],
+    rx: [u8; 16 * 1024],
+    tx_meta: [PacketMetadata; 16],
+    tx: [u8; 16 * 1024],
+    tcp_rx: [[u8; TCP_BUF]; POOL],
+    tcp_tx: [[u8; TCP_BUF]; POOL],
+  }
+
+  let (dev, _peer) = pair();
+  let mut res = StackResources::<{ POOL + 2 }>::new();
+  let (stack, _net) = build_stack(dev, &mut res, 1, 0x3333_4444);
+
+  let mut over = OverCapBufs {
+    rx_meta: [PacketMetadata::EMPTY; GOSSIP_READ_CAP],
+    rx: [0u8; 16 * 1024],
+    tx_meta: [PacketMetadata::EMPTY; 16],
+    tx: [0u8; 16 * 1024],
+    tcp_rx: [[0u8; TCP_BUF]; POOL],
+    tcp_tx: [[0u8; TCP_BUF]; POOL],
+  };
+  let udp = UdpSocket::new(
+    stack,
+    &mut over.rx_meta,
+    &mut over.rx,
+    &mut over.tx_meta,
+    &mut over.tx,
+  );
+  let mut rx_iter = over.tcp_rx.iter_mut();
+  let mut tx_iter = over.tcp_tx.iter_mut();
+  let tcp = core::array::from_fn::<_, POOL, _>(|_| {
+    TcpSocket::new(
+      stack,
+      rx_iter.next().expect("POOL rx buffers"),
+      tx_iter.next().expect("POOL tx buffers"),
+    )
+  });
+  let rejected = block_on(Memberlist::<SmolStr, SocketAddr>::new_with_rng::<_, POOL>(
+    Options::new(),
+    TransformOptions::default(),
+    EndpointOptions::new(SmolStr::new("over"), addr(1, 7946)),
+    &SocketAddrResolver,
+    udp,
+    tcp,
+    now(),
+    SmallRng::seed_from_u64(1),
+  ));
+  match rejected.map(|_| ()) {
+    Err(InitError::UdpRxCapacityTooLarge(n)) => assert_eq!(
+      n, GOSSIP_READ_CAP,
+      "the rejection carries the socket's receive-packet capacity"
+    ),
+    Err(other) => {
+      panic!("a socket sized at the read cap must be rejected for its capacity, got {other}")
+    }
+    Ok(()) => panic!("a socket sized at the read cap must be rejected"),
+  }
+
+  // The 16-slot socket the rest of this suite uses is below the cap and builds.
+  let mut bufs = NodeBufs::new();
+  let (_ml, _run) = node(stack, &mut bufs, "under", 1, 2);
 }
 
 /// The sync query/accessor surface reports a coherent single-node view at

--- a/memberlist-embassy/tests/handle.rs
+++ b/memberlist-embassy/tests/handle.rs
@@ -26,6 +26,7 @@ use memberlist_embassy::{
   CompressionOptions, EndpointOptions, GOSSIP_READ_CAP, InitError, MaybeResolved, Memberlist,
   Options, Runner, SocketAddrResolver, TransformOptions, event::Event, now,
 };
+use memberlist_embedded::InitError as EngineInitError;
 use memberlist_proto::{SeedableRng, SmallRng, typed::State};
 use smol_str::SmolStr;
 
@@ -162,6 +163,10 @@ async fn until(mut cond: impl FnMut() -> bool) {
 /// sized exactly at the cap is rejected too (an exactly-full ring is
 /// indistinguishable from an over-cap one and costs a spurious re-pump), while the
 /// 16-slot socket every other test here uses constructs.
+///
+/// The rejection comes from the ENGINE, which screens the receive capacity the
+/// gossip view over this socket declares, and reaches the caller through this
+/// driver's `InitError::Engine`.
 #[test]
 fn udp_socket_at_or_above_the_gossip_read_cap_rejected() {
   /// A receive-packet ring sized exactly at the engine's per-pump read cap.
@@ -213,7 +218,7 @@ fn udp_socket_at_or_above_the_gossip_read_cap_rejected() {
     SmallRng::seed_from_u64(1),
   ));
   match rejected.map(|_| ()) {
-    Err(InitError::UdpRxCapacityTooLarge(n)) => assert_eq!(
+    Err(InitError::Engine(EngineInitError::GossipRecvCapacityTooLarge(n))) => assert_eq!(
       n, GOSSIP_READ_CAP,
       "the rejection carries the socket's receive-packet capacity"
     ),

--- a/memberlist-embedded/src/engine/mod.rs
+++ b/memberlist-embedded/src/engine/mod.rs
@@ -87,6 +87,32 @@ fn gossip_recv_buf_size(gossip_mtu: usize) -> usize {
   (gossip_mtu + ENCRYPTED_WRAPPER_OVERHEAD + CHECKSUMED_WRAPPER_OVERHEAD).max(1500)
 }
 
+/// The maximum number of gossip datagrams one [`Engine::pump`] reads from the
+/// driver's receive ring.
+///
+/// It is at the same time the per-pump DECODE bound: every datagram a pump pops
+/// is unwrapped, decoded and applied to the machine within that pump, at that
+/// pump's instant. No datagram is carried across a pump, so this one number
+/// bounds both the work and the transient memory a pump can spend on gossip
+/// ingress.
+///
+/// A driver's gossip receive ring must stay STRICTLY BELOW this cap (smoltcp
+/// defaults to 8 metadata slots, the in-repo embassy sockets to 16; both drivers
+/// reject a larger ring at construction). A ring able to hold as many datagrams
+/// as the cap or more leaves the excess sitting in the ring — unread, so
+/// unobserved and un-stamped — across this pump's membership sweep, to be applied
+/// only at a later pump's instant. Strictly below is required rather than equal
+/// because the engine cannot distinguish "the ring was exactly emptied" from
+/// "more remain" without peeking: a full ring of exactly `GOSSIP_READ_CAP`
+/// datagrams would report the cap as hit and cost one spurious re-pump.
+///
+/// The bound is a count, not a byte budget. The implied byte ceiling is
+/// `GOSSIP_READ_CAP × gossip_recv_buf_size(gossip_mtu)` — per-pump AEAD and
+/// decode work scales with bytes, so the count is a CPU ceiling only at the
+/// configured MTU. A byte dimension may join the count when the cap becomes a
+/// configurable knob.
+pub const GOSSIP_READ_CAP: usize = 64;
+
 /// Validate every construction-time config field that does NOT depend on the
 /// resolved advertise address.
 ///
@@ -320,6 +346,17 @@ pub struct Engine<I, C, R = SmallRng> {
   /// gates membership admission via the routable-address alive filter, which the
   /// constructor installs with this policy as its inner predicate.
   cidr_policy: CidrFilter,
+  /// Count of pumps that stopped reading gossip at [`GOSSIP_READ_CAP`] while the
+  /// node was running.
+  ///
+  /// Non-zero means the driver's receive ring holds more datagrams than the
+  /// engine applies per pump — a ring sized at or above the cap, or a caller
+  /// whose pump cadence cannot keep up with arrivals. The engine itself loses
+  /// nothing when it stops at the cap (the remainder stays in the driver's ring
+  /// and is read on the next pump, which the returned deadline asks for
+  /// immediately); the drop signal for a genuinely overrun ring lives at the
+  /// link-layer stack, which tail-drops on a full ring.
+  gossip_read_cap_hits: u64,
 }
 
 // Construction, config, accessors, and the membership-machine forwarders —
@@ -405,6 +442,18 @@ where
   #[inline]
   pub fn teardown_overruns(&self) -> u64 {
     self.plane.teardown_overruns
+  }
+
+  /// Diagnostic count of pumps that stopped reading gossip at
+  /// [`GOSSIP_READ_CAP`] while running.
+  ///
+  /// A non-zero value means the driver's gossip receive ring can hold more than
+  /// the engine applies per pump, or the caller's pump cadence is behind the
+  /// arrival rate. Both drivers reject an over-cap ring at construction, so on a
+  /// validated driver this stays zero.
+  #[inline]
+  pub fn gossip_read_cap_hits(&self) -> u64 {
+    self.gossip_read_cap_hits
   }
 
   /// Whether a passive-open listener slot is currently installed.
@@ -1224,6 +1273,7 @@ where
       last_completed_send: None,
       label,
       cidr_policy,
+      gossip_read_cap_hits: 0,
     })
   }
 
@@ -2145,19 +2195,38 @@ where
   ///    the pool.
   /// 1b. **Accept inbound** — if the listener completed a passive open, hand it
   ///    to the machine and replenish the listener from the pool.
-  /// 1c. **Rebalance** — self-heal a missing listener, then assign any remaining
-  ///    free slots to deferred dials (listener-first).
-  /// 2a/2b. **Gossip ingress** — drain received datagrams into `handle_gossip`,
-  ///    then decode buffered raw frames through the codec and feed typed messages
-  ///    back via `handle_packet`.
+  /// 2. **Gossip ingress** — pop up to [`GOSSIP_READ_CAP`] datagrams from the
+  ///    driver's receive ring, unwrapping, decoding and feeding each one's typed
+  ///    messages to `handle_packet` as it is popped.
   /// 3. **Reliable ingress pump** — drain each connection's rx into
   ///    `handle_transport_data`; deliver a one-shot EOF on peer FIN.
+  /// 1c. **Rebalance** — self-heal a missing listener, then assign any remaining
+  ///    free slots to deferred dials (listener-first).
   /// 5. **Join-seed drain** — `start_push_pull(seed, Join, now)` per queued seed.
   /// 6. **Machine tick** — `handle_timeout` fires due timers.
   /// 7a–7e. **Stream actions + egress** — drain `poll_action`, promote, pump
   ///    outbound, flush deferred FINs, complete `Closing` drains, re-rebalance,
   ///    then drain + send outbound gossip.
-  /// 8. **Deadline** — `min(machine_next, closing_next)`.
+  /// 8. **Deadline** — `min(machine_next, closing_next, gossip_read_capped)`.
+  ///
+  /// # Observation is the read
+  ///
+  /// Every gossip datagram this pump pops is applied at this pump's `now` before
+  /// any machine call that can run the membership sweep: 1a and 1b make no such
+  /// call, and 3, 1c, 5, 6 and 7 all follow phase 2. Every reliable byte read in
+  /// phase 3 is likewise fed before 1c, 5, 6 and 7. Nothing observed is carried
+  /// across a pump, so no timer can overtake evidence the engine holds, and the
+  /// machine sees one real instant per pump — the instant at which the engine
+  /// read what it feeds. Per-pump work is bounded by the driver's rings and by
+  /// [`GOSSIP_READ_CAP`]; a driver's gossip receive ring must stay below that cap
+  /// (both drivers validate it at construction).
+  ///
+  /// One same-instant ordering residual survives, on the reliable plane only:
+  /// within phase 3 an earlier connection's feed can run a transitive sweep before
+  /// a later connection's bytes — read at the same instant — are fed, so a
+  /// refutable deadline falling within the last pump interval can fire ahead of
+  /// the evidence that would have refuted it. It is pre-existing on main and in
+  /// the standard drivers, and closing it needs a non-ticking feed in the machine.
   pub fn pump<G, S>(&mut self, now: Instant, gossip: &mut G, stream: &mut S) -> Option<Instant>
   where
     G: GossipIo,
@@ -2179,6 +2248,10 @@ where
     //   1c. `rebalance_pool`  — self-heal a missing listener, then deferred dials
     //                           take any remaining slots (listener-first)
     //
+    // They are no longer adjacent: the two ingress feeds (phases 2 and 3) run
+    // between them, because `rebalance_pool` can sweep the machine and `1b`
+    // cannot. Their relative order — and with it listener priority — is unchanged.
+    //
     // 1b. Accept an inbound connection completed on the listener and replenish the
     // listener from the pool.
     //
@@ -2194,6 +2267,112 @@ where
     // Accept-and-replenish first claims it for the listener instead.
     self.check_listener(now, stream);
 
+    // 2. Gossip ingress: pop, decode and apply one datagram at a time, at most
+    // `GOSSIP_READ_CAP` of them.
+    //
+    // Observation is the read: a datagram enters the engine's view when this loop
+    // pops it, and it is applied to the machine at this pump's `now` — before any
+    // later phase can run the membership sweep. Nothing is queued for a later
+    // pump, so there is no held evidence for a timer to overtake and no reason for
+    // the machine to be handed anything but the real instant.
+    //
+    // The read is capped rather than run to exhaustion so one pump's work is
+    // bounded for ANY `GossipIo`, including one whose ring the link layer could
+    // refill while the loop runs. Datagrams beyond the cap stay in the driver's
+    // ring and are read on the next pump, which step 8 asks for immediately; on a
+    // ring sized below the cap the ring is always emptied and the cap never hit.
+    //
+    // The machine's own `handle_gossip` / `poll_memberlist_ingress` round-trip is
+    // deliberately bypassed: it would copy every datagram into a machine-side
+    // buffer for this same pump to poll straight back out. Feeding `handle_packet`
+    // directly is equivalent — it re-checks the running state itself, and the
+    // `last_now` anchor `handle_gossip` would have written is re-established by
+    // step 6's `handle_timeout(now)` on every pump.
+    //
+    // The lifecycle state is read once: only `leave` changes it, and `leave` is a
+    // between-pumps call.
+    let running = self.endpoint.is_running();
+    let mut popped = 0usize;
+    {
+      // The receive scratch, the machine endpoint, the cluster label and the CIDR
+      // policy are separate fields, so all four can be borrowed across the loop at
+      // once as disjoint field paths.
+      let buf = self.gossip_recv.as_mut_slice();
+      let endpoint = &mut self.endpoint;
+      let cidr_policy = &self.cidr_policy;
+      let label = &self.label;
+      while popped < GOSSIP_READ_CAP {
+        // The driver's datagram I/O pops one datagram per `recv` call and returns
+        // `None` once the rx ring is empty.
+        let Some((src, n)) = gossip.recv(buf) else {
+          break;
+        };
+        // Charge EVERY pop, whatever becomes of it: the cap bounds reads of the
+        // driver's ring, which is the resource an inbound flood drives.
+        popped += 1;
+        // Three reasons to drop a popped datagram without decoding it:
+        //
+        // - the node has left, so there is no membership left to update (the
+        //   machine's `handle_packet` re-checks this too; refusing here also
+        //   spares a post-leave flood every unwrap and decode);
+        // - a zero-length read, the driver's marker for a datagram too large for
+        //   this scratch buffer, which it consumed and skipped so one oversized
+        //   datagram cannot stall the in-budget ones queued behind it;
+        // - a CIDR-blocked source (the transport-source filter; the
+        //   advertised-address filter is the composed routable-address alive
+        //   delegate).
+        if !running || n == 0 || cidr_blocks(cidr_policy, src.ip()) {
+          continue;
+        }
+        // Strip the Encrypted-then-Checksumed-then-Compressed wrapper stack FIRST
+        // (each layer is identity when its wrapper is absent, so the plaintext path
+        // is preserved exactly). With an encryption backend the endpoint's
+        // keyring-aware unwrap also enforces the strict-mode entry check on an
+        // encrypted cluster; without one the base unwrap strips any checksum and
+        // compression wrappers (and is identity for a plain frame). A corrupt frame,
+        // an unknown or not-built-in algorithm, an oversized wrapper, or a checksum
+        // mismatch is an Err. Drop on Err — a plaintext datagram on an encrypted
+        // node, or a corrupt frame, must not reach the decoder. Gossip is lossy and
+        // self-healing.
+        #[cfg(encryption)]
+        let decrypted = match endpoint.decrypt_gossip(&buf[..n]) {
+          Ok(p) => bytes::Bytes::from(p),
+          Err(_) => continue,
+        };
+        #[cfg(not(encryption))]
+        let decrypted = match memberlist_proto::framing::unwrap_transforms(
+          &buf[..n],
+          endpoint.endpoint_ref().gossip_mtu(),
+        ) {
+          Ok(p) => bytes::Bytes::from(p.into_owned()),
+          Err(_) => continue,
+        };
+        let opts = memberlist_proto::codec::DecodeOptions::new(label.clone());
+        // Drop malformed inbound datagrams silently — bad network input must not
+        // panic the node; SWIM is self-healing. (`decode_incoming` Err = label
+        // mismatch / framing error; `parse_messages` Err = malformed frame.)
+        if let Ok(plain) = memberlist_proto::codec::decode_incoming(decrypted, &opts) {
+          if let Ok(msgs) = memberlist_proto::codec::parse_messages::<I, SocketAddr>(plain) {
+            for msg in msgs {
+              endpoint.handle_packet(src, msg, now);
+            }
+          }
+        }
+      }
+    }
+    // The loop stopped at the cap while running, so the ring may still hold
+    // datagrams: step 8 folds an already-due wake for them, and the hit is counted
+    // as the overload / misconfiguration signal.
+    let gossip_more = running && popped == GOSSIP_READ_CAP;
+    if gossip_more {
+      self.gossip_read_cap_hits += 1;
+    }
+
+    // 3. Reliable ingress pump: drain each active exchange's socket rx buffer into
+    // the machine. Must run before the machine tick so the machine sees fresh
+    // inbound bytes (including the peer-FIN EOF) when firing timers.
+    self.pump_inbound_reliable(now, stream);
+
     // 1c. Self-heal a still-missing listener, then assign any remaining free slots
     // to deferred dials (listener-first). This runs the SAME rebalance as the late
     // call after the in-tick frees below (step 7), here over whatever
@@ -2201,72 +2380,14 @@ where
     // (step 6) is required: a `PendingDial` deferred on a PRIOR tick must be
     // assigned a freed slot and dialed before step 6's `handle_timeout` could
     // elapse its bridge and tear it down — so the early site cannot move later.
+    // Running it AFTER both evidence feeds is required for the same reason in the
+    // other direction: a dial this call rejects synchronously (a CIDR-blocked or
+    // unroutable peer) terminalizes through the machine, whose tick would sweep
+    // membership at `now` — ahead of this pump's gossip and reliable evidence if it
+    // ran first. A prior-tick `PendingDial` parked here is unaffected by the two
+    // feeds: they mark only their own bridges dirty, and a parked dial's bridge has
+    // no residual work, so nothing between 1b and here can elapse it.
     self.rebalance_pool(now, stream);
-
-    // 2a. Drain inbound gossip datagrams into the machine's raw ingress buffer.
-    {
-      // The reusable receive scratch and the machine endpoint are separate fields,
-      // so both can be borrowed across the drain loop at once.
-      let buf = self.gossip_recv.as_mut_slice();
-      let endpoint = &mut self.endpoint;
-      let cidr_policy = &self.cidr_policy;
-      // The driver's datagram I/O pops one datagram per `recv` call and returns
-      // `None` once the rx ring is empty (an over-budget datagram larger than this
-      // buffer is consumed and skipped by the driver, so one oversized datagram
-      // cannot stall the in-budget datagrams queued behind it).
-      while let Some((src, n)) = gossip.recv(buf) {
-        // Drop a gossip datagram from a CIDR-blocked source before the machine
-        // sees it (the transport-source filter; the advertised-address filter is
-        // the composed routable-address alive delegate).
-        if !cidr_blocks(cidr_policy, src.ip()) {
-          endpoint.handle_gossip(src, &buf[..n], now);
-        }
-      }
-    }
-
-    // 2b. Unwrap the encryption/compression transforms, then decode each raw
-    // gossip frame and feed typed messages back.
-    while let Some((src, raw)) = self.endpoint.poll_memberlist_ingress() {
-      // Strip the Encrypted-then-Checksumed-then-Compressed wrapper stack FIRST
-      // (each layer is identity when its wrapper is absent, so the plaintext path
-      // is preserved exactly). With an encryption backend the endpoint's
-      // keyring-aware unwrap also enforces the strict-mode entry check on an
-      // encrypted cluster; without one the base unwrap strips any checksum and
-      // compression wrappers (and is identity for a plain frame). A corrupt frame,
-      // an unknown or not-built-in algorithm, an oversized wrapper, or a checksum
-      // mismatch is an Err. Drop on Err — a plaintext datagram on an encrypted
-      // node, or a corrupt frame, must not reach the decoder. Gossip is lossy and
-      // self-healing.
-      #[cfg(encryption)]
-      let decrypted = match self.endpoint.decrypt_gossip(&raw) {
-        Ok(p) => bytes::Bytes::from(p),
-        Err(_) => continue,
-      };
-      #[cfg(not(encryption))]
-      let decrypted = match memberlist_proto::framing::unwrap_transforms(
-        &raw,
-        self.endpoint.endpoint_ref().gossip_mtu(),
-      ) {
-        Ok(p) => bytes::Bytes::from(p.into_owned()),
-        Err(_) => continue,
-      };
-      let opts = memberlist_proto::codec::DecodeOptions::new(self.label.clone());
-      // Drop malformed inbound datagrams silently — bad network input must not
-      // panic the node; SWIM is self-healing. (`decode_incoming` Err = label
-      // mismatch / framing error; `parse_messages` Err = malformed frame.)
-      if let Ok(plain) = memberlist_proto::codec::decode_incoming(decrypted, &opts) {
-        if let Ok(msgs) = memberlist_proto::codec::parse_messages::<I, SocketAddr>(plain) {
-          for msg in msgs {
-            self.endpoint.handle_packet(src, msg, now);
-          }
-        }
-      }
-    }
-
-    // 3. Reliable ingress pump: drain each active exchange's socket rx buffer into
-    // the machine. Must run before the machine tick so the machine sees fresh
-    // inbound bytes (including the peer-FIN EOF) when firing timers.
-    self.pump_inbound_reliable(now, stream);
 
     // 5. Drain join seeds: each seed queued by `join()` gets a push/pull exchange
     // initiated now. `start_push_pull` internally calls `service_dials` +
@@ -2364,7 +2485,7 @@ where
     // 7e. Egress: drain outbound gossip transmits, encode, and send.
     self.drain_gossip_transmits(gossip);
 
-    // 8. Next deadline = min(machine, closing).
+    // 8. Next deadline = min(machine, closing, gossip-read-capped).
     //
     // The returned instant is the wake contract: a caller that sleeps until it
     // (combined with its own link-layer next-event deadline) must wake in time to
@@ -2385,6 +2506,13 @@ where
     //   Folding the soonest of BOTH in guarantees the caller wakes by
     //   `close_timeout` to escalate it, so pool / listener recovery is bounded by
     //   `Options::close_timeout` as documented.
+    // - the read-cap term — an already-due `now`, set only when phase 2 stopped
+    //   reading at `GOSSIP_READ_CAP` while running, so datagrams may still be
+    //   waiting in the driver's ring. It asks a deadline-driven caller to service
+    //   its other work and poll again at once rather than sleep on a timer while
+    //   observed traffic sits unread. A gossip ring sized below the cap never sets
+    //   it (the ring empties before the cap is reached), and a node that has left
+    //   never sets it (the term is gated on the running state).
     //
     // `pending_dial` deliberately contributes NO deadline of its own: a buffered
     // dial is serviced when a slot frees, never on a clock of its own, and every
@@ -2420,7 +2548,7 @@ where
       )
       .min()
       .copied();
-    min_opt(machine, closing)
+    min_opt(min_opt(machine, closing), gossip_more.then_some(now))
   }
 
   /// Open a TCP dial for the `Dialing` connection `eid` on its assigned slot `c`.

--- a/memberlist-embedded/src/engine/mod.rs
+++ b/memberlist-embedded/src/engine/mod.rs
@@ -97,14 +97,16 @@ fn gossip_recv_buf_size(gossip_mtu: usize) -> usize {
 /// ingress.
 ///
 /// A driver's gossip receive ring must stay STRICTLY BELOW this cap (smoltcp
-/// defaults to 8 metadata slots, the in-repo embassy sockets to 16; both drivers
-/// reject a larger ring at construction). A ring able to hold as many datagrams
-/// as the cap or more leaves the excess sitting in the ring — unread, so
-/// unobserved and un-stamped — across this pump's membership sweep, to be applied
-/// only at a later pump's instant. Strictly below is required rather than equal
-/// because the engine cannot distinguish "the ring was exactly emptied" from
-/// "more remain" without peeking: a full ring of exactly `GOSSIP_READ_CAP`
-/// datagrams would report the cap as hit and cost one spurious re-pump.
+/// defaults to 8 metadata slots, the in-repo embassy sockets to 16).
+/// [`Engine::try_new_at`] enforces it for every driver, by screening the
+/// [`GossipIo::recv_capacity`] the view it is handed declares. A ring able to
+/// hold as many datagrams as the cap or more leaves the excess sitting in the
+/// ring — unread, so unobserved and un-stamped — across this pump's membership
+/// sweep, to be applied only at a later pump's instant. Strictly below is
+/// required rather than equal because the engine cannot distinguish "the ring
+/// was exactly emptied" from "more remain" without peeking: a full ring of
+/// exactly `GOSSIP_READ_CAP` datagrams would report the cap as hit and cost one
+/// spurious re-pump.
 ///
 /// The bound is a count, not a byte budget. The implied byte ceiling is
 /// `GOSSIP_READ_CAP × gossip_recv_buf_size(gossip_mtu)` — per-pump AEAD and
@@ -1099,16 +1101,18 @@ where
   /// # Panics
   ///
   /// Panics if [`try_new_at`](Self::try_new_at) returns an [`InitError`] — e.g.
-  /// on a zero/over-ceiling gossip MTU, a non-routable or port-mismatched
-  /// advertise address, or a machine-endpoint init failure.
+  /// on a zero/over-ceiling gossip MTU, an over-cap gossip receive ring, a
+  /// non-routable or port-mismatched advertise address, or a machine-endpoint
+  /// init failure.
   pub fn new_at(
     cfg: Options,
     transform: TransformOptions,
     ep_cfg: EndpointOptions<I, SocketAddr>,
     now: Instant,
     rng: R,
+    gossip: &impl GossipIo,
   ) -> Self {
-    Self::try_new_at(cfg, transform, ep_cfg, now, rng)
+    Self::try_new_at(cfg, transform, ep_cfg, now, rng, gossip)
       .expect("Engine::new_at: invalid configuration; use try_new_at to handle")
   }
 
@@ -1130,6 +1134,17 @@ where
   ///   `Endpoint` so timers start from a consistent origin).
   /// - `rng`: the gossip RNG, already seeded by the driver from its entropy
   ///   source. The core performs no entropy acquisition of its own.
+  /// - `gossip`: the datagram view the driver will pump this engine with. It is
+  ///   only read here, for [`GossipIo::recv_capacity`]; no datagram is moved and
+  ///   the view is not retained (`pump` takes its own `&mut` view per call).
+  ///
+  /// # The gossip read-cap invariant
+  ///
+  /// This is the SINGLE enforcement point of the invariant `pump` phase 2 relies
+  /// on: the gossip receive ring must hold strictly fewer datagrams than
+  /// [`GOSSIP_READ_CAP`]. Taking the view here — rather than trusting each driver
+  /// to screen its own socket — is what binds every driver to it, including one
+  /// written outside this workspace.
   ///
   /// # Errors
   ///
@@ -1140,6 +1155,8 @@ where
   /// - [`InitError::ZeroCloseTimeout`] — `cfg.close_timeout` is zero.
   /// - [`InitError::GossipMtuTooLarge`] — the configured gossip MTU's on-wire
   ///   datagram cannot fit a UDP packet.
+  /// - [`InitError::GossipRecvCapacityTooLarge`] — `gossip` declares a receive
+  ///   ring that can hold at least [`GOSSIP_READ_CAP`] datagrams.
   /// - [`InitError::NonRoutableAdvertiseAddr`] — the advertise address is the
   ///   unspecified address, a multicast/broadcast IP, or port 0.
   /// - [`InitError::AdvertisePortMismatch`] — the advertised port differs from
@@ -1160,6 +1177,7 @@ where
     ep_cfg: EndpointOptions<I, SocketAddr>,
     now: Instant,
     rng: R,
+    gossip: &impl GossipIo,
   ) -> Result<Self, InitError> {
     // Validate every advertise-independent config field (port, gossip-MTU
     // ceiling, close timeout, and the encryption keyring) up front. Sharing this
@@ -1168,6 +1186,21 @@ where
     // binds any socket. The advertise-dependent checks (non-routable advertise,
     // port mismatch) remain below, where the resolved address is in hand.
     validate_runtime_config(&cfg, &transform, ep_cfg.gossip_mtu())?;
+
+    // Keep the driver's gossip rx ring strictly below this engine's per-pump read
+    // cap. Phase 2 pops at most `GOSSIP_READ_CAP` datagrams and applies every one
+    // of them at that pump's instant; a ring able to hold as many or more would
+    // leave the excess unread across the pump's membership sweep, so a refutation
+    // already sitting in the ring could be applied only after the timer it refutes
+    // had fired. Screening the view the driver hands over — not each driver's own
+    // socket knob — is what makes this hold for EVERY `GossipIo`, including one
+    // implemented outside this workspace. Strict, not inclusive: a ring exactly at
+    // the cap that happens to be full is indistinguishable from an over-cap one
+    // without peeking, so it would cost a spurious re-pump on every full read.
+    let recv_capacity = gossip.recv_capacity();
+    if recv_capacity >= GOSSIP_READ_CAP {
+      return Err(InitError::GossipRecvCapacityTooLarge(recv_capacity));
+    }
 
     // Size the inbound-gossip scratch from the configured gossip MTU BEFORE
     // `ep_cfg` is moved into `Endpoint::try_new_at`. The buffer must hold the
@@ -2218,8 +2251,9 @@ where
   /// across a pump, so no timer can overtake evidence the engine holds, and the
   /// machine sees one real instant per pump — the instant at which the engine
   /// read what it feeds. Per-pump work is bounded by the driver's rings and by
-  /// [`GOSSIP_READ_CAP`]; a driver's gossip receive ring must stay below that cap
-  /// (both drivers validate it at construction).
+  /// [`GOSSIP_READ_CAP`]; a driver's gossip receive ring must stay below that cap,
+  /// which [`try_new_at`](Self::try_new_at) enforces against the view's declared
+  /// [`GossipIo::recv_capacity`].
   ///
   /// One same-instant ordering residual survives, on the reliable plane only:
   /// within phase 3 an earlier connection's feed can run a transitive sweep before
@@ -2289,6 +2323,20 @@ where
     // `last_now` anchor `handle_gossip` would have written is re-established by
     // step 6's `handle_timeout(now)` on every pump.
     //
+    // The ring this pump reads must be the one construction screened. A driver
+    // that validated with one view and pumps with another (a different socket, a
+    // resized buffer) would silently reopen the cross-pump residency the cap
+    // exists to close, and only the driver can see that divergence — so assert it
+    // where the read happens. Debug-only: the constructor already rejected an
+    // over-cap ring, and release builds pay nothing.
+    debug_assert!(
+      gossip.recv_capacity() < GOSSIP_READ_CAP,
+      "the pumped gossip receive ring holds {} datagrams, at or above the per-pump read cap {}: \
+       construction screened a different view",
+      gossip.recv_capacity(),
+      GOSSIP_READ_CAP
+    );
+
     // The lifecycle state is read once: only `leave` changes it, and `leave` is a
     // between-pumps call.
     let running = self.endpoint.is_running();

--- a/memberlist-embedded/src/engine/mod.rs
+++ b/memberlist-embedded/src/engine/mod.rs
@@ -87,26 +87,31 @@ fn gossip_recv_buf_size(gossip_mtu: usize) -> usize {
   (gossip_mtu + ENCRYPTED_WRAPPER_OVERHEAD + CHECKSUMED_WRAPPER_OVERHEAD).max(1500)
 }
 
-/// The maximum number of gossip datagrams one [`Engine::pump`] reads from the
-/// driver's receive ring.
+/// The largest gossip receive ring an [`Engine`] accepts at construction, and so
+/// the ceiling on the work one [`Engine::pump`] spends on gossip ingress.
 ///
-/// It is at the same time the per-pump DECODE bound: every datagram a pump pops
-/// is unwrapped, decoded and applied to the machine within that pump, at that
-/// pump's instant. No datagram is carried across a pump, so this one number
-/// bounds both the work and the transient memory a pump can spend on gossip
-/// ingress.
+/// This is a CONSTRUCTION-TIME POLICY, not the read loop's bound.
+/// [`Engine::try_new_at`] rejects a [`GossipIo`] whose declared
+/// [`recv_capacity`](GossipIo::recv_capacity) reaches this number. Every datagram
+/// a pump pops is unwrapped, decoded and applied to the machine within that pump,
+/// at that pump's instant, and none is carried across a pump — so the largest ring
+/// the engine accepts is at once the per-pump decode bound and the transient
+/// memory a pump can spend on gossip ingress.
+///
+/// The read loop bounds each pump by the capacity the view being PUMPED declares,
+/// never by this constant (see [`Engine::pump`]). Correctness must not depend on
+/// the pumped view being the one construction screened: only the driver can see
+/// that divergence, so a pump over an over-cap view is read in full — a bounded,
+/// driver-declared amount of extra work in exchange for never leaving an observed
+/// datagram behind a membership sweep — and counted in
+/// [`Engine::gossip_over_cap_pumps`].
 ///
 /// A driver's gossip receive ring must stay STRICTLY BELOW this cap (smoltcp
-/// defaults to 8 metadata slots, the in-repo embassy sockets to 16).
-/// [`Engine::try_new_at`] enforces it for every driver, by screening the
-/// [`GossipIo::recv_capacity`] the view it is handed declares. A ring able to
-/// hold as many datagrams as the cap or more leaves the excess sitting in the
-/// ring — unread, so unobserved and un-stamped — across this pump's membership
-/// sweep, to be applied only at a later pump's instant. Strictly below is
-/// required rather than equal because the engine cannot distinguish "the ring
-/// was exactly emptied" from "more remain" without peeking: a full ring of
-/// exactly `GOSSIP_READ_CAP` datagrams would report the cap as hit and cost one
-/// spurious re-pump.
+/// defaults to 8 metadata slots, the in-repo embassy sockets to 16). Strictly
+/// below rather than at it because phase 2's bound is the declared capacity plus
+/// one probe pop: a ring below the cap keeps every conforming pump's reads at or
+/// under `GOSSIP_READ_CAP`, so the constant is the ceiling it names with no
+/// off-by-one slack.
 ///
 /// The bound is a count, not a byte budget. The implied byte ceiling is
 /// `GOSSIP_READ_CAP × gossip_recv_buf_size(gossip_mtu)` — per-pump AEAD and
@@ -348,17 +353,16 @@ pub struct Engine<I, C, R = SmallRng> {
   /// gates membership admission via the routable-address alive filter, which the
   /// constructor installs with this policy as its inner predicate.
   cidr_policy: CidrFilter,
-  /// Count of pumps that stopped reading gossip at [`GOSSIP_READ_CAP`] while the
-  /// node was running.
+  /// Count of pumps whose gossip view declared a receive capacity at or above
+  /// [`GOSSIP_READ_CAP`].
   ///
-  /// Non-zero means the driver's receive ring holds more datagrams than the
-  /// engine applies per pump — a ring sized at or above the cap, or a caller
-  /// whose pump cadence cannot keep up with arrivals. The engine itself loses
-  /// nothing when it stops at the cap (the remainder stays in the driver's ring
-  /// and is read on the next pump, which the returned deadline asks for
-  /// immediately); the drop signal for a genuinely overrun ring lives at the
-  /// link-layer stack, which tail-drops on a full ring.
-  gossip_read_cap_hits: u64,
+  /// Construction rejects such a ring, so a non-zero value means the driver pumps
+  /// a different — or since-resized — view than the one it constructed with: a
+  /// contract violation only the driver can see. Membership stays correct either
+  /// way, because phase 2 reads whatever the pumped view declares; what a non-zero
+  /// count reports is that the per-pump work ceiling the cap sets is no longer
+  /// being honored.
+  gossip_over_cap_pumps: u64,
 }
 
 // Construction, config, accessors, and the membership-machine forwarders —
@@ -446,16 +450,17 @@ where
     self.plane.teardown_overruns
   }
 
-  /// Diagnostic count of pumps that stopped reading gossip at
-  /// [`GOSSIP_READ_CAP`] while running.
+  /// Diagnostic count of pumps whose gossip view declared a receive capacity at
+  /// or above [`GOSSIP_READ_CAP`].
   ///
-  /// A non-zero value means the driver's gossip receive ring can hold more than
-  /// the engine applies per pump, or the caller's pump cadence is behind the
-  /// arrival rate. Both drivers reject an over-cap ring at construction, so on a
-  /// validated driver this stays zero.
+  /// [`try_new_at`](Self::try_new_at) rejects such a ring, so a non-zero value
+  /// means the pumped view is not the one construction screened — a different
+  /// socket, or one resized since. The reads stay bounded and every popped
+  /// datagram is still applied within its pump; what is lost is the per-pump work
+  /// ceiling. A driver that pumps the view it validated leaves this at zero.
   #[inline]
-  pub fn gossip_read_cap_hits(&self) -> u64 {
-    self.gossip_read_cap_hits
+  pub fn gossip_over_cap_pumps(&self) -> u64 {
+    self.gossip_over_cap_pumps
   }
 
   /// Whether a passive-open listener slot is currently installed.
@@ -1138,13 +1143,20 @@ where
   ///   only read here, for [`GossipIo::recv_capacity`]; no datagram is moved and
   ///   the view is not retained (`pump` takes its own `&mut` view per call).
   ///
-  /// # The gossip read-cap invariant
+  /// # The gossip work ceiling
   ///
-  /// This is the SINGLE enforcement point of the invariant `pump` phase 2 relies
-  /// on: the gossip receive ring must hold strictly fewer datagrams than
-  /// [`GOSSIP_READ_CAP`]. Taking the view here — rather than trusting each driver
-  /// to screen its own socket — is what binds every driver to it, including one
-  /// written outside this workspace.
+  /// This is where the per-pump WORK CEILING is enforced: the gossip receive ring
+  /// must hold strictly fewer datagrams than [`GOSSIP_READ_CAP`]. Taking the view
+  /// here — rather than trusting each driver to screen its own socket — is what
+  /// binds every driver to it, including one written outside this workspace.
+  ///
+  /// It is not what makes `pump` phase 2 correct; that is structural at pump time.
+  /// The read loop derives its bound from the capacity the view it is handed
+  /// declares, so every datagram present when a pump starts is applied before that
+  /// pump's membership sweep for ANY truthful view, screened here or not. What
+  /// this screen buys is the size of that bound: a pump over an unscreened
+  /// over-cap view is still read in full, and counted in
+  /// [`gossip_over_cap_pumps`](Self::gossip_over_cap_pumps).
   ///
   /// # Errors
   ///
@@ -1188,15 +1200,15 @@ where
     validate_runtime_config(&cfg, &transform, ep_cfg.gossip_mtu())?;
 
     // Keep the driver's gossip rx ring strictly below this engine's per-pump read
-    // cap. Phase 2 pops at most `GOSSIP_READ_CAP` datagrams and applies every one
-    // of them at that pump's instant; a ring able to hold as many or more would
-    // leave the excess unread across the pump's membership sweep, so a refutation
-    // already sitting in the ring could be applied only after the timer it refutes
-    // had fired. Screening the view the driver hands over — not each driver's own
-    // socket knob — is what makes this hold for EVERY `GossipIo`, including one
-    // implemented outside this workspace. Strict, not inclusive: a ring exactly at
-    // the cap that happens to be full is indistinguishable from an over-cap one
-    // without peeking, so it would cost a spurious re-pump on every full read.
+    // cap. This bounds WORK, not correctness: phase 2 derives its read bound from
+    // the capacity of the view it is actually pumped with, so a truthful ring of
+    // any size is emptied before that pump's membership sweep. What the cap buys is
+    // a bounded amount of unwrap/decode/apply per pump on a driver that pumps what
+    // it validated. Screening the view the driver hands over — not each driver's
+    // own socket knob — is what makes the ceiling bind EVERY `GossipIo`, including
+    // one implemented outside this workspace. Strict, not inclusive: phase 2's
+    // bound is the declared capacity plus one probe pop, so a ring strictly below
+    // the cap keeps a conforming pump's reads at or under it.
     let recv_capacity = gossip.recv_capacity();
     if recv_capacity >= GOSSIP_READ_CAP {
       return Err(InitError::GossipRecvCapacityTooLarge(recv_capacity));
@@ -1306,7 +1318,7 @@ where
       last_completed_send: None,
       label,
       cidr_policy,
-      gossip_read_cap_hits: 0,
+      gossip_over_cap_pumps: 0,
     })
   }
 
@@ -2228,9 +2240,9 @@ where
   ///    the pool.
   /// 1b. **Accept inbound** — if the listener completed a passive open, hand it
   ///    to the machine and replenish the listener from the pool.
-  /// 2. **Gossip ingress** — pop up to [`GOSSIP_READ_CAP`] datagrams from the
-  ///    driver's receive ring, unwrapping, decoding and feeding each one's typed
-  ///    messages to `handle_packet` as it is popped.
+  /// 2. **Gossip ingress** — pop from the driver's receive ring up to the capacity
+  ///    that view declares, plus one probe pop, unwrapping, decoding and feeding
+  ///    each datagram's typed messages to `handle_packet` as it is popped.
   /// 3. **Reliable ingress pump** — drain each connection's rx into
   ///    `handle_transport_data`; deliver a one-shot EOF on peer FIN.
   /// 1c. **Rebalance** — self-heal a missing listener, then assign any remaining
@@ -2240,7 +2252,7 @@ where
   /// 7a–7e. **Stream actions + egress** — drain `poll_action`, promote, pump
   ///    outbound, flush deferred FINs, complete `Closing` drains, re-rebalance,
   ///    then drain + send outbound gossip.
-  /// 8. **Deadline** — `min(machine_next, closing_next, gossip_read_capped)`.
+  /// 8. **Deadline** — `min(machine_next, closing_next, gossip_more)`.
   ///
   /// # Observation is the read
   ///
@@ -2250,10 +2262,25 @@ where
   /// phase 3 is likewise fed before 1c, 5, 6 and 7. Nothing observed is carried
   /// across a pump, so no timer can overtake evidence the engine holds, and the
   /// machine sees one real instant per pump — the instant at which the engine
-  /// read what it feeds. Per-pump work is bounded by the driver's rings and by
-  /// [`GOSSIP_READ_CAP`]; a driver's gossip receive ring must stay below that cap,
-  /// which [`try_new_at`](Self::try_new_at) enforces against the view's declared
-  /// [`GossipIo::recv_capacity`].
+  /// read what it feeds.
+  ///
+  /// # The gossip read bound
+  ///
+  /// Phase 2 pops at most the capacity THIS view declares
+  /// ([`GossipIo::recv_capacity`]) plus one. A ring of capacity `C` holds at most
+  /// `C` datagrams, so a truthful view of any size is emptied within the pump that
+  /// observed it, in every build profile: nothing the driver had waiting when the
+  /// pump began survives to sit behind a sweep. The bound is taken from the view
+  /// in hand rather than from [`GOSSIP_READ_CAP`] because `pump` accepts a fresh
+  /// view on every call and cannot know whether this one is what
+  /// [`try_new_at`](Self::try_new_at) screened; the cap governs which rings that
+  /// constructor accepts, and so how large this bound is on a conforming driver.
+  ///
+  /// The extra pop is the refill detector, and the sole source of the wake term:
+  /// a `(C + 1)`th datagram means the ring refilled while the loop ran, or the
+  /// view under-declares its capacity, so step 8 asks for an immediate re-pump. A
+  /// conforming ring never sets it — not even an exactly-full one, whose probe pop
+  /// finds nothing.
   ///
   /// One same-instant ordering residual survives, on the reliable plane only:
   /// within phase 3 an earlier connection's feed can run a transitive sweep before
@@ -2301,8 +2328,8 @@ where
     // Accept-and-replenish first claims it for the listener instead.
     self.check_listener(now, stream);
 
-    // 2. Gossip ingress: pop, decode and apply one datagram at a time, at most
-    // `GOSSIP_READ_CAP` of them.
+    // 2. Gossip ingress: pop, decode and apply one datagram at a time, bounded by
+    // the capacity the PUMPED view declares plus one probe pop.
     //
     // Observation is the read: a datagram enters the engine's view when this loop
     // pops it, and it is applied to the machine at this pump's `now` — before any
@@ -2310,11 +2337,22 @@ where
     // pump, so there is no held evidence for a timer to overtake and no reason for
     // the machine to be handed anything but the real instant.
     //
-    // The read is capped rather than run to exhaustion so one pump's work is
-    // bounded for ANY `GossipIo`, including one whose ring the link layer could
-    // refill while the loop runs. Datagrams beyond the cap stay in the driver's
-    // ring and are read on the next pump, which step 8 asks for immediately; on a
-    // ring sized below the cap the ring is always emptied and the cap never hit.
+    // The bound comes from the view in hand, not from `GOSSIP_READ_CAP`: `pump`
+    // takes a fresh view on every call, so nothing here can know this is the view
+    // construction screened, and correctness must not rest on that. A ring of
+    // capacity C holds at most C datagrams, so C pops empty ANY truthful view — 8
+    // slots, 63, or 65 — and everything the driver had waiting when this pump began
+    // is applied at this instant, ahead of every sweep-capable phase, in every
+    // build profile.
+    //
+    // The probe pop is the refill/lie detector and the sole source of the wake
+    // term: a (C+1)th datagram can only mean the ring refilled while the loop ran
+    // or the declaration is wrong, so step 8 asks the caller to come back at once
+    // rather than sleep on a timer with unread traffic behind it. A conforming ring
+    // that happens to be exactly full pops C and finds nothing on the probe, so it
+    // costs no spurious re-pump. Reads stay bounded at C + 1 per pump for ANY
+    // `GossipIo`, including one whose ring the link layer refills while the loop
+    // runs.
     //
     // The machine's own `handle_gossip` / `poll_memberlist_ingress` round-trip is
     // deliberately bypassed: it would copy every datagram into a machine-side
@@ -2323,19 +2361,21 @@ where
     // `last_now` anchor `handle_gossip` would have written is re-established by
     // step 6's `handle_timeout(now)` on every pump.
     //
-    // The ring this pump reads must be the one construction screened. A driver
-    // that validated with one view and pumps with another (a different socket, a
-    // resized buffer) would silently reopen the cross-pump residency the cap
-    // exists to close, and only the driver can see that divergence — so assert it
-    // where the read happens. Debug-only: the constructor already rejected an
-    // over-cap ring, and release builds pay nothing.
-    debug_assert!(
-      gossip.recv_capacity() < GOSSIP_READ_CAP,
-      "the pumped gossip receive ring holds {} datagrams, at or above the per-pump read cap {}: \
-       construction screened a different view",
-      gossip.recv_capacity(),
-      GOSSIP_READ_CAP
-    );
+    // A view declaring at or above the cap is a contract violation: construction
+    // rejects such a ring, so this pump is being run over a different or
+    // since-resized view than the one screened. Read it in full anyway — a bounded,
+    // driver-declared amount of extra work is always the better trade against a
+    // datagram left behind a membership sweep — and surface the divergence, which
+    // otherwise only the driver can see.
+    let declared = gossip.recv_capacity();
+    if declared >= GOSSIP_READ_CAP {
+      self.gossip_over_cap_pumps += 1;
+    }
+    // A ring of capacity `declared` holds at most that many datagrams, so the one
+    // extra pop succeeds only on a ring that refilled mid-pump or under-declared.
+    // Saturating because a nonsense declaration must not wrap the bound to zero and
+    // stall ingress outright.
+    let bound = declared.saturating_add(1);
 
     // The lifecycle state is read once: only `leave` changes it, and `leave` is a
     // between-pumps call.
@@ -2349,13 +2389,13 @@ where
       let endpoint = &mut self.endpoint;
       let cidr_policy = &self.cidr_policy;
       let label = &self.label;
-      while popped < GOSSIP_READ_CAP {
+      while popped < bound {
         // The driver's datagram I/O pops one datagram per `recv` call and returns
         // `None` once the rx ring is empty.
         let Some((src, n)) = gossip.recv(buf) else {
           break;
         };
-        // Charge EVERY pop, whatever becomes of it: the cap bounds reads of the
+        // Charge EVERY pop, whatever becomes of it: the bound is on reads of the
         // driver's ring, which is the resource an inbound flood drives.
         popped += 1;
         // Three reasons to drop a popped datagram without decoding it:
@@ -2408,13 +2448,10 @@ where
         }
       }
     }
-    // The loop stopped at the cap while running, so the ring may still hold
-    // datagrams: step 8 folds an already-due wake for them, and the hit is counted
-    // as the overload / misconfiguration signal.
-    let gossip_more = running && popped == GOSSIP_READ_CAP;
-    if gossip_more {
-      self.gossip_read_cap_hits += 1;
-    }
+    // The probe pop found a datagram past the declared capacity while running, so
+    // the ring refilled under the loop (or the view under-declares it) and may
+    // still hold more: step 8 folds an already-due wake for them.
+    let gossip_more = running && popped > declared;
 
     // 3. Reliable ingress pump: drain each active exchange's socket rx buffer into
     // the machine. Must run before the machine tick so the machine sees fresh
@@ -2554,13 +2591,14 @@ where
     //   Folding the soonest of BOTH in guarantees the caller wakes by
     //   `close_timeout` to escalate it, so pool / listener recovery is bounded by
     //   `Options::close_timeout` as documented.
-    // - the read-cap term — an already-due `now`, set only when phase 2 stopped
-    //   reading at `GOSSIP_READ_CAP` while running, so datagrams may still be
-    //   waiting in the driver's ring. It asks a deadline-driven caller to service
-    //   its other work and poll again at once rather than sleep on a timer while
-    //   observed traffic sits unread. A gossip ring sized below the cap never sets
-    //   it (the ring empties before the cap is reached), and a node that has left
-    //   never sets it (the term is gated on the running state).
+    // - the gossip term — an already-due `now`, set only when phase 2's probe pop
+    //   found a datagram past the pumped view's declared capacity while running, so
+    //   the ring refilled under the loop (or under-declares itself) and may still
+    //   hold more. It asks a deadline-driven caller to service its other work and
+    //   poll again at once rather than sleep on a timer while observed traffic sits
+    //   unread. A truthful ring never sets it — not even an exactly-full one, whose
+    //   probe pop finds nothing — and a node that has left never sets it (the term
+    //   is gated on the running state).
     //
     // `pending_dial` deliberately contributes NO deadline of its own: a buffered
     // dial is serviced when a slot frees, never on a clock of its own, and every

--- a/memberlist-embedded/src/engine/tests.rs
+++ b/memberlist-embedded/src/engine/tests.rs
@@ -3827,3 +3827,555 @@ fn error_delivered_is_one_shot() {
     "a latched connection surfaces no further fault"
   );
 }
+
+/// Number of datagrams still waiting in the fake driver ring.
+impl QueueGossip {
+  fn ring_len(&self) -> usize {
+    self.inbound.len()
+  }
+}
+
+/// Encode a plaintext, unlabelled `Alive` for `(id, addr)` at `incarnation`, as a
+/// peer's gossip datagram would arrive on the wire.
+fn alive_datagram(id: &str, addr: SocketAddr, incarnation: u32) -> Vec<u8> {
+  use memberlist_proto::{
+    EncodeOptions, codec,
+    typed::{Alive, Message},
+  };
+
+  let msg = Message::<SmolStr, SocketAddr>::Alive(Alive::new(
+    incarnation,
+    Node::new(SmolStr::new(id), addr),
+  ));
+  codec::encode_outgoing(&msg, &EncodeOptions::new(None))
+    .expect("encode Alive")
+    .to_vec()
+}
+
+/// An undecodable gossip datagram: it costs a pop and an unwrap attempt, and is
+/// dropped before the machine sees anything.
+fn junk_datagram() -> Vec<u8> {
+  std::vec![0xABu8; 24]
+}
+
+/// Bring up a running engine whose sole other member is peer `B`, then pump the
+/// clock forward until the SWIM failure-detection probe fires a direct `Ping` at
+/// `B`. Returns the engine, its gossip fake, `B`'s address, the pump instant `F`
+/// at which the probe was sent, and the probe's ack sequence number decoded from
+/// that `Ping`. At the initial (healthy) awareness score the probe's authoritative
+/// failure deadline is `F + probe_interval` (the 1s default).
+///
+/// `cfg` carries whatever engine options the caller needs (a CIDR policy, say);
+/// the port must stay 7946 so `B` is reachable from the local advertise address.
+fn arm_detection_probe_on_b_with(
+  cfg: Options,
+) -> (Engine<SmolStr, u32>, QueueGossip, SocketAddr, Instant, u32) {
+  use memberlist_proto::{DecodeOptions, codec, typed::Message};
+
+  let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new("local"), node_addr(7946));
+  let start = Instant::from_origin(Duration::from_secs(86_400));
+  let mut engine: Engine<SmolStr, u32> =
+    Engine::try_new_at(cfg, TransformOptions::default(), ep_cfg, start, test_rng())
+      .expect("valid configuration");
+  engine.start(start);
+  // A distinct, routable address so B is a separate member and the probe's direct
+  // Ping is addressed to it.
+  let b_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 7947);
+  engine.inject_alive(SmolStr::new("b"), b_addr, start);
+
+  let mut gossip = QueueGossip::new();
+  let mut stream = NoStream::with_pool(4);
+  // The probe interval is 1s; step coarsely until the direct Ping at B appears.
+  let mut t = start;
+  for _ in 0..200 {
+    t += Duration::from_millis(50);
+    engine.pump(t, &mut gossip, &mut stream);
+    // Scan (and clear) this pump's egress for a Ping addressed to B; decode it to
+    // recover the ack sequence number the machine expects back.
+    let mut seq = None;
+    for (bytes, dest) in core::mem::take(&mut gossip.outbound) {
+      if dest != b_addr {
+        continue;
+      }
+      let Ok(plain) = codec::decode_incoming(bytes::Bytes::from(bytes), &DecodeOptions::new(None))
+      else {
+        continue;
+      };
+      let Ok(msgs) = codec::parse_messages::<SmolStr, SocketAddr>(plain) else {
+        continue;
+      };
+      for msg in msgs {
+        if let Message::Ping(p) = msg {
+          seq = Some(p.sequence_number());
+        }
+      }
+    }
+    if let Some(seq) = seq {
+      return (engine, gossip, b_addr, t, seq);
+    }
+  }
+  panic!("the failure-detection probe never fired a direct Ping at B");
+}
+
+/// [`arm_detection_probe_on_b_with`] under the plain default options.
+fn arm_detection_probe_on_b() -> (Engine<SmolStr, u32>, QueueGossip, SocketAddr, Instant, u32) {
+  arm_detection_probe_on_b_with(
+    Options::new()
+      .with_port(7946)
+      .with_close_timeout(Duration::from_secs(10)),
+  )
+}
+
+/// Let the armed probe on `B` expire so `B` transitions to `Suspect`, and return
+/// `(t1, S)`: the pump instant at which it was suspected, and the instant its
+/// suspicion deadline falls due.
+///
+/// With the default `probe_interval` (1s) and `suspicion_mult` (4) over a
+/// two-member cluster the node-count scale is 1.0 and `k` collapses to 0
+/// (`n < suspicion_mult`), so the suspicion timer is fixed at
+/// `probe_interval * suspicion_mult` = 4s from `t1`.
+fn suspect_b(
+  engine: &mut Engine<SmolStr, u32>,
+  gossip: &mut QueueGossip,
+  stream: &mut NoStream,
+  f: Instant,
+) -> (Instant, Instant) {
+  use memberlist_proto::typed::State;
+
+  let t1 = f + Duration::from_millis(1100);
+  engine.pump(t1, gossip, stream);
+  assert_eq!(
+    engine.num_members_by(|ns| ns.id_ref() == &SmolStr::new("b") && ns.state() == State::Suspect),
+    1,
+    "the expired detection probe must suspect B, or the test proves nothing"
+  );
+  // Discard the events the arming produced; the assertions below watch only the
+  // events the refutation pump emits.
+  while engine.poll_event().is_some() {}
+  (t1, t1 + Duration::from_secs(4))
+}
+
+/// Queue `GOSSIP_READ_CAP - 1` undecodable datagrams and then `B`'s
+/// `Alive(inc + 1)` refutation, so the refutation is the LAST datagram the pump's
+/// read cap admits.
+fn junk_then_b_refutation(
+  engine: &Engine<SmolStr, u32>,
+  gossip: &mut QueueGossip,
+  b_addr: SocketAddr,
+) {
+  let junk_src = node_addr(7050);
+  for _ in 0..(GOSSIP_READ_CAP - 1) {
+    gossip.push(junk_src, junk_datagram());
+  }
+  let inc = engine
+    .endpoint
+    .endpoint_ref()
+    .node_incarnation(&SmolStr::new("b"))
+    .expect("B is a member");
+  gossip.push(b_addr, alive_datagram("b", b_addr, inc + 1));
+}
+
+/// Assert `B` came out of the pump `Alive` with no membership flap.
+fn assert_b_refuted(engine: &mut Engine<SmolStr, u32>) {
+  use memberlist_proto::typed::State;
+
+  assert_eq!(
+    engine.num_members_by(|ns| ns.id_ref() == &SmolStr::new("b") && ns.state() == State::Alive),
+    1,
+    "B's own refutation, read in this pump, must leave it Alive"
+  );
+  while let Some(ev) = engine.poll_event() {
+    assert!(
+      !matches!(ev, Event::NodeLeft(_) | Event::NodeJoined(_)),
+      "B must not flap: no death and no re-join event"
+    );
+  }
+}
+
+/// A refutation read in the same pump that crosses its subject's suspicion
+/// deadline wins, because phase 2 applies every datagram it pops before step 6
+/// can fire a timer.
+///
+/// `process_alive` has no instant cutoff — only the incarnation gate — so an
+/// `Alive(inc + 1)` for a `Suspect` B clears the suspicion outright. What decides
+/// the outcome is purely the order of the two within the pump: read-then-tick
+/// keeps B alive, tick-then-read kills it and immediately resurrects it. The
+/// refutation is placed LAST in the ring, behind a cap's worth of junk, so it is
+/// also the final datagram the read cap admits.
+#[test]
+fn same_pump_alive_refutation_precedes_the_tick() {
+  let (mut engine, mut gossip, b_addr, f, _seq) = arm_detection_probe_on_b();
+  let mut stream = NoStream::with_pool(4);
+  let (_t1, s) = suspect_b(&mut engine, &mut gossip, &mut stream, f);
+
+  junk_then_b_refutation(&engine, &mut gossip, b_addr);
+
+  let t = s + Duration::from_secs(1);
+  assert!(t > s, "this pump runs past B's suspicion deadline");
+  engine.pump(t, &mut gossip, &mut stream);
+
+  assert_b_refuted(&mut engine);
+  assert_eq!(
+    gossip.ring_len(),
+    0,
+    "a full cap's worth of datagrams is read and applied within the pump"
+  );
+}
+
+/// Reliable-plane input ticks the machine too: `handle_transport_data` ends in
+/// `run_tick`, whose membership step is the same sweep step 6 runs. Feeding it
+/// before this pump's gossip would let arbitrary bytes on an unrelated connection
+/// fire a suspicion the gossip ring already refutes — so phase 3 must follow phase
+/// 2. The bytes here are junk: input the record layer will reject is enough,
+/// because the tick happens on the feed, not on the parse.
+#[test]
+fn same_pump_reliable_input_cannot_sweep_past_this_pumps_gossip() {
+  let (mut engine, mut gossip, b_addr, f, _seq) = arm_detection_probe_on_b();
+  let mut probe_stream = NoStream::with_pool(4);
+  let (t1, s) = suspect_b(&mut engine, &mut gossip, &mut probe_stream, f);
+
+  // Admit an inbound reliable connection on a pump before the deadline, so the
+  // pump under test only has to feed its bytes.
+  let mut stream = armed_inbound_listener(&mut engine);
+  let accepted_before = engine.accepted_inbound_count();
+  engine.pump(t1 + Duration::from_millis(100), &mut gossip, &mut stream);
+  assert_eq!(
+    engine.accepted_inbound_count(),
+    accepted_before + 1,
+    "the inbound reliable connection must be admitted, or the test proves nothing"
+  );
+  while engine.poll_event().is_some() {}
+
+  stream.sock_mut(1).rx = std::vec![0xABu8; 64];
+  junk_then_b_refutation(&engine, &mut gossip, b_addr);
+
+  let t = s + Duration::from_secs(1);
+  engine.pump(t, &mut gossip, &mut stream);
+
+  assert_b_refuted(&mut engine);
+  assert_eq!(gossip.ring_len(), 0, "the whole ring was read this pump");
+}
+
+/// The reliable plane ticks the machine on its FAULT paths too: a socket that died
+/// without a graceful peer FIN routes to `handle_transport_error`, which — like
+/// `handle_transport_data` — ends in `run_tick`. A peer that merely RSTs its
+/// connection must not sweep past this pump's gossip either.
+#[test]
+fn same_pump_reliable_fault_cannot_sweep_past_this_pumps_gossip() {
+  let (mut engine, mut gossip, b_addr, f, _seq) = arm_detection_probe_on_b();
+  let mut probe_stream = NoStream::with_pool(4);
+  let (t1, s) = suspect_b(&mut engine, &mut gossip, &mut probe_stream, f);
+
+  let mut stream = armed_inbound_listener(&mut engine);
+  let accepted_before = engine.accepted_inbound_count();
+  engine.pump(t1 + Duration::from_millis(100), &mut gossip, &mut stream);
+  assert_eq!(
+    engine.accepted_inbound_count(),
+    accepted_before + 1,
+    "the inbound reliable connection must be admitted, or the test proves nothing"
+  );
+  while engine.poll_event().is_some() {}
+
+  // The peer RSTs: the socket closes with no graceful FIN and nothing to read,
+  // which phase 3 surfaces to the machine as a transport fault.
+  stream.sock_mut(1).open = false;
+  junk_then_b_refutation(&engine, &mut gossip, b_addr);
+
+  let t = s + Duration::from_secs(1);
+  engine.pump(t, &mut gossip, &mut stream);
+
+  assert_b_refuted(&mut engine);
+  assert_eq!(gossip.ring_len(), 0, "the whole ring was read this pump");
+}
+
+/// One pump reads at most `GOSSIP_READ_CAP` datagrams. The remainder stays in the
+/// driver's ring — not dropped, not copied into the engine — and is read on the
+/// next pump, which the returned already-due deadline asks for immediately.
+#[test]
+fn gossip_read_is_capped_per_pump_and_the_remainder_is_read_next_pump() {
+  let mut engine = make_engine();
+  let t = Instant::from_origin(Duration::from_secs(86_400));
+  engine.start(t);
+  let mut gossip = QueueGossip::new();
+  let mut stream = NoStream::with_pool(2);
+
+  // Settle the machine's own schedulers first, so the only already-due term the
+  // pump under test can return is the read cap's.
+  let quiescent = engine.pump(t, &mut gossip, &mut stream);
+  assert!(
+    quiescent > Some(t),
+    "no machine timer may be due at this instant, or the wake assertion proves nothing"
+  );
+
+  // `cap + k` distinct, valid Alives, each for its own id and address.
+  let extra = 5usize;
+  let src = node_addr(7050);
+  for i in 0..(GOSSIP_READ_CAP + extra) {
+    let addr = node_addr(8000 + i as u16);
+    gossip.push(src, alive_datagram(&std::format!("n{i}"), addr, 1));
+  }
+
+  let first = engine.pump(t, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.num_members(),
+    1 + GOSSIP_READ_CAP,
+    "exactly one cap's worth of Alives is applied in the first pump"
+  );
+  assert_eq!(
+    gossip.ring_len(),
+    extra,
+    "the remainder waits in the driver's ring, neither dropped nor engine-held"
+  );
+  assert_eq!(
+    first,
+    Some(t),
+    "stopping at the cap folds an already-due wake so the caller polls again at once"
+  );
+  assert_eq!(
+    engine.gossip_read_cap_hits(),
+    1,
+    "the cap hit is counted exactly once"
+  );
+
+  let second = engine.pump(t, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.num_members(),
+    1 + GOSSIP_READ_CAP + extra,
+    "the remainder is applied on the next pump"
+  );
+  assert_eq!(gossip.ring_len(), 0, "the ring is now empty");
+  assert!(
+    second > Some(t),
+    "a pump that emptied the ring folds no already-due wake"
+  );
+  assert_eq!(
+    engine.gossip_read_cap_hits(),
+    1,
+    "a pump that stopped short of the cap counts no hit"
+  );
+}
+
+/// The sweep is never withheld while gossip is outstanding: a pump that stops at
+/// the read cap still fires every timer due at its instant. A design that ticked
+/// only once nothing observed was pending would let a sustained flood silence the
+/// node's own failure detection.
+#[test]
+fn a_due_timer_fires_in_the_pump_that_hits_the_read_cap() {
+  use memberlist_proto::typed::State;
+
+  let (mut engine, mut gossip, _b_addr, f, _seq) = arm_detection_probe_on_b();
+  let mut stream = NoStream::with_pool(4);
+
+  let junk_src = node_addr(7050);
+  for _ in 0..(GOSSIP_READ_CAP + 5) {
+    gossip.push(junk_src, junk_datagram());
+  }
+
+  // Past the probe's authoritative failure deadline (`F + probe_interval`).
+  let t = f + Duration::from_millis(1100);
+  let wake = engine.pump(t, &mut gossip, &mut stream);
+
+  assert_eq!(
+    engine.num_members_by(|ns| ns.id_ref() == &SmolStr::new("b") && ns.state() == State::Suspect),
+    1,
+    "the expired probe must suspect B in the very pump that hit the read cap"
+  );
+  assert_eq!(
+    wake,
+    Some(t),
+    "the read cap folds an already-due wake for the datagrams still in the ring"
+  );
+  assert_eq!(engine.gossip_read_cap_hits(), 1, "one cap hit is counted");
+  assert_eq!(
+    gossip.ring_len(),
+    5,
+    "the pump read exactly the cap and left the rest in the ring"
+  );
+}
+
+/// After `leave` the engine still POPS gossip — the ring is the driver's and would
+/// otherwise back up — but it decodes none of it, changes no membership, and never
+/// asks to be re-pumped. The pop stays bounded by the read cap, so a flood aimed at
+/// a node that has left costs at most a cap's worth of memcpys per pump.
+#[test]
+fn post_leave_gossip_is_popped_not_decoded_and_never_wakes() {
+  let mut engine = make_engine();
+  let t = Instant::from_origin(Duration::from_secs(86_400));
+  engine.start(t);
+  let mut gossip = QueueGossip::new();
+  let mut stream = NoStream::with_pool(2);
+  engine.leave(t).expect("a running engine leaves cleanly");
+
+  let members_before = engine.num_members();
+  let extra = 8usize;
+  let src = node_addr(7050);
+  for i in 0..(GOSSIP_READ_CAP + extra) {
+    let addr = node_addr(8000 + i as u16);
+    gossip.push(src, alive_datagram(&std::format!("n{i}"), addr, 1));
+  }
+
+  let wake = engine.pump(t, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.num_members(),
+    members_before,
+    "a left node admits no member from gossip"
+  );
+  assert_eq!(
+    gossip.ring_len(),
+    extra,
+    "the post-leave pop is bounded by the read cap, not run to exhaustion"
+  );
+  assert_eq!(
+    engine.gossip_read_cap_hits(),
+    0,
+    "a left node counts no cap hit — the wake term it feeds is gated on running"
+  );
+  assert_ne!(
+    wake,
+    Some(t),
+    "a left node never asks to be re-pumped for gossip it will not decode"
+  );
+
+  engine.pump(t, &mut gossip, &mut stream);
+  assert_eq!(gossip.ring_len(), 0, "the rest is popped on the next pump");
+  assert_eq!(
+    engine.num_members(),
+    members_before,
+    "still no membership change"
+  );
+}
+
+/// The early rebalance dials a `PendingDial` parked on a previous pump, and a dial
+/// the transport rejects synchronously terminalizes through the machine — whose
+/// tick sweeps membership at this pump's instant. Running that before the gossip
+/// phase, as the pump did previously, let an unrelated outbound dial fire a
+/// suspicion this pump's ring already refutes. The rebalance therefore runs after
+/// both evidence feeds, while still preceding the machine tick that a parked dial
+/// needs it to precede.
+#[cfg(feature = "cidr")]
+#[test]
+fn early_rebalance_dial_rejection_cannot_sweep_before_this_pumps_gossip() {
+  use memberlist_proto::CidrPolicy;
+
+  let cfg = Options::new()
+    .with_port(7946)
+    .with_close_timeout(Duration::from_secs(10))
+    // B (10.0.0.2) and the local node (10.0.0.1) are both in policy; the dial
+    // target below is not.
+    .with_cidr_policy(CidrPolicy::try_from(["10.0.0.0/8"].as_slice()).expect("valid cidr"));
+  let (mut engine, mut gossip, b_addr, f, _seq) = arm_detection_probe_on_b_with(cfg);
+  let mut stream = NoStream::with_pool(4);
+  let (t1, s) = suspect_b(&mut engine, &mut gossip, &mut stream, f);
+
+  // A listener is installed and the pool is empty, so the dial below has to park
+  // as a `PendingDial` rather than taking a slot straight away.
+  engine.set_listener(1);
+  let blocked = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 7001);
+  engine
+    .send_reliable(blocked, bytes::Bytes::from_static(b"blocked-bytes"), t1)
+    .expect("send_reliable queues the exchange");
+
+  let t2 = t1 + Duration::from_millis(100);
+  engine.pump(t2, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.pending_dial_count(),
+    1,
+    "the dial must park with no slot, or the early rebalance has nothing to do"
+  );
+  while engine.poll_event().is_some() {}
+
+  // Free the slot the parked dial will claim in the pump under test. The listener
+  // is already present, so `ensure_listener` leaves it for the dial.
+  engine.plane_mut().pool.push(0);
+  junk_then_b_refutation(&engine, &mut gossip, b_addr);
+
+  let t = s + Duration::from_secs(1);
+  engine.pump(t, &mut gossip, &mut stream);
+
+  assert_eq!(
+    engine.pending_dial_count(),
+    0,
+    "the early rebalance must have dialed the parked exchange in this pump"
+  );
+  assert_b_refuted(&mut engine);
+  assert_eq!(gossip.ring_len(), 0, "the whole ring was read this pump");
+}
+
+/// Nothing the engine observed is still pending when the machine ticks, at every
+/// ring size a driver can present.
+///
+/// Below the read cap the ring is emptied and the pump folds no already-due wake.
+/// At exactly the cap the ring is also emptied and everything applied, but the
+/// engine cannot tell an exactly-emptied ring from one with more behind it without
+/// peeking, so it folds one spurious already-due wake — which is why both drivers
+/// require a ring STRICTLY below the cap.
+#[test]
+fn nothing_observed_is_pending_when_the_machine_ticks() {
+  for ring in [1usize, 8, 16, GOSSIP_READ_CAP] {
+    let mut engine = make_engine();
+    let t = Instant::from_origin(Duration::from_secs(86_400));
+    engine.start(t);
+    let mut gossip = QueueGossip::new();
+    let mut stream = NoStream::with_pool(2);
+
+    let quiescent = engine.pump(t, &mut gossip, &mut stream);
+    assert!(
+      quiescent > Some(t),
+      "ring {ring}: no machine timer may be due at this instant"
+    );
+
+    let src = node_addr(7050);
+    for i in 0..ring {
+      let addr = node_addr(8000 + i as u16);
+      gossip.push(src, alive_datagram(&std::format!("n{i}"), addr, 1));
+    }
+
+    let wake = engine.pump(t, &mut gossip, &mut stream);
+    assert_eq!(gossip.ring_len(), 0, "ring {ring}: the ring is emptied");
+    assert_eq!(
+      engine.num_members(),
+      1 + ring,
+      "ring {ring}: every datagram read was applied in that same pump"
+    );
+    if ring < GOSSIP_READ_CAP {
+      assert!(
+        wake > Some(t),
+        "ring {ring}: a conforming ring folds no already-due wake"
+      );
+      assert_eq!(
+        engine.gossip_read_cap_hits(),
+        0,
+        "ring {ring}: a conforming ring never reaches the cap"
+      );
+    } else {
+      assert_eq!(
+        wake,
+        Some(t),
+        "ring {ring}: a ring exactly at the cap costs one spurious re-pump"
+      );
+      assert_eq!(
+        engine.gossip_read_cap_hits(),
+        1,
+        "ring {ring}: the exactly-full ring is indistinguishable from an over-cap one"
+      );
+    }
+  }
+}
+
+/// Arm `engine` with a reliable listener on slot 1 and one spare (slot 0) to
+/// replenish from, backed by a fresh `ProgRel`. The mock admits the passive open
+/// on the first `check_listener` that runs after the caller marks slot 1
+/// `accepted` + `established`, which is what gives the test a live inbound
+/// exchange to drive reliable input through.
+fn armed_inbound_listener(engine: &mut Engine<SmolStr, u32>) -> ProgRel {
+  engine.plane_mut().pool.push(0);
+  engine.set_listener(1);
+  let mut stream = ProgRel::new(&[0, 1]);
+  stream
+    .listen(1, 7946, crate::SlotGen::START)
+    .expect("mock listen succeeds");
+  // A settled passive open from an in-policy remote, ready for the next accept.
+  stream.sock_mut(1).accepted = Some(node_addr(7950));
+  stream.sock_mut(1).established = true;
+  stream
+}

--- a/memberlist-embedded/src/engine/tests.rs
+++ b/memberlist-embedded/src/engine/tests.rs
@@ -18,6 +18,12 @@ fn test_rng() -> SmallRng {
   SmallRng::seed_from_u64(42)
 }
 
+/// The receive ring every gossip fake here declares. Their queues are `Vec`-backed
+/// and have no fixed bound, so they declare the largest ring the engine accepts —
+/// one slot below its per-pump read cap — and every fake is usable both as the
+/// construction-time capacity witness and as the pumped view.
+const FAKE_RECV_CAPACITY: usize = GOSSIP_READ_CAP - 1;
+
 struct NoGossip;
 
 impl GossipIo for NoGossip {
@@ -26,6 +32,10 @@ impl GossipIo for NoGossip {
   }
 
   fn send(&mut self, _bytes: &[u8], _dest: SocketAddr) {}
+
+  fn recv_capacity(&self) -> usize {
+    FAKE_RECV_CAPACITY
+  }
 }
 
 /// A [`GossipIo`] that records every outbound datagram so a test can inspect
@@ -53,6 +63,10 @@ impl GossipIo for CaptureGossip {
   fn send(&mut self, bytes: &[u8], _dest: SocketAddr) {
     self.sent.push(bytes.to_vec());
   }
+
+  fn recv_capacity(&self) -> usize {
+    FAKE_RECV_CAPACITY
+  }
 }
 
 /// Drive `engine` until it emits at least one outbound gossip datagram (or the
@@ -66,8 +80,8 @@ fn capture_gossip(transform: TransformOptions) -> Vec<Vec<u8>> {
     .with_port(7946)
     .with_close_timeout(Duration::from_secs(10));
   let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new("test"), node_addr(7946));
-  let mut engine =
-    Engine::try_new_at(cfg, transform, ep_cfg, now, test_rng()).expect("valid configuration");
+  let mut engine = Engine::try_new_at(cfg, transform, ep_cfg, now, test_rng(), &NoGossip)
+    .expect("valid configuration");
   engine.start(now);
   // A peer to gossip TO, so `pump` emits at least one outbound gossip datagram.
   engine.inject_alive(SmolStr::new("peer"), node_addr(7947), now);
@@ -191,8 +205,15 @@ fn make_engine() -> Engine<SmolStr, u32> {
     .with_close_timeout(Duration::from_secs(10));
   let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new("test"), node_addr(7946));
   let now = Instant::from_origin(Duration::from_secs(86_400));
-  Engine::try_new_at(cfg, TransformOptions::default(), ep_cfg, now, test_rng())
-    .expect("valid configuration must construct without error")
+  Engine::try_new_at(
+    cfg,
+    TransformOptions::default(),
+    ep_cfg,
+    now,
+    test_rng(),
+    &NoGossip,
+  )
+  .expect("valid configuration must construct without error")
 }
 
 /// `set_compression_options` is accepted and the engine remains operational
@@ -267,9 +288,15 @@ fn cidr_policy_gates_membership_admission_by_advertised_address() {
     .with_cidr_policy(CidrPolicy::try_from(["10.0.0.0/8"].as_slice()).expect("valid cidr"));
   let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new("test"), node_addr(7946));
   let now = Instant::from_origin(Duration::from_secs(86_400));
-  let mut engine: Engine<SmolStr, u32> =
-    Engine::try_new_at(cfg, TransformOptions::default(), ep_cfg, now, test_rng())
-      .expect("construct");
+  let mut engine: Engine<SmolStr, u32> = Engine::try_new_at(
+    cfg,
+    TransformOptions::default(),
+    ep_cfg,
+    now,
+    test_rng(),
+    &NoGossip,
+  )
+  .expect("construct");
   engine.start(now);
 
   // Routable but outside 10.0.0.0/8 — rejected by the policy.
@@ -312,9 +339,15 @@ fn set_alive_delegate_preserves_the_cidr_policy() {
     .with_cidr_policy(CidrPolicy::try_from(["10.0.0.0/8"].as_slice()).expect("valid cidr"));
   let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new("test"), node_addr(7946));
   let now = Instant::from_origin(Duration::from_secs(86_400));
-  let mut engine: Engine<SmolStr, u32> =
-    Engine::try_new_at(cfg, TransformOptions::default(), ep_cfg, now, test_rng())
-      .expect("construct");
+  let mut engine: Engine<SmolStr, u32> = Engine::try_new_at(
+    cfg,
+    TransformOptions::default(),
+    ep_cfg,
+    now,
+    test_rng(),
+    &NoGossip,
+  )
+  .expect("construct");
   // An accept-all delegate installed AFTER the policy must not loosen it.
   engine.set_alive_delegate(AcceptAll);
   engine.start(now);
@@ -356,9 +389,15 @@ fn cidr_blocked_send_reliable_fails_not_succeeds() {
     .with_cidr_policy(CidrPolicy::try_from(["10.0.0.0/8"].as_slice()).expect("valid cidr"));
   let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new("test"), node_addr(7946));
   let now = Instant::from_origin(Duration::from_secs(86_400));
-  let mut engine: Engine<SmolStr, u32> =
-    Engine::try_new_at(cfg, TransformOptions::default(), ep_cfg, now, test_rng())
-      .expect("construct");
+  let mut engine: Engine<SmolStr, u32> = Engine::try_new_at(
+    cfg,
+    TransformOptions::default(),
+    ep_cfg,
+    now,
+    test_rng(),
+    &NoGossip,
+  )
+  .expect("construct");
 
   // Seed a reliable slot for the dial plus a listener slot, so the Connect drives
   // a real dial this tick rather than deferring to PendingDial.
@@ -412,9 +451,15 @@ fn rejected_inbound_accept_returns_its_slot_to_the_pool() {
   // node stays running, so `check_listener` always takes the `None` arm.
   let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new("test"), node_addr(7946))
     .with_max_inbound_streams(Some(0));
-  let mut engine: Engine<SmolStr, u32> =
-    Engine::try_new_at(cfg, TransformOptions::default(), ep_cfg, now, test_rng())
-      .expect("construct");
+  let mut engine: Engine<SmolStr, u32> = Engine::try_new_at(
+    cfg,
+    TransformOptions::default(),
+    ep_cfg,
+    now,
+    test_rng(),
+    &NoGossip,
+  )
+  .expect("construct");
 
   // Two free reliable slots plus a listener on a third: capacity is three.
   engine.plane_mut().pool.push(10);
@@ -451,9 +496,15 @@ fn cidr_blocked_unreliable_send_emits_no_datagram() {
     .with_cidr_policy(CidrPolicy::try_from(["10.0.0.0/8"].as_slice()).expect("valid cidr"));
   let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new("test"), node_addr(7946));
   let now = Instant::from_origin(Duration::from_secs(86_400));
-  let mut engine: Engine<SmolStr, u32> =
-    Engine::try_new_at(cfg, TransformOptions::default(), ep_cfg, now, test_rng())
-      .expect("construct");
+  let mut engine: Engine<SmolStr, u32> = Engine::try_new_at(
+    cfg,
+    TransformOptions::default(),
+    ep_cfg,
+    now,
+    test_rng(),
+    &NoGossip,
+  )
+  .expect("construct");
   engine.start(now);
   let mut stream = NoStream::with_pool(0);
 
@@ -747,7 +798,7 @@ fn try_new_at_accepts_disabled_checksum() {
   let transform = TransformOptions::default().with_checksum(ChecksumOptions::new());
 
   assert!(
-    Engine::<SmolStr, u32>::try_new_at(cfg, transform, ep_cfg, now, test_rng()).is_ok(),
+    Engine::<SmolStr, u32>::try_new_at(cfg, transform, ep_cfg, now, test_rng(), &NoGossip).is_ok(),
     "a disabled checksum policy must always construct"
   );
 }
@@ -757,13 +808,22 @@ struct QueueGossip {
   inbound: Vec<(SocketAddr, Vec<u8>)>,
   /// Outbound datagrams captured from `send`.
   outbound: Vec<(Vec<u8>, SocketAddr)>,
+  /// What [`GossipIo::recv_capacity`] declares. The `inbound` queue itself is
+  /// unbounded, so this is the ring size the fake CLAIMS — settable so a test can
+  /// present the engine with a capacity it must reject.
+  recv_capacity: usize,
 }
 
 impl QueueGossip {
   fn new() -> Self {
+    Self::with_recv_capacity(FAKE_RECV_CAPACITY)
+  }
+
+  fn with_recv_capacity(recv_capacity: usize) -> Self {
     Self {
       inbound: Vec::new(),
       outbound: Vec::new(),
+      recv_capacity,
     }
   }
 
@@ -785,6 +845,10 @@ impl GossipIo for QueueGossip {
 
   fn send(&mut self, bytes: &[u8], dest: SocketAddr) {
     self.outbound.push((bytes.to_vec(), dest));
+  }
+
+  fn recv_capacity(&self) -> usize {
+    self.recv_capacity
   }
 }
 
@@ -814,7 +878,7 @@ fn gossip_carries_and_checks_the_configured_label() {
     .with_label(Some(b"alpha".to_vec()))
     .expect("valid label");
   let mut engine =
-    Engine::try_new_at(cfg, transform, ep_cfg, now, test_rng()).expect("valid config");
+    Engine::try_new_at(cfg, transform, ep_cfg, now, test_rng(), &NoGossip).expect("valid config");
   engine.start(now);
 
   // ── Ingress: unlabeled datagram must be dropped. ─────────────────────────
@@ -1175,9 +1239,15 @@ fn engine_with_stream_timeout(stream_timeout: Duration) -> (Engine<SmolStr, u32>
     .with_close_timeout(Duration::from_secs(10));
   let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new("test"), node_addr(7946))
     .with_stream_timeout(stream_timeout);
-  let mut engine: Engine<SmolStr, u32> =
-    Engine::try_new_at(cfg, TransformOptions::default(), ep_cfg, now, test_rng())
-      .expect("construct");
+  let mut engine: Engine<SmolStr, u32> = Engine::try_new_at(
+    cfg,
+    TransformOptions::default(),
+    ep_cfg,
+    now,
+    test_rng(),
+    &NoGossip,
+  )
+  .expect("construct");
   engine.start(now);
   (engine, now)
 }
@@ -1968,6 +2038,10 @@ impl GossipIo for GossipWire {
   fn send(&mut self, bytes: &[u8], dest: SocketAddr) {
     self.outbound.borrow_mut().push((dest, bytes.to_vec()));
   }
+
+  fn recv_capacity(&self) -> usize {
+    FAKE_RECV_CAPACITY
+  }
 }
 
 /// A linked two-engine fixture sharing one reliable fabric and a cross-wired
@@ -2000,9 +2074,15 @@ impl LinkPair {
         .with_close_timeout(Duration::from_secs(10));
       let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new(id), addr)
         .with_stream_timeout(Duration::from_secs(5));
-      let mut e: Engine<SmolStr, u32> =
-        Engine::try_new_at(cfg, TransformOptions::default(), ep_cfg, now, test_rng())
-          .expect("construct");
+      let mut e: Engine<SmolStr, u32> = Engine::try_new_at(
+        cfg,
+        TransformOptions::default(),
+        ep_cfg,
+        now,
+        test_rng(),
+        &NoGossip,
+      )
+      .expect("construct");
       e.start(now);
       e
     };
@@ -2561,8 +2641,14 @@ fn new_at_builds_and_port_reads_back() {
     .with_close_timeout(Duration::from_secs(10));
   let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new("p"), node_addr(7946));
   let now = Instant::from_origin(Duration::from_secs(86_400));
-  let engine: Engine<SmolStr, u32> =
-    Engine::new_at(cfg, TransformOptions::default(), ep_cfg, now, test_rng());
+  let engine: Engine<SmolStr, u32> = Engine::new_at(
+    cfg,
+    TransformOptions::default(),
+    ep_cfg,
+    now,
+    test_rng(),
+    &NoGossip,
+  );
   assert_eq!(
     engine.port(),
     7946,
@@ -2595,7 +2681,8 @@ fn try_new_at_rejects_each_misconfiguration() {
         TransformOptions::default(),
         ep,
         now,
-        test_rng()
+        test_rng(),
+        &NoGossip
       ),
       Err(InitError::ZeroPort)
     ),
@@ -2614,7 +2701,8 @@ fn try_new_at_rejects_each_misconfiguration() {
         TransformOptions::default(),
         ep,
         now,
-        test_rng()
+        test_rng(),
+        &NoGossip
       ),
       Err(InitError::ZeroCloseTimeout)
     ),
@@ -2631,7 +2719,8 @@ fn try_new_at_rejects_each_misconfiguration() {
         TransformOptions::default(),
         ep,
         now,
-        test_rng()
+        test_rng(),
+        &NoGossip
       ),
       Err(InitError::GossipMtuTooLarge(_))
     ),
@@ -2650,7 +2739,8 @@ fn try_new_at_rejects_each_misconfiguration() {
         TransformOptions::default(),
         ep,
         now,
-        test_rng()
+        test_rng(),
+        &NoGossip
       ),
       Err(InitError::NonRoutableAdvertiseAddr(_))
     ),
@@ -2666,7 +2756,8 @@ fn try_new_at_rejects_each_misconfiguration() {
         TransformOptions::default(),
         ep,
         now,
-        test_rng()
+        test_rng(),
+        &NoGossip
       ),
       Err(InitError::AdvertisePortMismatch)
     ),
@@ -2688,8 +2779,8 @@ fn try_new_at_honors_skip_inbound_label_check() {
     .with_label(Some(b"cluster".to_vec()))
     .expect("valid label")
     .with_skip_inbound_label_check(true);
-  let mut engine =
-    Engine::try_new_at(cfg, transform, ep_cfg, now, test_rng()).expect("construct with skip-label");
+  let mut engine = Engine::try_new_at(cfg, transform, ep_cfg, now, test_rng(), &NoGossip)
+    .expect("construct with skip-label");
   engine.start(now);
   let mut gossip = NoGossip;
   let mut stream = NoStream::with_pool(2);
@@ -2715,9 +2806,15 @@ fn send_many_to_cidr_blocked_destination_emits_no_datagram() {
     .with_cidr_policy(CidrPolicy::try_from(["10.0.0.0/8"].as_slice()).expect("valid cidr"));
   let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new("c"), node_addr(7946));
   let now = Instant::from_origin(Duration::from_secs(86_400));
-  let mut engine: Engine<SmolStr, u32> =
-    Engine::try_new_at(cfg, TransformOptions::default(), ep_cfg, now, test_rng())
-      .expect("construct");
+  let mut engine: Engine<SmolStr, u32> = Engine::try_new_at(
+    cfg,
+    TransformOptions::default(),
+    ep_cfg,
+    now,
+    test_rng(),
+    &NoGossip,
+  )
+  .expect("construct");
   engine.start(now);
   let mut stream = NoStream::with_pool(0);
 
@@ -2893,9 +2990,15 @@ fn check_listener_rejects_cidr_blocked_inbound_and_rearms() {
     .with_close_timeout(Duration::from_secs(10))
     .with_cidr_policy(CidrPolicy::try_from(["10.0.0.0/8"].as_slice()).expect("valid cidr"));
   let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new("c"), node_addr(7946));
-  let mut engine: Engine<SmolStr, u32> =
-    Engine::try_new_at(cfg, TransformOptions::default(), ep_cfg, now, test_rng())
-      .expect("construct");
+  let mut engine: Engine<SmolStr, u32> = Engine::try_new_at(
+    cfg,
+    TransformOptions::default(),
+    ep_cfg,
+    now,
+    test_rng(),
+    &NoGossip,
+  )
+  .expect("construct");
   // A spare slot to re-arm the listener from after the reject.
   engine.plane_mut().pool.push(0);
   engine.set_listener(1);
@@ -3035,8 +3138,8 @@ fn encrypted_node_drops_plaintext_inbound_gossip() {
   let key = SecretKey::Aes256([0x11; 32]);
   let transform = TransformOptions::default()
     .with_encryption(EncryptionOptions::new().with_keyring(Keyring::new(key)));
-  let mut engine =
-    Engine::try_new_at(cfg, transform, ep_cfg, now, test_rng()).expect("construct encrypted");
+  let mut engine = Engine::try_new_at(cfg, transform, ep_cfg, now, test_rng(), &NoGossip)
+    .expect("construct encrypted");
   engine.start(now);
 
   // A perfectly valid PLAINTEXT Alive — but this node expects encrypted frames, so
@@ -3874,9 +3977,15 @@ fn arm_detection_probe_on_b_with(
 
   let ep_cfg = memberlist_proto::EndpointOptions::new(SmolStr::new("local"), node_addr(7946));
   let start = Instant::from_origin(Duration::from_secs(86_400));
-  let mut engine: Engine<SmolStr, u32> =
-    Engine::try_new_at(cfg, TransformOptions::default(), ep_cfg, start, test_rng())
-      .expect("valid configuration");
+  let mut engine: Engine<SmolStr, u32> = Engine::try_new_at(
+    cfg,
+    TransformOptions::default(),
+    ep_cfg,
+    start,
+    test_rng(),
+    &NoGossip,
+  )
+  .expect("valid configuration");
   engine.start(start);
   // A distinct, routable address so B is a separate member and the probe's direct
   // Ping is addressed to it.
@@ -4307,8 +4416,10 @@ fn early_rebalance_dial_rejection_cannot_sweep_before_this_pumps_gossip() {
 /// Below the read cap the ring is emptied and the pump folds no already-due wake.
 /// At exactly the cap the ring is also emptied and everything applied, but the
 /// engine cannot tell an exactly-emptied ring from one with more behind it without
-/// peeking, so it folds one spurious already-due wake — which is why both drivers
-/// require a ring STRICTLY below the cap.
+/// peeking, so it folds one spurious already-due wake — which is why construction
+/// requires a declared ring STRICTLY below the cap. The cap-sized case stays
+/// reachable here because the fake declares a conforming ring and is then handed
+/// that many datagrams.
 #[test]
 fn nothing_observed_is_pending_when_the_machine_ticks() {
   for ring in [1usize, 8, 16, GOSSIP_READ_CAP] {
@@ -4360,6 +4471,63 @@ fn nothing_observed_is_pending_when_the_machine_ticks() {
       );
     }
   }
+}
+
+/// An engine cannot be constructed over a gossip view whose declared receive ring
+/// reaches the per-pump read cap: `try_new_at` rejects it with the typed
+/// `GossipRecvCapacityTooLarge`, carrying the capacity the view declared. A ring
+/// one slot below the cap constructs.
+///
+/// This is what makes the over-cap ingress scenario unconstructible rather than
+/// merely discouraged. A 65-slot ring could hold 64 datagrams plus an Alive in slot
+/// 65; phase 2 stops at the cap, so that Alive would sit unread — unobserved and
+/// un-stamped — across the pump's membership sweep, and the suspicion timeout it
+/// refutes would fire in step 6 of that same pump, the refutation landing only at a
+/// later pump's instant. The screen is on the trait, so it binds every `GossipIo`,
+/// including one implemented outside this workspace.
+#[test]
+fn a_gossip_io_whose_ring_reaches_the_read_cap_cannot_construct_an_engine() {
+  let now = Instant::from_origin(Duration::from_secs(86_400));
+  let cfg = || {
+    Options::new()
+      .with_port(7946)
+      .with_close_timeout(Duration::from_secs(10))
+  };
+  let ep_cfg = || memberlist_proto::EndpointOptions::new(SmolStr::new("cap"), node_addr(7946));
+
+  // One slot over the cap, and the cap itself: the bound is strict.
+  for declared in [GOSSIP_READ_CAP + 1, GOSSIP_READ_CAP] {
+    let gossip = QueueGossip::with_recv_capacity(declared);
+    let rejected: Result<Engine<SmolStr, u32>, _> = Engine::try_new_at(
+      cfg(),
+      TransformOptions::default(),
+      ep_cfg(),
+      now,
+      test_rng(),
+      &gossip,
+    );
+    match rejected {
+      Err(InitError::GossipRecvCapacityTooLarge(n)) => assert_eq!(
+        n, declared,
+        "the rejection carries the capacity the view declared"
+      ),
+      Err(other) => panic!("a {declared}-slot ring must be rejected for its capacity, got {other}"),
+      Ok(_) => panic!("a {declared}-slot ring must not construct an engine"),
+    }
+  }
+
+  // The largest conforming ring still constructs a working single-node engine.
+  let gossip = QueueGossip::with_recv_capacity(GOSSIP_READ_CAP - 1);
+  let engine: Engine<SmolStr, u32> = Engine::try_new_at(
+    cfg(),
+    TransformOptions::default(),
+    ep_cfg(),
+    now,
+    test_rng(),
+    &gossip,
+  )
+  .expect("a ring one slot below the cap must construct");
+  assert_eq!(engine.num_members(), 1, "the constructed engine is usable");
 }
 
 /// Arm `engine` with a reliable listener on slot 1 and one spare (slot 0) to

--- a/memberlist-embedded/src/engine/tests.rs
+++ b/memberlist-embedded/src/engine/tests.rs
@@ -4064,16 +4064,16 @@ fn suspect_b(
   (t1, t1 + Duration::from_secs(4))
 }
 
-/// Queue `GOSSIP_READ_CAP - 1` undecodable datagrams and then `B`'s
+/// Fill the fake's declared ring with undecodable datagrams and then `B`'s
 /// `Alive(inc + 1)` refutation, so the refutation is the LAST datagram the pump's
-/// read cap admits.
+/// read bound admits.
 fn junk_then_b_refutation(
   engine: &Engine<SmolStr, u32>,
   gossip: &mut QueueGossip,
   b_addr: SocketAddr,
 ) {
   let junk_src = node_addr(7050);
-  for _ in 0..(GOSSIP_READ_CAP - 1) {
+  for _ in 0..FAKE_RECV_CAPACITY {
     gossip.push(junk_src, junk_datagram());
   }
   let inc = engine
@@ -4109,8 +4109,8 @@ fn assert_b_refuted(engine: &mut Engine<SmolStr, u32>) {
 /// `Alive(inc + 1)` for a `Suspect` B clears the suspicion outright. What decides
 /// the outcome is purely the order of the two within the pump: read-then-tick
 /// keeps B alive, tick-then-read kills it and immediately resurrects it. The
-/// refutation is placed LAST in the ring, behind a cap's worth of junk, so it is
-/// also the final datagram the read cap admits.
+/// refutation is placed LAST in the ring, behind a full ring of junk, so it is
+/// also the final datagram the read bound admits.
 #[test]
 fn same_pump_alive_refutation_precedes_the_tick() {
   let (mut engine, mut gossip, b_addr, f, _seq) = arm_detection_probe_on_b();
@@ -4197,29 +4197,93 @@ fn same_pump_reliable_fault_cannot_sweep_past_this_pumps_gossip() {
   assert_eq!(gossip.ring_len(), 0, "the whole ring was read this pump");
 }
 
-/// One pump reads at most `GOSSIP_READ_CAP` datagrams. The remainder stays in the
+/// The read bound is the PUMPED view's own declared capacity, never the capacity
+/// construction screened — and it holds in every build profile.
+///
+/// `try_new_at` sees one view; `pump` accepts a fresh view on every call, and only
+/// the driver can see the two diverge. Here the engine is built over a conforming
+/// 63-slot view and then pumped with a truthful 65-slot one whose last slot holds
+/// B's refutation, at an instant past B's suspicion deadline. A bound fixed at
+/// `GOSSIP_READ_CAP` would leave that datagram in the ring across step 6's sweep,
+/// so B would die and be resurrected by a later pump — a flap the immediate wake
+/// cannot undo. Deriving the bound from the view in hand applies it first instead,
+/// with no assertion for a release build to strip out.
+#[test]
+fn pumping_a_larger_truthful_view_than_constructed_with_still_applies_everything_before_the_sweep()
+{
+  let (mut engine, mut small, b_addr, f, _seq) = arm_detection_probe_on_b();
+  let mut stream = NoStream::with_pool(4);
+  let (_t1, s) = suspect_b(&mut engine, &mut small, &mut stream, f);
+
+  // A second, distinct view: 65 truthful slots — past the engine's cap, and larger
+  // than the 63-slot view construction screened. It arrives full: 64 junk
+  // datagrams, then B's own refutation in the last slot.
+  let over_cap = GOSSIP_READ_CAP + 1;
+  let mut big = QueueGossip::with_recv_capacity(over_cap);
+  let junk_src = node_addr(7050);
+  for _ in 0..(over_cap - 1) {
+    big.push(junk_src, junk_datagram());
+  }
+  let inc = engine
+    .endpoint
+    .endpoint_ref()
+    .node_incarnation(&SmolStr::new("b"))
+    .expect("B is a member");
+  big.push(b_addr, alive_datagram("b", b_addr, inc + 1));
+
+  let t = s + Duration::from_secs(1);
+  assert!(t > s, "this pump runs past B's suspicion deadline");
+  let wake = engine.pump(t, &mut big, &mut stream);
+
+  assert_b_refuted(&mut engine);
+  assert_eq!(
+    big.ring_len(),
+    0,
+    "the whole 65-slot ring is read within the pump that observed it"
+  );
+  assert_eq!(
+    engine.gossip_over_cap_pumps(),
+    1,
+    "the divergence from the screened view is surfaced, not silently trusted"
+  );
+  assert!(
+    wake > Some(t),
+    "a truthful ring, over-cap or not, is emptied and folds no already-due wake"
+  );
+}
+
+/// A view that delivers more datagrams than it declares is read to its declared
+/// capacity plus the one probe pop, and no further. The remainder stays in the
 /// driver's ring — not dropped, not copied into the engine — and is read on the
 /// next pump, which the returned already-due deadline asks for immediately.
+///
+/// Only an under-declaring (or mid-pump refilling) view can reach this: for a
+/// truthful one the declared capacity is the most the ring can hold, so the ring
+/// is always emptied within the pump.
 #[test]
-fn gossip_read_is_capped_per_pump_and_the_remainder_is_read_next_pump() {
+fn a_view_delivering_more_than_it_declares_is_read_to_its_bound_and_re_pumped() {
   let mut engine = make_engine();
   let t = Instant::from_origin(Duration::from_secs(86_400));
   engine.start(t);
-  let mut gossip = QueueGossip::new();
+  // The fake's queue is unbounded, so it can be handed more datagrams than the
+  // capacity it declares — the under-declaration the probe pop exists to catch.
+  let declared = FAKE_RECV_CAPACITY;
+  let bound = declared + 1;
+  let mut gossip = QueueGossip::with_recv_capacity(declared);
   let mut stream = NoStream::with_pool(2);
 
   // Settle the machine's own schedulers first, so the only already-due term the
-  // pump under test can return is the read cap's.
+  // pump under test can return is the gossip one.
   let quiescent = engine.pump(t, &mut gossip, &mut stream);
   assert!(
     quiescent > Some(t),
     "no machine timer may be due at this instant, or the wake assertion proves nothing"
   );
 
-  // `cap + k` distinct, valid Alives, each for its own id and address.
+  // `bound + k` distinct, valid Alives, each for its own id and address.
   let extra = 5usize;
   let src = node_addr(7050);
-  for i in 0..(GOSSIP_READ_CAP + extra) {
+  for i in 0..(bound + extra) {
     let addr = node_addr(8000 + i as u16);
     gossip.push(src, alive_datagram(&std::format!("n{i}"), addr, 1));
   }
@@ -4227,8 +4291,8 @@ fn gossip_read_is_capped_per_pump_and_the_remainder_is_read_next_pump() {
   let first = engine.pump(t, &mut gossip, &mut stream);
   assert_eq!(
     engine.num_members(),
-    1 + GOSSIP_READ_CAP,
-    "exactly one cap's worth of Alives is applied in the first pump"
+    1 + bound,
+    "the declared capacity plus the probe pop is applied in the first pump"
   );
   assert_eq!(
     gossip.ring_len(),
@@ -4238,45 +4302,174 @@ fn gossip_read_is_capped_per_pump_and_the_remainder_is_read_next_pump() {
   assert_eq!(
     first,
     Some(t),
-    "stopping at the cap folds an already-due wake so the caller polls again at once"
+    "the probe pop found a datagram past the declaration: fold an already-due wake so the caller \
+     polls again at once"
   );
   assert_eq!(
-    engine.gossip_read_cap_hits(),
-    1,
-    "the cap hit is counted exactly once"
+    engine.gossip_over_cap_pumps(),
+    0,
+    "the view declared a conforming capacity — it under-declared its occupancy, which is not an \
+     over-cap pump"
   );
 
   let second = engine.pump(t, &mut gossip, &mut stream);
   assert_eq!(
     engine.num_members(),
-    1 + GOSSIP_READ_CAP + extra,
+    1 + bound + extra,
     "the remainder is applied on the next pump"
   );
   assert_eq!(gossip.ring_len(), 0, "the ring is now empty");
   assert!(
     second > Some(t),
-    "a pump that emptied the ring folds no already-due wake"
+    "a pump whose probe pop found nothing folds no already-due wake"
   );
   assert_eq!(
-    engine.gossip_read_cap_hits(),
-    1,
-    "a pump that stopped short of the cap counts no hit"
+    engine.gossip_over_cap_pumps(),
+    0,
+    "still no over-cap pump: the declaration never reached the cap"
+  );
+}
+
+/// A conforming ring that is completely full is emptied within the pump and folds
+/// no already-due wake: the bound is the declared capacity plus one, so the probe
+/// pop past a full ring of capacity `C` finds nothing. This is the corner a bound
+/// fixed at the cap could not tell apart from a ring with more behind it, and it
+/// cost one spurious re-pump on every full read.
+#[test]
+fn a_full_conforming_ring_does_not_set_the_wake_term() {
+  let capacity = 8usize;
+  let mut engine = make_engine();
+  let t = Instant::from_origin(Duration::from_secs(86_400));
+  engine.start(t);
+  let mut gossip = QueueGossip::with_recv_capacity(capacity);
+  let mut stream = NoStream::with_pool(2);
+
+  // Settle the machine's own schedulers first, so the only already-due term the
+  // pump under test could return is the gossip one.
+  let quiescent = engine.pump(t, &mut gossip, &mut stream);
+  assert!(
+    quiescent > Some(t),
+    "no machine timer may be due at this instant, or the wake assertion proves nothing"
+  );
+
+  let src = node_addr(7050);
+  for i in 0..capacity {
+    let addr = node_addr(8000 + i as u16);
+    gossip.push(src, alive_datagram(&std::format!("n{i}"), addr, 1));
+  }
+
+  let wake = engine.pump(t, &mut gossip, &mut stream);
+  assert_eq!(
+    engine.num_members(),
+    1 + capacity,
+    "every datagram in the full ring is applied in the pump that popped it"
+  );
+  assert_eq!(gossip.ring_len(), 0, "the full ring is emptied");
+  assert!(
+    wake > Some(t),
+    "a full conforming ring asks for no immediate re-pump"
+  );
+  assert_eq!(
+    engine.gossip_over_cap_pumps(),
+    0,
+    "a conforming view is not an over-cap pump"
+  );
+}
+
+/// A [`GossipIo`] whose ring the link layer refills as fast as the engine reads
+/// it: every `recv` succeeds, so only the engine's own bound can end the loop.
+struct RefillGossip {
+  /// The ring size the link layer keeps topped up, as declared to the engine.
+  recv_capacity: usize,
+  /// `recv` calls served, so a test can pin the per-pump read bound exactly.
+  recv_calls: usize,
+}
+
+impl RefillGossip {
+  fn new(recv_capacity: usize) -> Self {
+    Self {
+      recv_capacity,
+      recv_calls: 0,
+    }
+  }
+}
+
+impl GossipIo for RefillGossip {
+  fn recv(&mut self, buf: &mut [u8]) -> Option<(SocketAddr, usize)> {
+    self.recv_calls += 1;
+    let bytes = junk_datagram();
+    let n = bytes.len().min(buf.len());
+    buf[..n].copy_from_slice(&bytes[..n]);
+    Some((node_addr(7050), n))
+  }
+
+  fn send(&mut self, _bytes: &[u8], _dest: SocketAddr) {}
+
+  fn recv_capacity(&self) -> usize {
+    self.recv_capacity
+  }
+}
+
+/// A ring that refills while the loop is reading it costs a bounded number of pops
+/// and sets the wake term.
+///
+/// The declared capacity is what a ring can hold between two pumps, so a datagram
+/// found past it means the link layer topped the ring up mid-pump (or the view
+/// under-declares itself). The engine takes exactly one pop past the declaration —
+/// enough to detect that and no more, so an unbounded arrival rate cannot
+/// monopolize a pump — and asks for an immediate re-pump instead.
+#[test]
+fn a_ring_that_refills_mid_pump_sets_the_wake_term() {
+  let capacity = 4usize;
+  let mut engine = make_engine();
+  let t = Instant::from_origin(Duration::from_secs(86_400));
+  engine.start(t);
+  let mut stream = NoStream::with_pool(2);
+
+  // Settle the machine's schedulers over an empty view — the refilling one can
+  // never report an idle ring — so the only already-due term the pump under test
+  // could return is the gossip one.
+  let quiescent = engine.pump(t, &mut NoGossip, &mut stream);
+  assert!(
+    quiescent > Some(t),
+    "no machine timer may be due at this instant, or the wake assertion proves nothing"
+  );
+
+  let mut gossip = RefillGossip::new(capacity);
+  let wake = engine.pump(t, &mut gossip, &mut stream);
+
+  assert_eq!(
+    gossip.recv_calls,
+    capacity + 1,
+    "an endlessly refilling ring is read to the declared capacity plus the probe pop, no further"
+  );
+  assert_eq!(
+    wake,
+    Some(t),
+    "a datagram past the declaration folds an already-due wake for the remainder"
+  );
+  assert_eq!(
+    engine.gossip_over_cap_pumps(),
+    0,
+    "the declared capacity is below the cap, so a refill is not an over-cap pump"
   );
 }
 
 /// The sweep is never withheld while gossip is outstanding: a pump that stops at
-/// the read cap still fires every timer due at its instant. A design that ticked
-/// only once nothing observed was pending would let a sustained flood silence the
-/// node's own failure detection.
+/// its gossip read bound still fires every timer due at its instant. A design that
+/// ticked only once nothing observed was pending would let a sustained flood
+/// silence the node's own failure detection.
 #[test]
-fn a_due_timer_fires_in_the_pump_that_hits_the_read_cap() {
+fn a_due_timer_fires_in_the_pump_that_stops_at_the_gossip_read_bound() {
   use memberlist_proto::typed::State;
 
   let (mut engine, mut gossip, _b_addr, f, _seq) = arm_detection_probe_on_b();
   let mut stream = NoStream::with_pool(4);
 
+  // More than the fake's declared capacity, so the pump under test cannot empty
+  // the ring and has gossip outstanding when the probe deadline falls due.
   let junk_src = node_addr(7050);
-  for _ in 0..(GOSSIP_READ_CAP + 5) {
+  for _ in 0..(FAKE_RECV_CAPACITY + 6) {
     gossip.push(junk_src, junk_datagram());
   }
 
@@ -4287,25 +4480,30 @@ fn a_due_timer_fires_in_the_pump_that_hits_the_read_cap() {
   assert_eq!(
     engine.num_members_by(|ns| ns.id_ref() == &SmolStr::new("b") && ns.state() == State::Suspect),
     1,
-    "the expired probe must suspect B in the very pump that hit the read cap"
+    "the expired probe must suspect B in the very pump that stopped at the read bound"
   );
   assert_eq!(
     wake,
     Some(t),
-    "the read cap folds an already-due wake for the datagrams still in the ring"
+    "the probe pop found more behind the declaration: fold an already-due wake for the datagrams \
+     still in the ring"
   );
-  assert_eq!(engine.gossip_read_cap_hits(), 1, "one cap hit is counted");
+  assert_eq!(
+    engine.gossip_over_cap_pumps(),
+    0,
+    "the fake declares a conforming capacity, so no over-cap pump is counted"
+  );
   assert_eq!(
     gossip.ring_len(),
     5,
-    "the pump read exactly the cap and left the rest in the ring"
+    "the pump read exactly the declared capacity plus the probe pop and left the rest in the ring"
   );
 }
 
 /// After `leave` the engine still POPS gossip — the ring is the driver's and would
 /// otherwise back up — but it decodes none of it, changes no membership, and never
-/// asks to be re-pumped. The pop stays bounded by the read cap, so a flood aimed at
-/// a node that has left costs at most a cap's worth of memcpys per pump.
+/// asks to be re-pumped. The pop stays bounded by the pumped view's read bound, so
+/// a flood aimed at a node that has left costs at most that many memcpys per pump.
 #[test]
 fn post_leave_gossip_is_popped_not_decoded_and_never_wakes() {
   let mut engine = make_engine();
@@ -4318,7 +4516,7 @@ fn post_leave_gossip_is_popped_not_decoded_and_never_wakes() {
   let members_before = engine.num_members();
   let extra = 8usize;
   let src = node_addr(7050);
-  for i in 0..(GOSSIP_READ_CAP + extra) {
+  for i in 0..(FAKE_RECV_CAPACITY + 1 + extra) {
     let addr = node_addr(8000 + i as u16);
     gossip.push(src, alive_datagram(&std::format!("n{i}"), addr, 1));
   }
@@ -4332,12 +4530,12 @@ fn post_leave_gossip_is_popped_not_decoded_and_never_wakes() {
   assert_eq!(
     gossip.ring_len(),
     extra,
-    "the post-leave pop is bounded by the read cap, not run to exhaustion"
+    "the post-leave pop is bounded by the view's read bound, not run to exhaustion"
   );
   assert_eq!(
-    engine.gossip_read_cap_hits(),
+    engine.gossip_over_cap_pumps(),
     0,
-    "a left node counts no cap hit — the wake term it feeds is gated on running"
+    "the fake declares a conforming capacity, so no over-cap pump is counted"
   );
   assert_ne!(
     wake,
@@ -4411,22 +4609,22 @@ fn early_rebalance_dial_rejection_cannot_sweep_before_this_pumps_gossip() {
 }
 
 /// Nothing the engine observed is still pending when the machine ticks, at every
-/// ring size a driver can present.
+/// ring size a driver can present — and no size costs a spurious wake.
 ///
-/// Below the read cap the ring is emptied and the pump folds no already-due wake.
-/// At exactly the cap the ring is also emptied and everything applied, but the
-/// engine cannot tell an exactly-emptied ring from one with more behind it without
-/// peeking, so it folds one spurious already-due wake — which is why construction
-/// requires a declared ring STRICTLY below the cap. The cap-sized case stays
-/// reachable here because the fake declares a conforming ring and is then handed
-/// that many datagrams.
+/// Each view here is TRUTHFUL: it declares the ring size it is then handed, which
+/// is the most a real ring of that size could hold. The pump's bound is that
+/// declaration plus one, so the ring is always emptied and the probe pop always
+/// comes back empty, whatever the size. Even a full ring at the cap — the corner
+/// that used to cost one spurious re-pump — folds no already-due wake now; it is
+/// only counted as the over-cap pump it is, since construction would have rejected
+/// that view.
 #[test]
 fn nothing_observed_is_pending_when_the_machine_ticks() {
-  for ring in [1usize, 8, 16, GOSSIP_READ_CAP] {
+  for ring in [1usize, 8, 16, GOSSIP_READ_CAP - 1, GOSSIP_READ_CAP] {
     let mut engine = make_engine();
     let t = Instant::from_origin(Duration::from_secs(86_400));
     engine.start(t);
-    let mut gossip = QueueGossip::new();
+    let mut gossip = QueueGossip::with_recv_capacity(ring);
     let mut stream = NoStream::with_pool(2);
 
     let quiescent = engine.pump(t, &mut gossip, &mut stream);
@@ -4448,28 +4646,22 @@ fn nothing_observed_is_pending_when_the_machine_ticks() {
       1 + ring,
       "ring {ring}: every datagram read was applied in that same pump"
     );
-    if ring < GOSSIP_READ_CAP {
-      assert!(
-        wake > Some(t),
-        "ring {ring}: a conforming ring folds no already-due wake"
-      );
-      assert_eq!(
-        engine.gossip_read_cap_hits(),
-        0,
-        "ring {ring}: a conforming ring never reaches the cap"
-      );
-    } else {
-      assert_eq!(
-        wake,
-        Some(t),
-        "ring {ring}: a ring exactly at the cap costs one spurious re-pump"
-      );
-      assert_eq!(
-        engine.gossip_read_cap_hits(),
-        1,
-        "ring {ring}: the exactly-full ring is indistinguishable from an over-cap one"
-      );
-    }
+    assert!(
+      wake > Some(t),
+      "ring {ring}: a truthful ring is emptied, so no already-due wake is folded"
+    );
+    // The settle pump above and the pump under test both ran over this view, and
+    // the counter counts PUMPS over an over-cap view, not distinct views.
+    let pumps_over_this_view = 2;
+    assert_eq!(
+      engine.gossip_over_cap_pumps(),
+      if ring >= GOSSIP_READ_CAP {
+        pumps_over_this_view
+      } else {
+        0
+      },
+      "ring {ring}: every pump over an over-cap view is counted, and a conforming one never is"
+    );
   }
 }
 
@@ -4478,12 +4670,11 @@ fn nothing_observed_is_pending_when_the_machine_ticks() {
 /// `GossipRecvCapacityTooLarge`, carrying the capacity the view declared. A ring
 /// one slot below the cap constructs.
 ///
-/// This is what makes the over-cap ingress scenario unconstructible rather than
-/// merely discouraged. A 65-slot ring could hold 64 datagrams plus an Alive in slot
-/// 65; phase 2 stops at the cap, so that Alive would sit unread — unobserved and
-/// un-stamped — across the pump's membership sweep, and the suspicion timeout it
-/// refutes would fire in step 6 of that same pump, the refutation landing only at a
-/// later pump's instant. The screen is on the trait, so it binds every `GossipIo`,
+/// What the screen enforces is the per-pump WORK CEILING, not the correctness
+/// bound: phase 2 reads to whatever capacity the pumped view declares, so a
+/// 65-slot ring is emptied ahead of that pump's sweep either way. Capping the ring
+/// a driver may present is what keeps the unwrap/decode/apply a single pump can be
+/// made to do bounded. The screen sits on the trait, so it binds every `GossipIo`,
 /// including one implemented outside this workspace.
 #[test]
 fn a_gossip_io_whose_ring_reaches_the_read_cap_cannot_construct_an_engine() {

--- a/memberlist-embedded/src/error/mod.rs
+++ b/memberlist-embedded/src/error/mod.rs
@@ -59,20 +59,17 @@ pub enum InitError {
   /// and the effective ceiling are carried for diagnostics.
   GossipMtuTooLarge(GossipMtuTooLarge),
   /// The driver's gossip receive ring
-  /// ([`GossipIo::recv_capacity`](crate::GossipIo::recv_capacity)) can hold at
-  /// least as many datagrams as the engine reads per pump
+  /// ([`GossipIo::recv_capacity`](crate::GossipIo::recv_capacity)) reaches the
+  /// engine's per-pump work ceiling
   /// ([`GOSSIP_READ_CAP`](crate::GOSSIP_READ_CAP)).
   ///
-  /// The engine reads at most that many datagrams from the ring per pump and
-  /// applies every one of them at that pump's instant. A ring able to hold as many
-  /// as the cap or more leaves the excess sitting unread — so unobserved and
-  /// un-stamped — across the pump's membership sweep, to be applied only at a later
-  /// pump's instant: a refutation waiting in the ring could then be applied only
-  /// after the timer it refutes had fired. The bound is strict rather than
-  /// inclusive because a ring exactly at the cap that happens to be full is
-  /// indistinguishable from an over-cap one without peeking, so it would cost one
-  /// spurious re-pump on every full read. The capacity reported is carried for
-  /// diagnostics.
+  /// A pump reads the whole ring the view declares and applies every datagram at
+  /// that pump's instant, so the accepted ring size IS the per-pump unwrap, decode
+  /// and apply budget: a ring at or above the cap would let a driver raise that
+  /// budget without limit. The bound is strict rather than inclusive because a pump
+  /// takes one probe pop past the declared capacity to detect a ring refilling
+  /// under it, so only a ring below the cap keeps a pump's reads at or under it.
+  /// The capacity reported is carried for diagnostics.
   GossipRecvCapacityTooLarge(usize),
   /// The SWIM machine endpoint failed to initialize.
   Endpoint(EndpointInitError),

--- a/memberlist-embedded/src/error/mod.rs
+++ b/memberlist-embedded/src/error/mod.rs
@@ -58,6 +58,22 @@ pub enum InitError {
   /// and the unchecked arena arithmetic would overflow. The configured value
   /// and the effective ceiling are carried for diagnostics.
   GossipMtuTooLarge(GossipMtuTooLarge),
+  /// The driver's gossip receive ring
+  /// ([`GossipIo::recv_capacity`](crate::GossipIo::recv_capacity)) can hold at
+  /// least as many datagrams as the engine reads per pump
+  /// ([`GOSSIP_READ_CAP`](crate::GOSSIP_READ_CAP)).
+  ///
+  /// The engine reads at most that many datagrams from the ring per pump and
+  /// applies every one of them at that pump's instant. A ring able to hold as many
+  /// as the cap or more leaves the excess sitting unread — so unobserved and
+  /// un-stamped — across the pump's membership sweep, to be applied only at a later
+  /// pump's instant: a refutation waiting in the ring could then be applied only
+  /// after the timer it refutes had fired. The bound is strict rather than
+  /// inclusive because a ring exactly at the cap that happens to be full is
+  /// indistinguishable from an over-cap one without peeking, so it would cost one
+  /// spurious re-pump on every full read. The capacity reported is carried for
+  /// diagnostics.
+  GossipRecvCapacityTooLarge(usize),
   /// The SWIM machine endpoint failed to initialize.
   Endpoint(EndpointInitError),
   /// The configured encryption keyring cannot be used by this build.
@@ -140,6 +156,12 @@ impl fmt::Display for InitError {
       InitError::ZeroPort => f.write_str("port is zero"),
       InitError::ZeroCloseTimeout => f.write_str("close_timeout must be non-zero"),
       InitError::GossipMtuTooLarge(m) => write!(f, "{m}"),
+      InitError::GossipRecvCapacityTooLarge(n) => write!(
+        f,
+        "the gossip receive ring holds {n} datagrams, which must be below the engine's \
+         per-pump gossip read cap ({})",
+        crate::GOSSIP_READ_CAP
+      ),
       InitError::Endpoint(e) => write!(f, "SWIM endpoint initialization failed: {e}"),
       #[cfg(encryption)]
       InitError::Encryption(e) => write!(f, "encryption configuration is unusable: {e}"),

--- a/memberlist-embedded/src/error/tests.rs
+++ b/memberlist-embedded/src/error/tests.rs
@@ -7,7 +7,7 @@ use super::{GossipMtuTooLarge, InitError};
 fn every_init_error_variant_displays_and_reports_its_source() {
   let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
   // (variant, whether `source()` should be `Some`).
-  let cases: [(InitError, bool); 8] = [
+  let cases: [(InitError, bool); 9] = [
     (InitError::NonRoutableAdvertiseAddr(addr), false),
     (InitError::AdvertisePortMismatch, false),
     (InitError::ZeroPort, false),
@@ -17,6 +17,10 @@ fn every_init_error_variant_displays_and_reports_its_source() {
         gossip_mtu: 70_000,
         ceiling: 65_000,
       }),
+      false,
+    ),
+    (
+      InitError::GossipRecvCapacityTooLarge(crate::GOSSIP_READ_CAP),
       false,
     ),
     (

--- a/memberlist-embedded/src/gossip_io.rs
+++ b/memberlist-embedded/src/gossip_io.rs
@@ -6,17 +6,39 @@ use core::net::SocketAddr;
 ///
 /// A driver supplies this over its already-ticked UDP socket buffers; the
 /// engine reads inbound gossip and writes outbound gossip through it without
-/// knowing the underlying stack. Both methods are non-blocking: they move at
+/// knowing the underlying stack. Both I/O methods are non-blocking: they move at
 /// most one datagram against buffers the driver's stack tick has already
-/// filled or drained.
+/// filled or drained. [`recv_capacity`](Self::recv_capacity) performs no I/O; it
+/// declares the receive ring the engine validates against its per-pump read cap.
 pub trait GossipIo {
   /// Pop one received datagram into `buf`; `(source, len)` or `None` when the rx ring is empty.
   ///
-  /// The ring must be FIFO, and it should hold fewer datagrams than the engine
-  /// reads per pump: an engine built on this trait bounds its per-pump reads, so a
-  /// larger ring leaves the excess un-stamped across a pump (see the engine's
-  /// `pump` for its cap).
+  /// The ring must be FIFO: an engine reads it in arrival order and stamps each
+  /// datagram with the instant it was popped, so a reordering ring would hand the
+  /// machine evidence out of the order the wire delivered it.
   fn recv(&mut self, buf: &mut [u8]) -> Option<(SocketAddr, usize)>;
+
+  /// The maximum number of datagrams the receive ring can hold between two engine
+  /// pumps.
+  ///
+  /// This is the ring's capacity, not its current occupancy — the number of
+  /// datagrams the link layer could leave waiting for [`recv`](Self::recv) while
+  /// the engine is away.
+  ///
+  /// An engine built on this trait reads a bounded number of datagrams per pump
+  /// and applies every one of them at that pump's instant. It therefore validates
+  /// this capacity against its own per-pump read cap when it is constructed and
+  /// rejects a ring that can hold as many datagrams as the cap or more: the excess
+  /// would sit in the ring unread — so unobserved and un-stamped — across a pump's
+  /// membership sweep, and a refutation waiting there could be applied only after
+  /// the timer it refutes had already fired. See
+  /// [`GOSSIP_READ_CAP`](crate::GOSSIP_READ_CAP) and
+  /// [`Engine::try_new_at`](crate::Engine::try_new_at).
+  ///
+  /// Report the ring the engine will actually read from — the bound socket's own
+  /// capacity wherever the stack exposes it — so the declared value cannot drift
+  /// from the buffer the driver installed.
+  fn recv_capacity(&self) -> usize;
 
   /// Best-effort enqueue of one datagram to `dest`. Gossip is lossy: drop on a full tx ring.
   fn send(&mut self, bytes: &[u8], dest: SocketAddr);

--- a/memberlist-embedded/src/gossip_io.rs
+++ b/memberlist-embedded/src/gossip_io.rs
@@ -11,6 +11,11 @@ use core::net::SocketAddr;
 /// filled or drained.
 pub trait GossipIo {
   /// Pop one received datagram into `buf`; `(source, len)` or `None` when the rx ring is empty.
+  ///
+  /// The ring must be FIFO, and it should hold fewer datagrams than the engine
+  /// reads per pump: an engine built on this trait bounds its per-pump reads, so a
+  /// larger ring leaves the excess un-stamped across a pump (see the engine's
+  /// `pump` for its cap).
   fn recv(&mut self, buf: &mut [u8]) -> Option<(SocketAddr, usize)>;
 
   /// Best-effort enqueue of one datagram to `dest`. Gossip is lossy: drop on a full tx ring.

--- a/memberlist-embedded/src/gossip_io.rs
+++ b/memberlist-embedded/src/gossip_io.rs
@@ -9,7 +9,8 @@ use core::net::SocketAddr;
 /// knowing the underlying stack. Both I/O methods are non-blocking: they move at
 /// most one datagram against buffers the driver's stack tick has already
 /// filled or drained. [`recv_capacity`](Self::recv_capacity) performs no I/O; it
-/// declares the receive ring the engine validates against its per-pump read cap.
+/// declares the receive ring, from which the engine derives how much of it to
+/// read per pump and which it screens against its per-pump work ceiling.
 pub trait GossipIo {
   /// Pop one received datagram into `buf`; `(source, len)` or `None` when the rx ring is empty.
   ///
@@ -25,19 +26,23 @@ pub trait GossipIo {
   /// datagrams the link layer could leave waiting for [`recv`](Self::recv) while
   /// the engine is away.
   ///
-  /// An engine built on this trait reads a bounded number of datagrams per pump
-  /// and applies every one of them at that pump's instant. It therefore validates
-  /// this capacity against its own per-pump read cap when it is constructed and
-  /// rejects a ring that can hold as many datagrams as the cap or more: the excess
-  /// would sit in the ring unread — so unobserved and un-stamped — across a pump's
-  /// membership sweep, and a refutation waiting there could be applied only after
-  /// the timer it refutes had already fired. See
-  /// [`GOSSIP_READ_CAP`](crate::GOSSIP_READ_CAP) and
-  /// [`Engine::try_new_at`](crate::Engine::try_new_at).
+  /// It must be the TRUE capacity of the ring `recv` pops from, for the view being
+  /// pumped. An engine built on this trait derives each pump's read bound from
+  /// this number, so that every datagram the ring held when the pump began is
+  /// popped and applied at that pump's instant, before any membership sweep. A
+  /// stale or wrong declaration is the one thing no engine can defend against: an
+  /// under-declared ring leaves the excess sitting unread — so unobserved and
+  /// un-stamped — across the sweep, and a refutation waiting there could be applied
+  /// only after the timer it refutes had already fired. Report the ring the engine
+  /// will actually read from — the bound socket's own capacity wherever the stack
+  /// exposes it — so the declared value cannot drift from the buffer the driver
+  /// installed, and re-declare it if the ring is ever resized.
   ///
-  /// Report the ring the engine will actually read from — the bound socket's own
-  /// capacity wherever the stack exposes it — so the declared value cannot drift
-  /// from the buffer the driver installed.
+  /// The engine additionally screens this capacity at construction against its own
+  /// per-pump work ceiling and rejects a ring that can hold as many datagrams as
+  /// the ceiling or more, which is what bounds the decode work one pump can cost.
+  /// See [`GOSSIP_READ_CAP`](crate::GOSSIP_READ_CAP) and
+  /// [`Engine::try_new_at`](crate::Engine::try_new_at).
   fn recv_capacity(&self) -> usize;
 
   /// Best-effort enqueue of one datagram to `dest`. Gossip is lossy: drop on a full tx ring.

--- a/memberlist-embedded/src/lib.rs
+++ b/memberlist-embedded/src/lib.rs
@@ -35,7 +35,7 @@ pub mod transform;
 
 pub use addr::socket_addr_is_routable;
 pub use config::{DEFAULT_CLOSE_TIMEOUT, Options};
-pub use engine::{Engine, validate_runtime_config};
+pub use engine::{Engine, GOSSIP_READ_CAP, validate_runtime_config};
 #[cfg(encryption)]
 #[cfg_attr(
   docsrs,

--- a/memberlist-smoltcp/src/config/mod.rs
+++ b/memberlist-smoltcp/src/config/mod.rs
@@ -33,9 +33,10 @@ pub struct Options {
   /// UDP rx datagram metadata slots.
   ///
   /// Must be strictly below the engine's per-pump gossip read cap
-  /// ([`memberlist_embedded::GOSSIP_READ_CAP`]), which construction enforces: the
-  /// engine applies at most that many datagrams per pump, so a larger ring leaves
-  /// the excess unread across a pump's membership sweep.
+  /// ([`memberlist_embedded::GOSSIP_READ_CAP`]), which construction enforces —
+  /// here, before the UDP arenas this count sizes are allocated, and again in the
+  /// engine against the bound socket. The engine applies every datagram it pops
+  /// within that pump, so this count is the per-pump gossip work budget.
   pub udp_rx_packets: usize,
   /// UDP tx datagram metadata slots.
   pub udp_tx_packets: usize,

--- a/memberlist-smoltcp/src/config/mod.rs
+++ b/memberlist-smoltcp/src/config/mod.rs
@@ -31,6 +31,11 @@ pub struct Options {
   /// Per-TCP-socket tx ring bytes.
   pub tcp_socket_tx_bytes: usize,
   /// UDP rx datagram metadata slots.
+  ///
+  /// Must be strictly below the engine's per-pump gossip read cap
+  /// ([`memberlist_embedded::GOSSIP_READ_CAP`]), which construction enforces: the
+  /// engine applies at most that many datagrams per pump, so a larger ring leaves
+  /// the excess unread across a pump's membership sweep.
   pub udp_rx_packets: usize,
   /// UDP tx datagram metadata slots.
   pub udp_tx_packets: usize,

--- a/memberlist-smoltcp/src/error/mod.rs
+++ b/memberlist-smoltcp/src/error/mod.rs
@@ -214,6 +214,18 @@ pub enum InitError {
   /// so gossip can never be received (or sent): a silently-dead gossip plane.
   /// Both must be non-zero.
   ZeroUdpPackets,
+  /// [`Options::udp_rx_packets`](crate::Options::udp_rx_packets) is not below the
+  /// engine's per-pump gossip read cap
+  /// ([`memberlist_embedded::GOSSIP_READ_CAP`]).
+  ///
+  /// The engine reads at most that many datagrams from this ring per pump and
+  /// applies every one of them at that pump's instant. A ring able to hold as many
+  /// as the cap or more leaves the excess sitting unread — so unobserved and
+  /// un-stamped — across the pump's membership sweep, to be applied only at a later
+  /// pump's instant. The bound is strict rather than inclusive because a ring
+  /// exactly at the cap that happens to be full is indistinguishable from an
+  /// over-cap one, and would cost one spurious re-poll.
+  UdpRxPacketsTooLarge,
   /// [`Options::close_timeout`](crate::Options::close_timeout) is zero.
   ///
   /// `close_timeout` bounds the graceful reliable-close drain: a connection
@@ -334,6 +346,11 @@ impl fmt::Display for InitError {
       InitError::ZeroUdpPackets => {
         f.write_str("udp_rx_packets and udp_tx_packets must be non-zero")
       }
+      InitError::UdpRxPacketsTooLarge => write!(
+        f,
+        "udp_rx_packets must be below the engine's per-pump gossip read cap ({})",
+        memberlist_embedded::GOSSIP_READ_CAP
+      ),
       InitError::ZeroCloseTimeout => f.write_str("close_timeout must be non-zero"),
     }
   }

--- a/memberlist-smoltcp/src/error/mod.rs
+++ b/memberlist-smoltcp/src/error/mod.rs
@@ -218,13 +218,16 @@ pub enum InitError {
   /// engine's per-pump gossip read cap
   /// ([`memberlist_embedded::GOSSIP_READ_CAP`]).
   ///
-  /// The engine reads at most that many datagrams from this ring per pump and
-  /// applies every one of them at that pump's instant. A ring able to hold as many
-  /// as the cap or more leaves the excess sitting unread — so unobserved and
-  /// un-stamped — across the pump's membership sweep, to be applied only at a later
-  /// pump's instant. The bound is strict rather than inclusive because a ring
-  /// exactly at the cap that happens to be full is indistinguishable from an
-  /// over-cap one, and would cost one spurious re-poll.
+  /// This is the engine's own rejection of the bound gossip socket's receive ring
+  /// ([`memberlist_embedded::InitError::GossipRecvCapacityTooLarge`]), surfaced
+  /// under the name of the option that sizes it. The engine reads at most
+  /// `GOSSIP_READ_CAP` datagrams from the ring per pump and applies every one of
+  /// them at that pump's instant. A ring able to hold as many as the cap or more
+  /// leaves the excess sitting unread — so unobserved and un-stamped — across the
+  /// pump's membership sweep, to be applied only at a later pump's instant. The
+  /// bound is strict rather than inclusive because a ring exactly at the cap that
+  /// happens to be full is indistinguishable from an over-cap one, and would cost
+  /// one spurious re-poll.
   UdpRxPacketsTooLarge,
   /// [`Options::close_timeout`](crate::Options::close_timeout) is zero.
   ///
@@ -362,9 +365,12 @@ impl InitError {
   ///
   /// The driver pre-validates the port, gossip MTU, close timeout, and advertise
   /// address before building the engine, so in practice the engine fails only with
-  /// [`Endpoint`](memberlist_embedded::InitError::Endpoint) (machine init) or
+  /// [`Endpoint`](memberlist_embedded::InitError::Endpoint) (machine init),
   /// [`Encryption`](memberlist_embedded::InitError::Encryption) (an unusable
-  /// keyring). The remaining variants are mapped to their driver equivalents
+  /// keyring), or
+  /// [`GossipRecvCapacityTooLarge`](memberlist_embedded::InitError::GossipRecvCapacityTooLarge)
+  /// (an over-cap gossip receive ring, which only the engine screens). The
+  /// remaining variants are mapped to their driver equivalents
   /// anyway so the conversion is total and stays correct if the driver's
   /// pre-checks are ever reordered or relaxed.
   pub(crate) fn from_embedded(e: memberlist_embedded::InitError) -> Self {
@@ -378,6 +384,10 @@ impl InitError {
         gossip_mtu: m.gossip_mtu,
         ceiling: m.ceiling,
       }),
+      // The engine screens the bound gossip socket's receive ring; the driver sizes
+      // that ring from `udp_rx_packets` alone, so the rejection is reported under
+      // the name of the knob the caller must lower.
+      E::GossipRecvCapacityTooLarge(_) => InitError::UdpRxPacketsTooLarge,
       E::Endpoint(inner) => InitError::Endpoint(inner),
       #[cfg(encryption)]
       E::Encryption(inner) => InitError::Encryption(inner),

--- a/memberlist-smoltcp/src/error/mod.rs
+++ b/memberlist-smoltcp/src/error/mod.rs
@@ -218,16 +218,18 @@ pub enum InitError {
   /// engine's per-pump gossip read cap
   /// ([`memberlist_embedded::GOSSIP_READ_CAP`]).
   ///
-  /// This is the engine's own rejection of the bound gossip socket's receive ring
-  /// ([`memberlist_embedded::InitError::GossipRecvCapacityTooLarge`]), surfaced
-  /// under the name of the option that sizes it. The engine reads at most
-  /// `GOSSIP_READ_CAP` datagrams from the ring per pump and applies every one of
-  /// them at that pump's instant. A ring able to hold as many as the cap or more
-  /// leaves the excess sitting unread — so unobserved and un-stamped — across the
-  /// pump's membership sweep, to be applied only at a later pump's instant. The
-  /// bound is strict rather than inclusive because a ring exactly at the cap that
-  /// happens to be full is indistinguishable from an over-cap one, and would cost
-  /// one spurious re-poll.
+  /// The cap is the engine's per-pump work ceiling: it applies every datagram it
+  /// pops within the pump that popped it, so the accepted ring size is that pump's
+  /// unwrap, decode and apply budget. The bound is strict rather than inclusive
+  /// because a pump takes one probe pop past the ring's declared capacity to detect
+  /// a ring refilling under it.
+  ///
+  /// The driver screens `udp_rx_packets` before it sizes and allocates the UDP
+  /// arenas, so a count large enough to exhaust memory is a returned error rather
+  /// than an allocation. The engine raises the same verdict against the bound
+  /// socket's actual receive ring
+  /// ([`memberlist_embedded::InitError::GossipRecvCapacityTooLarge`]), which this
+  /// variant also carries — surfaced under the name of the option to lower.
   UdpRxPacketsTooLarge,
   /// [`Options::close_timeout`](crate::Options::close_timeout) is zero.
   ///
@@ -384,9 +386,11 @@ impl InitError {
         gossip_mtu: m.gossip_mtu,
         ceiling: m.ceiling,
       }),
-      // The engine screens the bound gossip socket's receive ring; the driver sizes
-      // that ring from `udp_rx_packets` alone, so the rejection is reported under
-      // the name of the knob the caller must lower.
+      // The engine screens the bound gossip socket's receive ring (the driver's own
+      // pre-allocation screen of `udp_rx_packets` runs first, so this arm covers a
+      // socket whose installed capacity differs from the count it was sized from);
+      // either way the driver sizes that ring from `udp_rx_packets` alone, so the
+      // rejection is reported under the name of the knob the caller must lower.
       E::GossipRecvCapacityTooLarge(_) => InitError::UdpRxPacketsTooLarge,
       E::Endpoint(inner) => InitError::Endpoint(inner),
       #[cfg(encryption)]

--- a/memberlist-smoltcp/src/error/tests.rs
+++ b/memberlist-smoltcp/src/error/tests.rs
@@ -56,6 +56,7 @@ fn all_variants() -> Vec<InitError> {
     InitError::ZeroTcpSocketBuffer,
     InitError::TcpRxBufferTooLarge,
     InitError::ZeroUdpPackets,
+    InitError::UdpRxPacketsTooLarge,
     InitError::ZeroCloseTimeout,
   ]
 }

--- a/memberlist-smoltcp/src/gossip_io.rs
+++ b/memberlist-smoltcp/src/gossip_io.rs
@@ -71,4 +71,17 @@ impl GossipIo for SmoltcpGossip<'_, '_> {
     // this datagram and SWIM recovers on the next gossip round.
     let _ = sock.send_slice(bytes, to_endpoint(dest));
   }
+
+  fn recv_capacity(&self) -> usize {
+    // The bound socket's own metadata-slot count, not the configured
+    // `udp_rx_packets` it was built from: reading the ring the engine will
+    // actually drain leaves no way for the declared capacity to drift from the
+    // buffer installed. A shared borrow suffices and is released here, so it
+    // never overlaps the `borrow_mut` the I/O methods take.
+    self
+      .sockets
+      .borrow()
+      .get::<udp::Socket>(self.udp)
+      .packet_recv_capacity()
+  }
 }

--- a/memberlist-smoltcp/src/lib.rs
+++ b/memberlist-smoltcp/src/lib.rs
@@ -35,8 +35,8 @@ pub use resolver::{Resolver, SocketAddrResolver};
 // and its bound are the return type a custom `Resolver` must produce, so they are
 // part of this crate's public resolver API.
 pub use memberlist_embedded::{
-  AliveDelegate, MAX_RESOLVED_ADDRS_PER_SEED, MaybeOwned, MaybeResolved, MergeDelegate,
-  ResolvedAddrs,
+  AliveDelegate, GOSSIP_READ_CAP, MAX_RESOLVED_ADDRS_PER_SEED, MaybeOwned, MaybeResolved,
+  MergeDelegate, ResolvedAddrs,
 };
 // `ControlError` is the encryption key-rotation error; it exists in the shared
 // core only when an encryption backend is built in.

--- a/memberlist-smoltcp/src/memberlist/mod.rs
+++ b/memberlist-smoltcp/src/memberlist/mod.rs
@@ -491,17 +491,6 @@ where
       return Err(InitError::ZeroUdpPackets);
     }
 
-    // Keep the gossip rx ring strictly below the engine's per-pump read cap. The
-    // engine reads at most `GOSSIP_READ_CAP` datagrams per pump and applies every
-    // one at that pump's instant; a ring that can hold as many or more would leave
-    // the excess unread across the pump's membership sweep, so a refutation already
-    // sitting in the ring could be applied only after the timer it refutes had
-    // fired. Strict, not inclusive: a ring exactly at the cap that happens to be
-    // full is indistinguishable from an over-cap one and costs a spurious re-poll.
-    if cfg.udp_rx_packets >= memberlist_embedded::GOSSIP_READ_CAP {
-      return Err(InitError::UdpRxPacketsTooLarge);
-    }
-
     // Reject a zero graceful-close timeout. `close_timeout` bounds the reliable
     // graceful-close drain: a connection still `Closing` past `now +
     // close_timeout` is force-aborted. Zero sets that deadline to `now`, so every
@@ -675,13 +664,22 @@ where
     // and membership admission. Seed the machine's gossip RNG from the
     // domain-separated `gossip_seed` (step 5), never the raw interface seed; the
     // core performs no entropy acquisition of its own.
-    let mut engine = Engine::try_new_at(
-      embedded_cfg,
-      transform,
-      ep_cfg,
-      now,
-      SmallRng::seed_from_u64(gossip_seed),
-    )
+    let mut engine = {
+      // The engine screens the gossip receive ring against its per-pump read cap,
+      // so it is handed a view over the socket just bound — the same view `poll`
+      // will pump it with. The borrow of the socket set ends with this block, well
+      // before the TCP pool is registered below.
+      let sockets_cell = RefCell::new(&mut sockets);
+      let gossip = SmoltcpGossip::new(&sockets_cell, udp);
+      Engine::try_new_at(
+        embedded_cfg,
+        transform,
+        ep_cfg,
+        now,
+        SmallRng::seed_from_u64(gossip_seed),
+        &gossip,
+      )
+    }
     .map_err(InitError::from_embedded)?;
 
     // Allocate pooled TCP sockets for the reliable plane and register their
@@ -949,17 +947,6 @@ where
       return Err(InitError::ZeroUdpPackets);
     }
 
-    // Keep the gossip rx ring strictly below the engine's per-pump read cap. The
-    // engine reads at most `GOSSIP_READ_CAP` datagrams per pump and applies every
-    // one at that pump's instant; a ring that can hold as many or more would leave
-    // the excess unread across the pump's membership sweep, so a refutation already
-    // sitting in the ring could be applied only after the timer it refutes had
-    // fired. Strict, not inclusive: a ring exactly at the cap that happens to be
-    // full is indistinguishable from an over-cap one and costs a spurious re-poll.
-    if cfg.udp_rx_packets >= memberlist_embedded::GOSSIP_READ_CAP {
-      return Err(InitError::UdpRxPacketsTooLarge);
-    }
-
     // Reject a zero graceful-close timeout. `close_timeout` bounds the reliable
     // graceful-close drain: a connection still `Closing` past `now +
     // close_timeout` is force-aborted. Zero sets that deadline to `now`, so every
@@ -1122,8 +1109,16 @@ where
     // policy carried on `embedded_cfg`. The caller owns the gossip RNG: hand `rng`
     // straight to the engine without deriving a seed (the `gossip_seed_from` path
     // is `try_new`'s alone); the core performs no entropy acquisition of its own.
-    let mut engine = Engine::try_new_at(embedded_cfg, transform, ep_cfg, now, rng)
-      .map_err(InitError::from_embedded)?;
+    let mut engine = {
+      // The engine screens the gossip receive ring against its per-pump read cap,
+      // so it is handed a view over the socket just bound — the same view `poll`
+      // will pump it with. The borrow of the socket set ends with this block, well
+      // before the TCP pool is registered below.
+      let sockets_cell = RefCell::new(&mut sockets);
+      let gossip = SmoltcpGossip::new(&sockets_cell, udp);
+      Engine::try_new_at(embedded_cfg, transform, ep_cfg, now, rng, &gossip)
+    }
+    .map_err(InitError::from_embedded)?;
 
     // Allocate pooled TCP sockets for the reliable plane and register their
     // handles with the engine's reliable plane (the pool authority). Each socket

--- a/memberlist-smoltcp/src/memberlist/mod.rs
+++ b/memberlist-smoltcp/src/memberlist/mod.rs
@@ -491,6 +491,20 @@ where
       return Err(InitError::ZeroUdpPackets);
     }
 
+    // Reject a gossip rx ring at or above the engine's per-pump gossip read cap
+    // BEFORE the UDP arenas are sized and allocated below. This is an allocation
+    // guard: `udp_rx_packets` scales the metadata ring AND floors the payload
+    // arena at `packets * max_datagram`, so a large-but-non-overflowing count
+    // would reach the allocator — an out-of-memory abort on a constrained target —
+    // before the engine could ever screen the socket and return the typed verdict.
+    // Screening the pure-`Options` value here costs nothing and keeps the answer a
+    // returned error. The engine's own check against the bound socket's actual
+    // capacity stays as defence in depth: it is the authority on the ring the
+    // engine will read, and it binds every driver, not just this one.
+    if cfg.udp_rx_packets >= memberlist_embedded::GOSSIP_READ_CAP {
+      return Err(InitError::UdpRxPacketsTooLarge);
+    }
+
     // Reject a zero graceful-close timeout. `close_timeout` bounds the reliable
     // graceful-close drain: a connection still `Closing` past `now +
     // close_timeout` is force-aborted. Zero sets that deadline to `now`, so every
@@ -945,6 +959,20 @@ where
     // packet buffers below.
     if cfg.udp_rx_packets == 0 || cfg.udp_tx_packets == 0 {
       return Err(InitError::ZeroUdpPackets);
+    }
+
+    // Reject a gossip rx ring at or above the engine's per-pump gossip read cap
+    // BEFORE the UDP arenas are sized and allocated below. This is an allocation
+    // guard: `udp_rx_packets` scales the metadata ring AND floors the payload
+    // arena at `packets * max_datagram`, so a large-but-non-overflowing count
+    // would reach the allocator — an out-of-memory abort on a constrained target —
+    // before the engine could ever screen the socket and return the typed verdict.
+    // Screening the pure-`Options` value here costs nothing and keeps the answer a
+    // returned error. The engine's own check against the bound socket's actual
+    // capacity stays as defence in depth: it is the authority on the ring the
+    // engine will read, and it binds every driver, not just this one.
+    if cfg.udp_rx_packets >= memberlist_embedded::GOSSIP_READ_CAP {
+      return Err(InitError::UdpRxPacketsTooLarge);
     }
 
     // Reject a zero graceful-close timeout. `close_timeout` bounds the reliable

--- a/memberlist-smoltcp/src/memberlist/mod.rs
+++ b/memberlist-smoltcp/src/memberlist/mod.rs
@@ -491,6 +491,17 @@ where
       return Err(InitError::ZeroUdpPackets);
     }
 
+    // Keep the gossip rx ring strictly below the engine's per-pump read cap. The
+    // engine reads at most `GOSSIP_READ_CAP` datagrams per pump and applies every
+    // one at that pump's instant; a ring that can hold as many or more would leave
+    // the excess unread across the pump's membership sweep, so a refutation already
+    // sitting in the ring could be applied only after the timer it refutes had
+    // fired. Strict, not inclusive: a ring exactly at the cap that happens to be
+    // full is indistinguishable from an over-cap one and costs a spurious re-poll.
+    if cfg.udp_rx_packets >= memberlist_embedded::GOSSIP_READ_CAP {
+      return Err(InitError::UdpRxPacketsTooLarge);
+    }
+
     // Reject a zero graceful-close timeout. `close_timeout` bounds the reliable
     // graceful-close drain: a connection still `Closing` past `now +
     // close_timeout` is force-aborted. Zero sets that deadline to `now`, so every
@@ -936,6 +947,17 @@ where
     // packet buffers below.
     if cfg.udp_rx_packets == 0 || cfg.udp_tx_packets == 0 {
       return Err(InitError::ZeroUdpPackets);
+    }
+
+    // Keep the gossip rx ring strictly below the engine's per-pump read cap. The
+    // engine reads at most `GOSSIP_READ_CAP` datagrams per pump and applies every
+    // one at that pump's instant; a ring that can hold as many or more would leave
+    // the excess unread across the pump's membership sweep, so a refutation already
+    // sitting in the ring could be applied only after the timer it refutes had
+    // fired. Strict, not inclusive: a ring exactly at the cap that happens to be
+    // full is indistinguishable from an over-cap one and costs a spurious re-poll.
+    if cfg.udp_rx_packets >= memberlist_embedded::GOSSIP_READ_CAP {
+      return Err(InitError::UdpRxPacketsTooLarge);
     }
 
     // Reject a zero graceful-close timeout. `close_timeout` bounds the reliable

--- a/memberlist-smoltcp/tests/interface.rs
+++ b/memberlist-smoltcp/tests/interface.rs
@@ -772,12 +772,18 @@ fn zero_udp_tx_packets_rejected() {
 /// sweep. The bound is strict: the cap itself is rejected (an exactly-full ring is
 /// indistinguishable from an over-cap one and costs a spurious re-poll), and one
 /// slot below it constructs.
+///
+/// The rejection is the ENGINE's: it screens the receive capacity of the gossip
+/// view this driver hands it (the bound socket's own metadata-slot count, which
+/// `udp_rx_packets` sizes), and the driver reports that verdict under the name of
+/// the option to lower. The shipped default is well below the cap and constructs.
 #[test]
 fn udp_rx_packets_at_or_above_the_gossip_read_cap_rejected() {
   for (slots, accepted) in [
     (GOSSIP_READ_CAP + 1, false),
     (GOSSIP_READ_CAP, false),
     (GOSSIP_READ_CAP - 1, true),
+    (Options::new().udp_rx_packets, true),
   ] {
     let mut dev = smoltcp::phy::Loopback::new(Medium::Ip);
     let now: Instant = harness::Clock::new().now();

--- a/memberlist-smoltcp/tests/interface.rs
+++ b/memberlist-smoltcp/tests/interface.rs
@@ -12,8 +12,9 @@ use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use memberlist_proto::{EndpointOptions, Instant};
 use memberlist_smoltcp::{
-  EthernetAddress, GossipMtuTooLarge, HardwareAddress, InitError, InterfaceOptions, IpCidr, Medium,
-  Memberlist, Options, Route, SocketAddrResolver, TransformOptions,
+  EthernetAddress, GOSSIP_READ_CAP, GossipMtuTooLarge, HardwareAddress, InitError,
+  InterfaceOptions, IpCidr, Medium, Memberlist, Options, Route, SocketAddrResolver,
+  TransformOptions,
 };
 use smol_str::SmolStr;
 
@@ -568,7 +569,9 @@ fn oversized_udp_arena_rejected() {
   let mut dev = smoltcp::phy::Loopback::new(Medium::Ip);
   let now: Instant = harness::Clock::new().now();
   let mut cfg = Options::new();
-  cfg.udp_rx_packets = usize::MAX; // × (gossip_mtu + overhead) overflows usize
+  // Driven through the TX slots: the RX count is capped far below any overflow by
+  // the engine's per-pump gossip read cap.
+  cfg.udp_tx_packets = usize::MAX; // × (gossip_mtu + overhead) overflows usize
   let res: Result<Memberlist<SmolStr, SocketAddr, _>, _> = Memberlist::try_new(
     cfg,
     InterfaceOptions::new(HardwareAddress::Ip).with_ip_addr(ip_cidr(1)),
@@ -760,6 +763,47 @@ fn zero_udp_tx_packets_rejected() {
     matches!(res, Err(InitError::ZeroUdpPackets)),
     "zero udp_tx_packets must be rejected as ZeroUdpPackets"
   );
+}
+
+/// A gossip rx ring that can hold at least as many datagrams as the engine reads
+/// per pump is rejected. The engine applies every datagram it pops within the pump
+/// that popped it, at most `GOSSIP_READ_CAP` of them, so a larger ring would leave
+/// the excess unread — unobserved and un-stamped — across the pump's membership
+/// sweep. The bound is strict: the cap itself is rejected (an exactly-full ring is
+/// indistinguishable from an over-cap one and costs a spurious re-poll), and one
+/// slot below it constructs.
+#[test]
+fn udp_rx_packets_at_or_above_the_gossip_read_cap_rejected() {
+  for (slots, accepted) in [
+    (GOSSIP_READ_CAP + 1, false),
+    (GOSSIP_READ_CAP, false),
+    (GOSSIP_READ_CAP - 1, true),
+  ] {
+    let mut dev = smoltcp::phy::Loopback::new(Medium::Ip);
+    let now: Instant = harness::Clock::new().now();
+    let mut cfg = Options::new();
+    cfg.udp_rx_packets = slots;
+    let res: Result<Memberlist<SmolStr, SocketAddr, _>, _> = Memberlist::try_new(
+      cfg,
+      InterfaceOptions::new(HardwareAddress::Ip).with_ip_addr(ip_cidr(1)),
+      TransformOptions::default(),
+      ep("a", 1),
+      &SocketAddrResolver,
+      &mut dev,
+      now,
+    );
+    if accepted {
+      assert!(
+        res.is_ok(),
+        "{slots} slots is below the cap and must construct"
+      );
+    } else {
+      assert!(
+        matches!(res, Err(InitError::UdpRxPacketsTooLarge)),
+        "{slots} slots is not below the cap and must be rejected"
+      );
+    }
+  }
 }
 
 /// A zero `close_timeout` is rejected: it would force-abort every graceful

--- a/memberlist-smoltcp/tests/interface.rs
+++ b/memberlist-smoltcp/tests/interface.rs
@@ -570,7 +570,7 @@ fn oversized_udp_arena_rejected() {
   let now: Instant = harness::Clock::new().now();
   let mut cfg = Options::new();
   // Driven through the TX slots: the RX count is capped far below any overflow by
-  // the engine's per-pump gossip read cap.
+  // the gossip read cap, which the constructor screens before it sizes the arenas.
   cfg.udp_tx_packets = usize::MAX; // × (gossip_mtu + overhead) overflows usize
   let res: Result<Memberlist<SmolStr, SocketAddr, _>, _> = Memberlist::try_new(
     cfg,
@@ -765,21 +765,29 @@ fn zero_udp_tx_packets_rejected() {
   );
 }
 
-/// A gossip rx ring that can hold at least as many datagrams as the engine reads
-/// per pump is rejected. The engine applies every datagram it pops within the pump
-/// that popped it, at most `GOSSIP_READ_CAP` of them, so a larger ring would leave
-/// the excess unread — unobserved and un-stamped — across the pump's membership
-/// sweep. The bound is strict: the cap itself is rejected (an exactly-full ring is
-/// indistinguishable from an over-cap one and costs a spurious re-poll), and one
+/// A gossip rx ring that reaches the engine's per-pump work ceiling is rejected.
+/// The engine applies every datagram it pops within the pump that popped it, so
+/// the accepted ring size IS a pump's gossip work budget, and `GOSSIP_READ_CAP` is
+/// what bounds it. The bound is strict: the cap itself is rejected (a pump takes
+/// one probe pop past the ring's capacity to detect a mid-pump refill), and one
 /// slot below it constructs.
 ///
-/// The rejection is the ENGINE's: it screens the receive capacity of the gossip
-/// view this driver hands it (the bound socket's own metadata-slot count, which
-/// `udp_rx_packets` sizes), and the driver reports that verdict under the name of
-/// the option to lower. The shipped default is well below the cap and constructs.
+/// The driver screens `udp_rx_packets` among its pure-`Options` guards, BEFORE it
+/// sizes and allocates the UDP metadata ring and payload arena from that same
+/// count — so a count large enough to exhaust memory returns the typed verdict
+/// instead of reaching the allocator, and never reaches the arena-overflow guard
+/// either. The engine raises the same verdict against the bound socket's actual
+/// receive ring, which the driver reports under the name of the option to lower.
+/// The shipped default is well below the cap and constructs.
 #[test]
 fn udp_rx_packets_at_or_above_the_gossip_read_cap_rejected() {
+  // `max_datagram` is bounded by the 65507-byte UDP payload ceiling the gossip-MTU
+  // check enforces, so this count cannot overflow the arena's `checked_mul` — its
+  // arenas would simply be far larger than any machine's memory. Without the
+  // pre-allocation screen it would be an allocation, not an error.
+  let huge_but_not_overflowing = usize::MAX / 65_536;
   for (slots, accepted) in [
+    (huge_but_not_overflowing, false),
     (GOSSIP_READ_CAP + 1, false),
     (GOSSIP_READ_CAP, false),
     (GOSSIP_READ_CAP - 1, true),
@@ -806,7 +814,8 @@ fn udp_rx_packets_at_or_above_the_gossip_read_cap_rejected() {
     } else {
       assert!(
         matches!(res, Err(InitError::UdpRxPacketsTooLarge)),
-        "{slots} slots is not below the cap and must be rejected"
+        "{slots} slots is not below the cap and must be rejected for the packet count itself, \
+         before any arena is sized or allocated"
       );
     }
   }


### PR DESCRIPTION
X1/F4 for the embedded tier, rebuilt after a multi-expert deep audit: **"observation is the read"** — inline, read-capped, deferral-free gossip ingress with one real clock, a pump reorder so every evidence feed precedes any membership sweep, and construction-time validation of the drivers' gossip rx rings. Closes #159 F4 and the embedded half of #162 X1 (see "What X1 asked for" below — the invariant is met by construction rather than by the remediation shape the issue sketched). Stacked on #213/#214/#215.

## What changed

- **Inline gossip ingress under a per-pump read cap** (`memberlist-embedded`). Phase 2 of `Engine::pump` pops at most `GOSSIP_READ_CAP` (64) datagrams from the driver ring and decodes each straight from the receive scratch buffer into `handle_packet(src, msg, now)` at the pump's real instant. Nothing is staged, nothing survives the pump, no clock is clamped, `memberlist-proto` is untouched (the engine simply stops routing gossip through the machine's `handle_gossip`/`poll_memberlist_ingress` staging, which carried no per-frame instant and whose only memory bound was the 8192-datagram backstop). Cross-pump gossip memory is now zero; per-pump work is bounded by the ring and the cap. Every pop is charged — including CIDR-blocked, oversized-marker and post-leave datagrams — so a flood is bounded by ring reads, not by what it can make the engine decode.
- **All ingress before any sweep.** The pump is reordered to `reap → check_listener → gossip → reliable → rebalance → seed drain → tick → stream actions`. Both evidence feeds now run before every call that can transitively run the membership sweep — including the early rebalance's synchronous dial-rejection path (`handle_dial_failed → run_tick`), which on `main` could fire a suspicion *before* this pump's gossip was applied. That is a pre-existing defect; T6 fails only under `main`'s order.
- **Wake term only for work the engine itself left.** Step 8 folds an already-due `now` only when phase 2 stopped at the cap while running; a conforming ring never sets it, a left node never sets it. `gossip_read_cap_hits` reports how often it happened (the engine drops nothing; drops happen at the stack ring, as network loss).
- **Bounded reads, derived from the pumped ring itself.** Receive capacity is part of the `GossipIo` contract (`recv_capacity()`, the FIFO ring's true maximum datagram count), and each pump reads at most that capacity **plus one** from the view it is actually handed. So every datagram present at pump start is applied before any sweep for *any* truthful view — the one the engine was constructed with, a different one, or a ring resized later — in every build profile, with no debug-only guard. The extra pop is the refill detector: a full conforming ring pops exactly its capacity and the next `recv` returns `None`, so it never triggers a wake; a ring that refilled mid-pump (or one declaring less than it holds) sets an already-due wake and is drained next pump. Reads stay bounded (≤ capacity + 1) even against a ring that never runs dry.
- **`GOSSIP_READ_CAP` (64) is the construction-time work ceiling.** Every `Engine` constructor rejects a view declaring a capacity at or above it with a typed `InitError`, bounding per-pump decode work on a conforming integration; a pump handed an over-cap view anyway (a contract violation) is still read fully — correctness over CPU — and surfaced via `gossip_over_cap_pumps`. `memberlist-smoltcp` additionally preflights `udp_rx_packets` against the cap *before* allocating its UDP arenas (so a bad count returns the typed error instead of reaching the allocator) and reads the bound socket's own `packet_recv_capacity()` for the engine check; `memberlist-embassy` validates the supplied socket's capacity and surfaces the engine error through its `InitError`. Shipped defaults (8 on smoltcp, 16 on every in-repo embassy configuration) are unaffected. Out-of-tree `GossipIo` implementors (e.g. the serf drivers) gain one required method.

## Invariant

Every gossip datagram the engine reads is applied to the machine in the pump that read it, at that pump's real instant, before any machine call that can run the membership sweep; nothing observed is carried across a pump, so the machine's clock is the pump's clock and no timer can overtake evidence the engine holds. Ack/Nack cutoffs, Alive refutations, Suspect/Dead creation, stale-created deadlines, freeze under sustained flood, super-loop fairness and memory are each argued impossible by construction in the audit's design document.

## What X1 asked for, and what this ships instead

#162 X1 sketched an `Ingress { payload, observed_at }` envelope, an oldest-eligible watermark for bounded queues, and a "queue filler + valid ACK at d−1, advance to d+1, process one item per turn" regression. This PR **does not** implement that shape for the embedded gossip plane and the regression vector is inapplicable by design: an earlier version of this branch did implement per-frame `observed_at` + a decode budget that deferred frames across pumps, and four adversarial review rounds showed that deferral against a frozen single-instant machine API cannot be made exact (timeouts overtaking deferred frames; the clamp bypassed transitively via the reliable feed's `run_tick`; same-pump Alive refutations straddled; deadlines created at clamped time expiring early). The invariant is instead enforced by (i) never carrying an observed datagram across a pump and (ii) the ring never exceeding the read cap, validated at construction. The full analysis, alternatives considered, and proofs are in the audit's golden-architecture document.

## Follow-ups (not in this PR)

- **C2 (approved, next PR):** the one residual shared with `main`, compio and reactor — within phase 3, an earlier-fed connection's transitive sweep can fire a refutable deadline that fell within the last pump interval before a later-fed connection's bytes at the same instant. Fix is an additive `feed_advances_membership_time` gate on `StreamEndpoint` mirroring `QuicEndpoint::tick`'s existing parameter; the embedded engine opts in so step 6 becomes the single sweep per pump.
- `serf-embedded` has its own pump copying `main`'s order and inherits both classes; follow-up in the serf project.
- PR-2: `Options::gossip_read_cap`, #161 F1 (smoltcp bounded `poll_ingress_single` loop), and the pre-existing no-encryption `--tests` compile gap in this crate's test modules.
