### PR TITLE
fix(embedded, smoltcp): ingress-budget knobs, bounded pre-pump stack poll, device-MTU guard, and real test lanes (#161 F1/F2, #162)

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -25,10 +25,17 @@ on:
 # hands each of them the union. Naming the engine and the drivers together would
 # therefore build the engine with whatever the drivers' dev-dependencies ask of
 # it, and a lane whose whole purpose is to build without a feature would build
-# with it. Every feature lane below loops over this list instead, one invocation
-# per package.
+# with it. Every feature lane below loops over one of these lists instead, one
+# invocation per package.
+#
+# `ALLOC_TEST_PACKAGES` is the subset whose *tests* still resolve an alloc-only
+# graph. `memberlist-embassy` is not in it: its harness needs a time driver and
+# an executor on the host, and cargo unifies those dev-dependency features into
+# the very dependency instances the library uses, so its alloc lane is the
+# library alone.
 env:
   PACKAGES: memberlist-embedded memberlist-smoltcp memberlist-embassy
+  ALLOC_TEST_PACKAGES: memberlist-embedded memberlist-smoltcp
 
 jobs:
   # Bare-metal compile gate: the `no_std` + `alloc` engine and both embedded
@@ -70,7 +77,9 @@ jobs:
   # an AEAD backend (so nothing test-side may depend unconditionally on
   # encryption), and the advertised `no_std + alloc` set, whose TESTS the
   # bare-metal check above cannot build — that target has no test runner, so the
-  # smallest supported configuration is exercised here on the host instead.
+  # smallest supported configuration is exercised here on the host instead. The
+  # engine and the smoltcp driver run their tests under that set; the embassy
+  # driver builds its library under it and runs its tests under the other two.
   host-tests:
     runs-on: ubuntu-latest
     steps:
@@ -84,6 +93,73 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
+      # Each reduced lane below is defined by what it must build WITHOUT, and
+      # cargo resolves features over the graph an invocation actually builds — so
+      # such a lane is only as strong as the graph it resolves. These assertions
+      # read that graph back, one package at a time, and fail the job if the
+      # excluded thing is in it.
+      #
+      # `--format '{p} [{f}]'` prints every package with the features actually
+      # resolved for it. An `-e features` edge list is not enough on its own: it
+      # omits the root package's own feature mappings.
+      #
+      # `no-build,no-proc-macro` drops the host-side toolchain — the wire codegen's
+      # build script and its dependencies, and proc macros. Those compile for the
+      # build host and may legitimately carry `std`; what is left is the graph that
+      # compiles for the target.
+      #
+      # `no-dev` is used only for the lane that builds no dev-dependencies
+      # (`cargo build` / `cargo clippy --lib`). The lanes that run tests are
+      # asserted WITH dev-dependencies, because cargo unifies a dev-dependency's
+      # features into the same instance of a package the library depends on too.
+      - name: Assert the reduced feature graphs
+        run: |
+          set -euo pipefail
+          aead='aes-gcm|chacha20poly1305'
+          target_std='(\[|,)std(,|\])'
+
+          # Fails on a match, and refuses to pass on a graph that does not carry
+          # the crates under test: an empty or wrong tree must not satisfy an
+          # "is absent" check by default.
+          assert_graph() {
+            local desc=$1 forbid=$2 edges=$3
+            shift 3
+            local graph
+            if ! graph=$(cargo tree "$@" -e "$edges" --prefix none --format '{p} [{f}]'); then
+              echo "::error::${desc}: cargo tree failed"
+              return 1
+            fi
+            local expect
+            for expect in 'memberlist-proto v' 'memberlist-embedded v'; do
+              if ! grep -qF -- "$expect" <<<"$graph"; then
+                echo "::error::${desc}: '${expect}' is absent, so this check would pass vacuously"
+                return 1
+              fi
+            done
+            if grep -E -- "$forbid" <<<"$graph"; then
+              echo "::error::${desc}: the packages listed above are excluded from this lane"
+              return 1
+            fi
+            echo "ok: ${desc}"
+          }
+
+          rc=0
+          # Guards the two "no encryption backend" lanes: neither AEAD crate may
+          # be in the graph, so nothing test-side can depend on one unconditionally.
+          for pkg in $PACKAGES; do
+            assert_graph "no encryption backend: ${pkg}" "$aead" no-build,no-proc-macro \
+              -p "$pkg" --features lz4,crc32,cidr || rc=1
+          done
+          # Guards the alloc lanes, which stand in for the bare-metal target: no
+          # AEAD backend, and no `std` on anything that compiles for that target.
+          for pkg in $ALLOC_TEST_PACKAGES; do
+            assert_graph "no_std + alloc: ${pkg}" "${aead}|${target_std}" no-build,no-proc-macro \
+              -p "$pkg" --no-default-features --features alloc || rc=1
+          done
+          assert_graph "no_std + alloc, library only: memberlist-embassy" "${aead}|${target_std}" \
+            no-build,no-dev,no-proc-macro \
+            -p memberlist-embassy --no-default-features --features alloc || rc=1
+          exit "$rc"
       # `cargo fmt` selects no features, so one invocation covers all three.
       - name: Format
         run: cargo fmt -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --check
@@ -99,7 +175,7 @@ jobs:
           done
       - name: Clippy (no_std + alloc)
         run: |
-          for pkg in $PACKAGES; do
+          for pkg in $ALLOC_TEST_PACKAGES; do
             cargo clippy -p "$pkg" --all-targets --no-default-features --features alloc --no-deps -- -D warnings
           done
       - name: Test
@@ -114,9 +190,19 @@ jobs:
           done
       - name: Test (no_std + alloc)
         run: |
-          for pkg in $PACKAGES; do
+          for pkg in $ALLOC_TEST_PACKAGES; do
             cargo test -p "$pkg" --no-default-features --features alloc
           done
+      # `--all-targets` would build memberlist-embassy's dev-dependencies, whose
+      # host time driver and executor put `std` on the very `embassy-time` and
+      # `smol_str` instances the library uses — the alloc-only graph this lane
+      # exists to exercise would not be the one it built. `cargo build` and
+      # `cargo clippy --lib` build no dev-dependencies, so the lane keeps its
+      # meaning; the tests it can no longer carry all run in the two lanes above.
+      - name: "Build + clippy (no_std + alloc, library only — the host test harness requires std; the driver's tests run in the full and no-encryption lanes)"
+        run: |
+          cargo build -p memberlist-embassy --no-default-features --features alloc
+          cargo clippy -p memberlist-embassy --lib --no-default-features --features alloc --no-deps -- -D warnings
 
   # Execution proof: build the `memberlist-embassy-qemu` firmware and run it under
   # QEMU. The crate's `.cargo/config.toml` supplies the target, the linker script,

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -54,9 +54,16 @@ jobs:
           --no-default-features --features alloc
           --target thumbv7em-none-eabihf
 
-  # Host test gate: the smoltcp and embassy drivers carry host-runnable test
+  # Host test gate: the shared engine and both drivers carry host-runnable test
   # suites (block_on + bounded virtual time) that the bare-metal check above does
-  # not exercise. Run them on a std host, plus fmt + clippy for both libs.
+  # not exercise. Run them on a std host, plus fmt + clippy for all three libs.
+  #
+  # Three feature sets, because a test target that only ever builds under one of
+  # them is not continuously tested: the full transform set, the same set without
+  # an AEAD backend (so nothing test-side may depend unconditionally on
+  # encryption), and the advertised `no_std + alloc` set, whose TESTS the
+  # bare-metal check above cannot build — that target has no test runner, so the
+  # smallest supported configuration is exercised here on the host instead.
   host-tests:
     runs-on: ubuntu-latest
     steps:
@@ -71,11 +78,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
       - name: Format
-        run: cargo fmt -p memberlist-smoltcp -p memberlist-embassy --check
+        run: cargo fmt -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --check
       - name: Clippy
-        run: cargo clippy -p memberlist-smoltcp -p memberlist-embassy --all-targets --features lz4,crc32,aes-gcm,cidr --no-deps -- -D warnings
+        run: cargo clippy -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --all-targets --features lz4,crc32,aes-gcm,cidr --no-deps -- -D warnings
+      - name: Clippy (no encryption backend)
+        run: cargo clippy -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --all-targets --features lz4,crc32,cidr --no-deps -- -D warnings
+      - name: Clippy (no_std + alloc)
+        run: cargo clippy -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --all-targets --no-default-features --features alloc --no-deps -- -D warnings
       - name: Test
-        run: cargo test -p memberlist-smoltcp -p memberlist-embassy --features lz4,crc32,aes-gcm,cidr
+        run: cargo test -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --features lz4,crc32,aes-gcm,cidr
+      - name: Test (no encryption backend)
+        run: cargo test -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --features lz4,crc32,cidr
+      - name: Test (no_std + alloc)
+        run: cargo test -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --no-default-features --features alloc
 
   # Execution proof: build the `memberlist-embassy-qemu` firmware and run it under
   # QEMU. The crate's `.cargo/config.toml` supplies the target, the linker script,

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -21,6 +21,15 @@ on:
       - "art"
   workflow_dispatch:
 
+# Cargo resolves features once for every package named in a single invocation and
+# hands each of them the union. Naming the engine and the drivers together would
+# therefore build the engine with whatever the drivers' dev-dependencies ask of
+# it, and a lane whose whole purpose is to build without a feature would build
+# with it. Every feature lane below loops over this list instead, one invocation
+# per package.
+env:
+  PACKAGES: memberlist-embedded memberlist-smoltcp memberlist-embassy
+
 jobs:
   # Bare-metal compile gate: the `no_std` + `alloc` engine and both embedded
   # drivers must build for a real Cortex-M target. A `no_std` lib also compiles on
@@ -46,13 +55,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
-      - run: >
-          cargo check
-          -p memberlist-embedded
-          -p memberlist-smoltcp
-          -p memberlist-embassy
-          --no-default-features --features alloc
-          --target thumbv7em-none-eabihf
+      - name: Bare-metal check
+        run: |
+          for pkg in $PACKAGES; do
+            cargo check -p "$pkg" --no-default-features --features alloc --target thumbv7em-none-eabihf
+          done
 
   # Host test gate: the shared engine and both drivers carry host-runnable test
   # suites (block_on + bounded virtual time) that the bare-metal check above does
@@ -77,20 +84,39 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
+      # `cargo fmt` selects no features, so one invocation covers all three.
       - name: Format
         run: cargo fmt -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --check
       - name: Clippy
-        run: cargo clippy -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --all-targets --features lz4,crc32,aes-gcm,cidr --no-deps -- -D warnings
+        run: |
+          for pkg in $PACKAGES; do
+            cargo clippy -p "$pkg" --all-targets --features lz4,crc32,aes-gcm,cidr --no-deps -- -D warnings
+          done
       - name: Clippy (no encryption backend)
-        run: cargo clippy -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --all-targets --features lz4,crc32,cidr --no-deps -- -D warnings
+        run: |
+          for pkg in $PACKAGES; do
+            cargo clippy -p "$pkg" --all-targets --features lz4,crc32,cidr --no-deps -- -D warnings
+          done
       - name: Clippy (no_std + alloc)
-        run: cargo clippy -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --all-targets --no-default-features --features alloc --no-deps -- -D warnings
+        run: |
+          for pkg in $PACKAGES; do
+            cargo clippy -p "$pkg" --all-targets --no-default-features --features alloc --no-deps -- -D warnings
+          done
       - name: Test
-        run: cargo test -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --features lz4,crc32,aes-gcm,cidr
+        run: |
+          for pkg in $PACKAGES; do
+            cargo test -p "$pkg" --features lz4,crc32,aes-gcm,cidr
+          done
       - name: Test (no encryption backend)
-        run: cargo test -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --features lz4,crc32,cidr
+        run: |
+          for pkg in $PACKAGES; do
+            cargo test -p "$pkg" --features lz4,crc32,cidr
+          done
       - name: Test (no_std + alloc)
-        run: cargo test -p memberlist-embedded -p memberlist-smoltcp -p memberlist-embassy --no-default-features --features alloc
+        run: |
+          for pkg in $PACKAGES; do
+            cargo test -p "$pkg" --no-default-features --features alloc
+          done
 
   # Execution proof: build the `memberlist-embassy-qemu` firmware and run it under
   # QEMU. The crate's `.cargo/config.toml` supplies the target, the linker script,

--- a/memberlist-embassy/Cargo.toml
+++ b/memberlist-embassy/Cargo.toml
@@ -83,17 +83,11 @@ embassy-time = { workspace = true, features = ["std", "generic-queue-8"] }
 futures = { workspace = true, features = ["executor"] }
 # A concrete node-id type for the loopback tests.
 smol_str = { workspace = true, features = ["std"] }
-# AES-256-GCM backend for the transform end-to-end tests (encryption round-trip
-# and key-rotation). Declared on the dev build only so the library's own build
-# stays backend-free and bare-metal compile checks exercise the disabled path.
-memberlist-proto = { workspace = true, default-features = false, features = [
-  "tcp",
-  "aes-gcm",
-] }
-memberlist-embedded = { workspace = true, default-features = false, features = [
-  "std",
-  "aes-gcm",
-] }
+# No transform backend is enabled here: the tests that need one are gated on this
+# crate's own `encryption` / `compression` cfgs, so the backend arrives with the
+# feature set the build selects. A dev-dependency enabling a backend on the shared
+# engine would enable it for every lane, including the ones whose whole purpose is
+# to build the engine without it.
 
 [lints]
 workspace = true

--- a/memberlist-embassy/README.md
+++ b/memberlist-embassy/README.md
@@ -65,7 +65,7 @@ A complete, runnable wiring (two nodes joining on an emulated Cortex-M) lives in
 
 | Feature | Description |
 |---------|-------------|
-| `std` *(default)* | host builds and the test harness |
+| `std` *(default)* | host builds, and this crate's tests — the harness needs a host time driver and executor, so the tests are `std` builds |
 | `alloc` | `no_std` with a global allocator (bare metal) — build with `--no-default-features --features alloc` |
 | `lz4` / `-snappy` / `-zstd` / `-brotli` | compression (gossip + reliable) |
 | `aes-gcm` / `-chacha20-poly1305` | AEAD encryption (gossip + plain-TCP reliable) |

--- a/memberlist-embassy/src/error/mod.rs
+++ b/memberlist-embassy/src/error/mod.rs
@@ -47,8 +47,8 @@ pub enum InitError {
   /// The shared engine rejected the configuration (see
   /// [`memberlist_embedded::InitError`]): a zero/over-ceiling gossip MTU, a
   /// non-routable or port-mismatched advertise address, a zero port or
-  /// close-timeout, a gossip UDP socket whose receive-packet capacity reaches the
-  /// engine's per-pump gossip read cap
+  /// close-timeout, a zero gossip read cap, a gossip UDP socket whose
+  /// receive-packet capacity reaches the engine's per-pump gossip read cap
   /// ([`GossipRecvCapacityTooLarge`](memberlist_embedded::InitError::GossipRecvCapacityTooLarge)),
   /// an unusable encryption keyring, or a machine-endpoint init failure (including
   /// an entropy draw failure).

--- a/memberlist-embassy/src/memberlist/mod.rs
+++ b/memberlist-embassy/src/memberlist/mod.rs
@@ -214,7 +214,8 @@ where
   ///   port / close-timeout, a non-routable or port-mismatched advertise address,
   ///   an over-ceiling gossip MTU, a gossip UDP socket whose receive-packet
   ///   capacity reaches the engine's per-pump gossip read cap
-  ///   ([`memberlist_embedded::GOSSIP_READ_CAP`]), an unusable encryption keyring,
+  ///   ([`memberlist_embedded::Options::gossip_read_cap`], defaulting to
+  ///   [`memberlist_embedded::GOSSIP_READ_CAP`]), an unusable encryption keyring,
   ///   or a machine-endpoint init failure).
   /// - [`InitError::Entropy`] — the platform [`getrandom`] backend failed while
   ///   seeding the default gossip RNG.
@@ -295,7 +296,8 @@ where
   ///   port / close-timeout, a non-routable or port-mismatched advertise address,
   ///   an over-ceiling gossip MTU, a gossip UDP socket whose receive-packet
   ///   capacity reaches the engine's per-pump gossip read cap
-  ///   ([`memberlist_embedded::GOSSIP_READ_CAP`]), an unusable encryption keyring,
+  ///   ([`memberlist_embedded::Options::gossip_read_cap`], defaulting to
+  ///   [`memberlist_embedded::GOSSIP_READ_CAP`]), an unusable encryption keyring,
   ///   or a machine-endpoint init failure).
   ///
   /// # Panics

--- a/memberlist-embassy/tests/handle.rs
+++ b/memberlist-embassy/tests/handle.rs
@@ -22,9 +22,11 @@ use embassy_net::{
 };
 use embassy_time::{Duration, Timer};
 use futures::executor::block_on;
+#[cfg(compression)]
+use memberlist_embassy::CompressionOptions;
 use memberlist_embassy::{
-  CompressionOptions, EndpointOptions, GOSSIP_READ_CAP, InitError, MaybeResolved, Memberlist,
-  Options, Runner, SocketAddrResolver, TransformOptions, event::Event, now,
+  EndpointOptions, GOSSIP_READ_CAP, InitError, MaybeResolved, Memberlist, Options, Runner,
+  SocketAddrResolver, TransformOptions, event::Event, now,
 };
 use memberlist_embedded::InitError as EngineInitError;
 use memberlist_proto::{SeedableRng, SmallRng, typed::State};
@@ -306,13 +308,16 @@ fn single_node_accessor_surface_is_coherent() {
 
   // Swapping the compression policy at runtime is a pure forward that leaves the
   // membership view untouched (it only re-policies future encodes).
-  ml.set_compression_options(CompressionOptions::new())
-    .expect("compression options set on a running node");
-  assert_eq!(
-    ml.num_members(),
-    1,
-    "re-policying compression keeps the view"
-  );
+  #[cfg(compression)]
+  {
+    ml.set_compression_options(CompressionOptions::new())
+      .expect("compression options set on a running node");
+    assert_eq!(
+      ml.num_members(),
+      1,
+      "re-policying compression keeps the view"
+    );
+  }
 }
 
 /// The `#[doc(hidden)]` reliable-plane diagnostics report the construction-time

--- a/memberlist-embassy/tests/transform.rs
+++ b/memberlist-embassy/tests/transform.rs
@@ -22,9 +22,11 @@ use embassy_net::{
 };
 use embassy_time::{Duration, Timer};
 use futures::executor::block_on;
+#[cfg(feature = "aes-gcm")]
+use memberlist_embassy::{EncryptionOptions, Keyring, SecretKey};
 use memberlist_embassy::{
-  EncryptionOptions, EndpointOptions, Keyring, LabelError, MaybeResolved, Memberlist, Options,
-  Runner, SecretKey, SocketAddrResolver, TransformOptions, now,
+  EndpointOptions, LabelError, MaybeResolved, Memberlist, Options, Runner, SocketAddrResolver,
+  TransformOptions, now,
 };
 use memberlist_proto::{SeedableRng, SmallRng};
 use smol_str::SmolStr;
@@ -122,6 +124,7 @@ async fn drive<T>(
 }
 
 /// A shared AES-256-GCM key used across the encryption tests.
+#[cfg(feature = "aes-gcm")]
 fn shared_key() -> EncryptionOptions {
   let key = SecretKey::Aes256([0x42u8; 32]);
   EncryptionOptions::new().with_keyring(Keyring::new(key))
@@ -135,6 +138,7 @@ fn shared_key() -> EncryptionOptions {
 /// encryption codec. A broken codec (or a key mismatch) would prevent the
 /// join push/pull exchange from decoding, so a successful join + 2-member
 /// view is a real end-to-end encrypted-path assertion.
+#[cfg(feature = "aes-gcm")]
 #[test]
 fn encrypted_gossip_round_trips() {
   let (dev_a, dev_b) = pair();
@@ -479,6 +483,7 @@ fn gossip_label_isolates_clusters() {
 /// This proves `set_encryption_options` is reflected by the next TCP
 /// push/pull attempt, and that fail→pass is achievable within a single
 /// test lifetime.
+#[cfg(feature = "aes-gcm")]
 #[test]
 fn runtime_set_encryption_rotates_key() {
   let key1 = SecretKey::Aes256([0xAAu8; 32]);

--- a/memberlist-embedded/src/config/mod.rs
+++ b/memberlist-embedded/src/config/mod.rs
@@ -6,8 +6,9 @@
 //! TCP pool size — on top of this; those govern memory the driver allocates,
 //! not protocol behaviour, so they stay on the driver. This struct holds only
 //! the knobs the [`Engine`](crate::Engine) reads directly: the bound port (used
-//! to `listen` and to derive ephemeral dial ports) and the graceful-close
-//! timeout that bounds the reliable plane's drain.
+//! to `listen` and to derive ephemeral dial ports), the graceful-close timeout
+//! that bounds the reliable plane's drain, and the per-pump gossip work ceiling
+//! that bounds which gossip receive rings the engine accepts.
 
 use core::time::Duration;
 
@@ -54,6 +55,25 @@ pub struct Options {
   /// reclaimed the moment its teardown is acknowledged; the timeout only governs
   /// the vanished-, stalled-, or trickling-peer case.
   pub close_timeout: Duration,
+  /// The per-pump gossip work ceiling: the largest gossip receive ring the
+  /// [`Engine`](crate::Engine) accepts at construction.
+  ///
+  /// This is a CONSTRUCTION-TIME policy, not the read loop's bound.
+  /// [`Engine::try_new_at`](crate::Engine::try_new_at) rejects a
+  /// [`GossipIo`](crate::GossipIo) whose declared
+  /// [`recv_capacity`](crate::GossipIo::recv_capacity) is at or above this value;
+  /// a pump then reads the ring the view in hand declares, so on an integration
+  /// that pumps the view it constructed with, per-pump unwrap/decode/apply work is
+  /// bounded by this count.
+  ///
+  /// The bound is a count, not a byte budget. Its byte implication is
+  /// `gossip_read_cap × gossip_recv_buf_size(gossip_mtu)`: per-pump AEAD and
+  /// decode cost scales with bytes, so the count is a CPU ceiling only at the
+  /// configured MTU. Raising it raises both.
+  ///
+  /// Must be non-zero ([`InitError::ZeroGossipReadCap`](crate::InitError::ZeroGossipReadCap));
+  /// [`GOSSIP_READ_CAP`](crate::GOSSIP_READ_CAP) is the default.
+  pub gossip_read_cap: usize,
   /// CIDR peer-admission policy. Filters inbound gossip by datagram source and
   /// inbound reliable connections by peer address at the transport boundary, AND
   /// inbound alives by the peer's self-advertised address at membership
@@ -69,6 +89,7 @@ impl Default for Options {
     Self {
       port: 7946,
       close_timeout: DEFAULT_CLOSE_TIMEOUT,
+      gossip_read_cap: crate::GOSSIP_READ_CAP,
       #[cfg(feature = "cidr")]
       cidr_policy: None,
     }
@@ -91,6 +112,13 @@ impl Options {
   /// Override the graceful-close timeout (see [`Options::close_timeout`]).
   pub fn with_close_timeout(mut self, d: Duration) -> Self {
     self.close_timeout = d;
+    self
+  }
+
+  /// Override the per-pump gossip work ceiling (see
+  /// [`Options::gossip_read_cap`]). Must be non-zero.
+  pub fn with_gossip_read_cap(mut self, cap: usize) -> Self {
+    self.gossip_read_cap = cap;
     self
   }
 

--- a/memberlist-embedded/src/config/tests.rs
+++ b/memberlist-embedded/src/config/tests.rs
@@ -11,3 +11,12 @@ fn defaults_are_sane_and_overridable() {
   assert_eq!(c.port, 1234);
   assert_eq!(c.close_timeout, Duration::from_secs(3));
 }
+
+/// The gossip work ceiling defaults to the documented constant and is overridable
+/// through the builder, so `GOSSIP_READ_CAP` stays the value the docs name while
+/// a caller can size the ceiling to its own driver.
+#[test]
+fn gossip_read_cap_defaults_to_the_constant_and_is_overridable() {
+  assert_eq!(Options::new().gossip_read_cap, crate::GOSSIP_READ_CAP);
+  assert_eq!(Options::new().with_gossip_read_cap(8).gossip_read_cap, 8);
+}

--- a/memberlist-embedded/src/engine/mod.rs
+++ b/memberlist-embedded/src/engine/mod.rs
@@ -87,12 +87,14 @@ fn gossip_recv_buf_size(gossip_mtu: usize) -> usize {
   (gossip_mtu + ENCRYPTED_WRAPPER_OVERHEAD + CHECKSUMED_WRAPPER_OVERHEAD).max(1500)
 }
 
-/// The largest gossip receive ring an [`Engine`] accepts at construction, and so
-/// the ceiling on the work one [`Engine::pump`] spends on gossip ingress.
+/// The default [`Options::gossip_read_cap`]: the largest gossip receive ring an
+/// [`Engine`] accepts at construction, and so the ceiling on the work one
+/// [`Engine::pump`] spends on gossip ingress.
 ///
 /// This is a CONSTRUCTION-TIME POLICY, not the read loop's bound.
 /// [`Engine::try_new_at`] rejects a [`GossipIo`] whose declared
-/// [`recv_capacity`](GossipIo::recv_capacity) reaches this number. Every datagram
+/// [`recv_capacity`](GossipIo::recv_capacity) reaches the CONFIGURED cap, of
+/// which this constant is only the default. Every datagram
 /// a pump pops is unwrapped, decoded and applied to the machine within that pump,
 /// at that pump's instant, and none is carried across a pump — so the largest ring
 /// the engine accepts is at once the per-pump decode bound and the transient
@@ -106,18 +108,17 @@ fn gossip_recv_buf_size(gossip_mtu: usize) -> usize {
 /// datagram behind a membership sweep — and counted in
 /// [`Engine::gossip_over_cap_pumps`].
 ///
-/// A driver's gossip receive ring must stay STRICTLY BELOW this cap (smoltcp
-/// defaults to 8 metadata slots, the in-repo embassy sockets to 16). Strictly
-/// below rather than at it because phase 2's bound is the declared capacity plus
-/// one probe pop: a ring below the cap keeps every conforming pump's reads at or
-/// under `GOSSIP_READ_CAP`, so the constant is the ceiling it names with no
-/// off-by-one slack.
+/// A driver's gossip receive ring must stay STRICTLY BELOW the configured cap
+/// (smoltcp defaults to 8 metadata slots, the in-repo embassy sockets to 16).
+/// Strictly below rather than at it because phase 2's bound is the declared
+/// capacity plus one probe pop: a ring below the cap keeps every conforming pump's
+/// reads at or under the cap, so it is the ceiling it names with no off-by-one
+/// slack.
 ///
 /// The bound is a count, not a byte budget. The implied byte ceiling is
-/// `GOSSIP_READ_CAP × gossip_recv_buf_size(gossip_mtu)` — per-pump AEAD and
+/// `gossip_read_cap × gossip_recv_buf_size(gossip_mtu)` — per-pump AEAD and
 /// decode work scales with bytes, so the count is a CPU ceiling only at the
-/// configured MTU. A byte dimension may join the count when the cap becomes a
-/// configurable knob.
+/// configured MTU. A byte dimension may join the count later.
 pub const GOSSIP_READ_CAP: usize = 64;
 
 /// Validate every construction-time config field that does NOT depend on the
@@ -140,6 +141,8 @@ pub const GOSSIP_READ_CAP: usize = 64;
 ///   downstream arena arithmetic would overflow.
 /// - [`InitError::ZeroCloseTimeout`] — `cfg.close_timeout` is zero, which would
 ///   force-abort every graceful reliable close immediately.
+/// - [`InitError::ZeroGossipReadCap`] — `cfg.gossip_read_cap` is zero, which no
+///   receive ring can stay strictly below, so no driver could ever construct.
 /// - `InitError::Encryption` — `transform.encryption` carries a keyring with a
 ///   key this build cannot use: an AEAD backend not compiled in, or a key whose
 ///   cipher variant disagrees with its algorithm tag. The keyring is probed
@@ -190,6 +193,14 @@ pub fn validate_runtime_config(
   // in-flight push/pull response is truncated.
   if cfg.close_timeout.is_zero() {
     return Err(InitError::ZeroCloseTimeout);
+  }
+
+  // Reject a zero gossip read cap. The cap is the per-pump gossip work ceiling and
+  // the ring screen is STRICTLY BELOW it, so zero admits no receive ring at all —
+  // every driver would fail construction with a capacity error naming a ceiling it
+  // could not meet. Rejecting the knob itself names the field the caller must fix.
+  if cfg.gossip_read_cap == 0 {
+    return Err(InitError::ZeroGossipReadCap);
   }
 
   // Validate the encryption keyring before any endpoint exists, so an unusable key
@@ -353,8 +364,8 @@ pub struct Engine<I, C, R = SmallRng> {
   /// gates membership admission via the routable-address alive filter, which the
   /// constructor installs with this policy as its inner predicate.
   cidr_policy: CidrFilter,
-  /// Count of pumps whose gossip view declared a receive capacity at or above
-  /// [`GOSSIP_READ_CAP`].
+  /// Count of pumps whose gossip view declared a receive capacity at or above the
+  /// configured [`Options::gossip_read_cap`].
   ///
   /// Construction rejects such a ring, so a non-zero value means the driver pumps
   /// a different — or since-resized — view than the one it constructed with: a
@@ -451,7 +462,7 @@ where
   }
 
   /// Diagnostic count of pumps whose gossip view declared a receive capacity at
-  /// or above [`GOSSIP_READ_CAP`].
+  /// or above the configured [`Options::gossip_read_cap`].
   ///
   /// [`try_new_at`](Self::try_new_at) rejects such a ring, so a non-zero value
   /// means the pumped view is not the one construction screened — a different
@@ -1146,7 +1157,8 @@ where
   /// # The gossip work ceiling
   ///
   /// This is where the per-pump WORK CEILING is enforced: the gossip receive ring
-  /// must hold strictly fewer datagrams than [`GOSSIP_READ_CAP`]. Taking the view
+  /// must hold strictly fewer datagrams than the configured
+  /// [`Options::gossip_read_cap`] (default [`GOSSIP_READ_CAP`]). Taking the view
   /// here — rather than trusting each driver to screen its own socket — is what
   /// binds every driver to it, including one written outside this workspace.
   ///
@@ -1165,10 +1177,11 @@ where
   ///
   /// - [`InitError::ZeroPort`] — `cfg.port` is zero.
   /// - [`InitError::ZeroCloseTimeout`] — `cfg.close_timeout` is zero.
+  /// - [`InitError::ZeroGossipReadCap`] — `cfg.gossip_read_cap` is zero.
   /// - [`InitError::GossipMtuTooLarge`] — the configured gossip MTU's on-wire
   ///   datagram cannot fit a UDP packet.
   /// - [`InitError::GossipRecvCapacityTooLarge`] — `gossip` declares a receive
-  ///   ring that can hold at least [`GOSSIP_READ_CAP`] datagrams.
+  ///   ring that can hold at least `cfg.gossip_read_cap` datagrams.
   /// - [`InitError::NonRoutableAdvertiseAddr`] — the advertise address is the
   ///   unspecified address, a multicast/broadcast IP, or port 0.
   /// - [`InitError::AdvertisePortMismatch`] — the advertised port differs from
@@ -1210,7 +1223,7 @@ where
     // bound is the declared capacity plus one probe pop, so a ring strictly below
     // the cap keeps a conforming pump's reads at or under it.
     let recv_capacity = gossip.recv_capacity();
-    if recv_capacity >= GOSSIP_READ_CAP {
+    if recv_capacity >= cfg.gossip_read_cap {
       return Err(InitError::GossipRecvCapacityTooLarge(recv_capacity));
     }
 
@@ -2283,7 +2296,7 @@ where
   /// `C` datagrams, so a truthful view of any size is emptied within the pump that
   /// observed it, in every build profile: nothing the driver had waiting when the
   /// pump began survives to sit behind a sweep. The bound is taken from the view
-  /// in hand rather than from [`GOSSIP_READ_CAP`] because `pump` accepts a fresh
+  /// in hand rather than from the configured cap because `pump` accepts a fresh
   /// view on every call and cannot know whether this one is what
   /// [`try_new_at`](Self::try_new_at) screened; the cap governs which rings that
   /// constructor accepts, and so how large this bound is on a conforming driver.
@@ -2358,7 +2371,7 @@ where
     // pump, so there is no held evidence for a timer to overtake and no reason for
     // the machine to be handed anything but the real instant.
     //
-    // The bound comes from the view in hand, not from `GOSSIP_READ_CAP`: `pump`
+    // The bound comes from the view in hand, not from the configured cap: `pump`
     // takes a fresh view on every call, so nothing here can know this is the view
     // construction screened, and correctness must not rest on that. A ring of
     // capacity C holds at most C datagrams, so C pops empty ANY truthful view — 8
@@ -2389,7 +2402,7 @@ where
     // datagram left behind a membership sweep — and surface the divergence, which
     // otherwise only the driver can see.
     let declared = gossip.recv_capacity();
-    if declared >= GOSSIP_READ_CAP {
+    if declared >= self.cfg.gossip_read_cap {
       self.gossip_over_cap_pumps += 1;
     }
     // A ring of capacity `declared` holds at most that many datagrams, so the one

--- a/memberlist-embedded/src/engine/tests.rs
+++ b/memberlist-embedded/src/engine/tests.rs
@@ -4722,6 +4722,89 @@ fn a_gossip_io_whose_ring_reaches_the_read_cap_cannot_construct_an_engine() {
   assert_eq!(engine.num_members(), 1, "the constructed engine is usable");
 }
 
+/// The ring screen follows the CONFIGURED ceiling, not the constant: an engine
+/// built with a cap of 8 rejects a 9-slot ring (and the 8-slot ring at the cap),
+/// and accepts a 7-slot one — all of which the default cap of 64 would have
+/// admitted. The rejection still carries the capacity the view declared.
+#[test]
+fn the_ring_screen_follows_the_configured_cap() {
+  const CAP: usize = 8;
+  let now = Instant::from_origin(Duration::from_secs(86_400));
+  let cfg = || {
+    Options::new()
+      .with_port(7946)
+      .with_close_timeout(Duration::from_secs(10))
+      .with_gossip_read_cap(CAP)
+  };
+  let ep_cfg = || memberlist_proto::EndpointOptions::new(SmolStr::new("cap"), node_addr(7946));
+
+  for declared in [CAP + 1, CAP] {
+    let gossip = QueueGossip::with_recv_capacity(declared);
+    let rejected: Result<Engine<SmolStr, u32>, _> = Engine::try_new_at(
+      cfg(),
+      TransformOptions::default(),
+      ep_cfg(),
+      now,
+      test_rng(),
+      &gossip,
+    );
+    match rejected {
+      Err(InitError::GossipRecvCapacityTooLarge(n)) => assert_eq!(
+        n, declared,
+        "the rejection carries the capacity the view declared"
+      ),
+      Err(other) => panic!("a {declared}-slot ring must be rejected under a cap of {CAP}: {other}"),
+      Ok(_) => panic!(
+        "a {declared}-slot ring must not construct under a cap of {CAP} (the default 64 would admit it)"
+      ),
+    }
+  }
+
+  let gossip = QueueGossip::with_recv_capacity(CAP - 1);
+  let engine: Engine<SmolStr, u32> = Engine::try_new_at(
+    cfg(),
+    TransformOptions::default(),
+    ep_cfg(),
+    now,
+    test_rng(),
+    &gossip,
+  )
+  .expect("a ring one slot below the configured cap must construct");
+  assert_eq!(engine.num_members(), 1, "the constructed engine is usable");
+}
+
+/// A zero gossip read cap is rejected as the knob it is, by the shared preflight
+/// and by construction alike. Zero admits no ring at all (the screen is strictly
+/// below the cap), so reporting it as a ring-capacity failure would name the wrong
+/// field: no `udp_rx_packets` / socket size could ever satisfy it.
+#[test]
+fn a_zero_gossip_read_cap_is_rejected_as_the_knob_it_is() {
+  let now = Instant::from_origin(Duration::from_secs(86_400));
+  let cfg = Options::new().with_port(7946).with_gossip_read_cap(0);
+
+  assert!(
+    matches!(
+      validate_runtime_config(&cfg, &TransformOptions::default(), 1400),
+      Err(InitError::ZeroGossipReadCap)
+    ),
+    "the shared preflight rejects a zero cap before a driver resolves or binds anything"
+  );
+
+  let gossip = QueueGossip::with_recv_capacity(0);
+  let rejected: Result<Engine<SmolStr, u32>, _> = Engine::try_new_at(
+    cfg,
+    TransformOptions::default(),
+    memberlist_proto::EndpointOptions::new(SmolStr::new("cap"), node_addr(7946)),
+    now,
+    test_rng(),
+    &gossip,
+  );
+  assert!(
+    matches!(rejected, Err(InitError::ZeroGossipReadCap)),
+    "construction rejects a zero cap even for an empty ring, naming the knob"
+  );
+}
+
 /// Arm `engine` with a reliable listener on slot 1 and one spare (slot 0) to
 /// replenish from, backed by a fresh `ProgRel`. The mock admits the passive open
 /// on the first `check_listener` that runs after the caller marks slot 1

--- a/memberlist-embedded/src/engine/tests.rs
+++ b/memberlist-embedded/src/engine/tests.rs
@@ -5,10 +5,11 @@ use core::{
   time::Duration,
 };
 
-use memberlist_proto::{
-  CompressionOptions, EncryptionOptions, Keyring, SecretKey, SeedableRng, SmallRng,
-  typed::NodeState,
-};
+#[cfg(compression)]
+use memberlist_proto::CompressionOptions;
+#[cfg(encryption)]
+use memberlist_proto::{EncryptionOptions, Keyring, SecretKey};
+use memberlist_proto::{SeedableRng, SmallRng, typed::NodeState};
 use smol_str::SmolStr;
 use std::vec::Vec;
 
@@ -218,6 +219,7 @@ fn make_engine() -> Engine<SmolStr, u32> {
 
 /// `set_compression_options` is accepted and the engine remains operational
 /// (a subsequent `pump` does not panic or error).
+#[cfg(compression)]
 #[test]
 fn set_compression_options_accepted_and_engine_still_pumps() {
   let mut engine = make_engine();
@@ -605,6 +607,7 @@ fn control_setters_reject_after_leave() {
     ),
     "queue_user_broadcast must reject after leave"
   );
+  #[cfg(compression)]
   assert!(
     matches!(
       engine.set_compression_options(CompressionOptions::default()),
@@ -612,6 +615,7 @@ fn control_setters_reject_after_leave() {
     ),
     "set_compression_options must reject after leave"
   );
+  #[cfg(encryption)]
   assert!(
     matches!(
       engine.set_encryption_options(EncryptionOptions::default()),
@@ -706,6 +710,7 @@ fn disabled_checksum_leaves_no_checksumed_tag_on_outbound_gossip() {
 }
 
 /// `set_encryption_options` with no keyring (disabled) is always accepted.
+#[cfg(encryption)]
 #[test]
 fn set_encryption_options_disabled_is_always_ok() {
   let mut engine = make_engine();
@@ -744,6 +749,7 @@ fn set_encryption_options_accepts_valid_aes256_keyring_and_engine_still_pumps() 
 /// the engine's identical re-check inside `try_new_at` cannot disagree. Repeated
 /// calls return the same verdict, and whether that verdict is `Ok` depends only on
 /// whether the AES-GCM backend is compiled in — never on entropy availability.
+#[cfg(encryption)]
 #[test]
 fn validate_runtime_config_for_encryption_is_deterministic() {
   let key = SecretKey::Aes256([0x42; 32]);
@@ -785,7 +791,9 @@ fn validate_runtime_config_for_encryption_is_deterministic() {
 }
 
 /// A disabled (no-algorithm) checksum policy always constructs cleanly — there
-/// is no backend to probe, so `try_new_at` succeeds regardless of feature set.
+/// is no backend to probe, so `try_new_at` succeeds whichever checksum backend is
+/// compiled in.
+#[cfg(checksum)]
 #[test]
 fn try_new_at_accepts_disabled_checksum() {
   use memberlist_proto::ChecksumOptions;
@@ -1010,7 +1018,8 @@ fn gossip_carries_and_checks_the_configured_label() {
 // the pool, EOF delivered once, exchange terminalizes Succeeded/Failed) rather
 // than convergence side effects.
 
-use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
+use core::cell::RefCell;
+use std::{collections::BTreeMap, rc::Rc};
 
 /// The simulated TCP state of one mock reliable socket, as the engine observes
 /// it through `StreamIo`. A test programs these directly (the single-engine

--- a/memberlist-embedded/src/error/mod.rs
+++ b/memberlist-embedded/src/error/mod.rs
@@ -49,6 +49,13 @@ pub enum InitError {
   /// immediately — the drain never runs and an in-flight push/pull response is
   /// truncated. Must be non-zero.
   ZeroCloseTimeout,
+  /// [`Options::gossip_read_cap`](crate::Options::gossip_read_cap) is zero.
+  ///
+  /// The cap is the per-pump gossip work ceiling, and the receive-ring screen is
+  /// STRICTLY BELOW it, so a zero cap admits no ring at all: every driver would
+  /// fail construction with a capacity error naming a ceiling nothing can meet.
+  /// Must be non-zero.
+  ZeroGossipReadCap,
   /// The configured gossip MTU's on-wire datagram cannot fit a UDP packet.
   ///
   /// A driver sizes its gossip arenas from
@@ -60,8 +67,8 @@ pub enum InitError {
   GossipMtuTooLarge(GossipMtuTooLarge),
   /// The driver's gossip receive ring
   /// ([`GossipIo::recv_capacity`](crate::GossipIo::recv_capacity)) reaches the
-  /// engine's per-pump work ceiling
-  /// ([`GOSSIP_READ_CAP`](crate::GOSSIP_READ_CAP)).
+  /// engine's configured per-pump work ceiling
+  /// ([`Options::gossip_read_cap`](crate::Options::gossip_read_cap)).
   ///
   /// A pump reads the whole ring the view declares and applies every datagram at
   /// that pump's instant, so the accepted ring size IS the per-pump unwrap, decode
@@ -152,11 +159,12 @@ impl fmt::Display for InitError {
       }
       InitError::ZeroPort => f.write_str("port is zero"),
       InitError::ZeroCloseTimeout => f.write_str("close_timeout must be non-zero"),
+      InitError::ZeroGossipReadCap => f.write_str("gossip_read_cap must be non-zero"),
       InitError::GossipMtuTooLarge(m) => write!(f, "{m}"),
       InitError::GossipRecvCapacityTooLarge(n) => write!(
         f,
         "the gossip receive ring holds {n} datagrams, which must be below the engine's \
-         per-pump gossip read cap ({})",
+         configured per-pump gossip read cap (Options::gossip_read_cap, default {})",
         crate::GOSSIP_READ_CAP
       ),
       InitError::Endpoint(e) => write!(f, "SWIM endpoint initialization failed: {e}"),

--- a/memberlist-embedded/src/error/tests.rs
+++ b/memberlist-embedded/src/error/tests.rs
@@ -6,12 +6,16 @@ use super::{GossipMtuTooLarge, InitError};
 #[test]
 fn every_init_error_variant_displays_and_reports_its_source() {
   let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
-  // (variant, whether `source()` should be `Some`).
-  let cases: [(InitError, bool); 9] = [
+  // (variant, whether `source()` should be `Some`). The transform-backed variants
+  // exist only when a backend is compiled in, so they join the list under the same
+  // cfgs that gate them on `InitError` itself.
+  #[allow(unused_mut)]
+  let mut cases: std::vec::Vec<(InitError, bool)> = std::vec![
     (InitError::NonRoutableAdvertiseAddr(addr), false),
     (InitError::AdvertisePortMismatch, false),
     (InitError::ZeroPort, false),
     (InitError::ZeroCloseTimeout, false),
+    (InitError::ZeroGossipReadCap, false),
     (
       InitError::GossipMtuTooLarge(GossipMtuTooLarge {
         gossip_mtu: 70_000,
@@ -27,9 +31,11 @@ fn every_init_error_variant_displays_and_reports_its_source() {
       memberlist_proto::EndpointInitError::AwarenessMultiplierZero.into(),
       true,
     ),
-    (memberlist_proto::EncryptionError::AuthFailed.into(), true),
-    (memberlist_proto::ChecksumError::Mismatch.into(), true),
   ];
+  #[cfg(encryption)]
+  cases.push((memberlist_proto::EncryptionError::AuthFailed.into(), true));
+  #[cfg(checksum)]
+  cases.push((memberlist_proto::ChecksumError::Mismatch.into(), true));
   for (err, has_source) in cases {
     assert!(!err.to_string().is_empty(), "Display non-empty for {err:?}");
     assert!(!format!("{err:?}").is_empty(), "Debug non-empty");

--- a/memberlist-embedded/src/gossip_io.rs
+++ b/memberlist-embedded/src/gossip_io.rs
@@ -41,7 +41,8 @@ pub trait GossipIo {
   /// The engine additionally screens this capacity at construction against its own
   /// per-pump work ceiling and rejects a ring that can hold as many datagrams as
   /// the ceiling or more, which is what bounds the decode work one pump can cost.
-  /// See [`GOSSIP_READ_CAP`](crate::GOSSIP_READ_CAP) and
+  /// See [`Options::gossip_read_cap`](crate::Options::gossip_read_cap) (whose
+  /// default is [`GOSSIP_READ_CAP`](crate::GOSSIP_READ_CAP)) and
   /// [`Engine::try_new_at`](crate::Engine::try_new_at).
   fn recv_capacity(&self) -> usize;
 

--- a/memberlist-embedded/src/transform/tests.rs
+++ b/memberlist-embedded/src/transform/tests.rs
@@ -1,14 +1,19 @@
-use super::{
-  ChecksumAlgorithm, ChecksumOptions, CompressAlgorithm, CompressionOptions, EncryptionOptions,
-  TransformOptions,
-};
+#[cfg(encryption)]
+use super::EncryptionOptions;
+use super::TransformOptions;
+#[cfg(feature = "crc32")]
+use super::{ChecksumAlgorithm, ChecksumOptions};
+#[cfg(feature = "lz4")]
+use super::{CompressAlgorithm, CompressionOptions};
 
 #[test]
 fn default_is_disabled_and_unlabelled() {
   for opts in [TransformOptions::new(), TransformOptions::default()] {
     assert!(opts.label().is_none());
     assert!(!opts.skip_inbound_label_check());
+    #[cfg(compression)]
     assert!(opts.compression.algorithm().is_none());
+    #[cfg(checksum)]
     assert!(opts.checksum.algorithm().is_none());
   }
 }
@@ -25,7 +30,7 @@ fn label_validation_and_skip_flag_round_trip() {
   // An empty slice and `None` both normalize to no label.
   assert!(
     TransformOptions::new()
-      .with_label(Some(Vec::new()))
+      .with_label(Some(std::vec::Vec::new()))
       .unwrap()
       .label()
       .is_none()
@@ -51,12 +56,25 @@ fn label_validation_and_skip_flag_round_trip() {
   );
 }
 
+#[cfg(feature = "lz4")]
 #[test]
-fn compression_checksum_and_encryption_builders_set_their_fields() {
+fn the_compression_builder_sets_its_field() {
   let opts = TransformOptions::new()
-    .with_compression(CompressionOptions::new().with_algorithm(CompressAlgorithm::Lz4))
-    .with_checksum(ChecksumOptions::new().with_algorithm(ChecksumAlgorithm::Crc32))
-    .with_encryption(EncryptionOptions::default());
+    .with_compression(CompressionOptions::new().with_algorithm(CompressAlgorithm::Lz4));
   assert_eq!(opts.compression.algorithm(), Some(CompressAlgorithm::Lz4));
+}
+
+#[cfg(feature = "crc32")]
+#[test]
+fn the_checksum_builder_sets_its_field() {
+  let opts = TransformOptions::new()
+    .with_checksum(ChecksumOptions::new().with_algorithm(ChecksumAlgorithm::Crc32));
   assert_eq!(opts.checksum.algorithm(), Some(ChecksumAlgorithm::Crc32));
+}
+
+#[cfg(encryption)]
+#[test]
+fn the_encryption_builder_sets_its_field() {
+  let opts = TransformOptions::new().with_encryption(EncryptionOptions::default());
+  assert!(opts.encryption.keyring().is_none());
 }

--- a/memberlist-proto/src/streams/mod.rs
+++ b/memberlist-proto/src/streams/mod.rs
@@ -1002,7 +1002,7 @@ where
   /// drained either at `ExchangeMeta` allocation or on the pre-`ExchangeMeta`
   /// failure paths inside `service_dials`). Test-only, used to prove the
   /// failure paths do not leak entries.
-  #[cfg(all(test, feature = "tls"))]
+  #[cfg(test)]
   pub(crate) fn pending_outbound_kinds_len(&self) -> usize {
     self.pending_outbound_kinds.len()
   }

--- a/memberlist-smoltcp/Cargo.toml
+++ b/memberlist-smoltcp/Cargo.toml
@@ -80,12 +80,8 @@ hashbrown = { version = "0.17", default-features = false, features = [
 
 [dev-dependencies]
 smol_str.workspace = true
-# Enable the lz4 + AES-GCM backends for the transform round-trip tests
-# (`tests/transform.rs`). Declared on the dev build only so the library's own
-# build stays backend-free and the no_std/bare-metal compile checks exercise the
-# disabled-transform identity paths.
-memberlist-proto = { workspace = true, default-features = false, features = [
-  "tcp",
-  "lz4",
-  "aes-gcm",
-] }
+# No transform backend is enabled here: the round-trip tests in `tests/transform.rs`
+# are gated on this crate's own `lz4` / `aes-gcm` features, so the backend arrives
+# with the feature set the build selects. A dev-dependency enabling a backend on
+# `memberlist-proto` would enable it for every lane, including the ones whose whole
+# purpose is to build without it.

--- a/memberlist-smoltcp/README.md
+++ b/memberlist-smoltcp/README.md
@@ -70,6 +70,25 @@ loop {
 }
 ```
 
+### Bounded ingress and the already-due deadline
+
+`poll` feeds the smoltcp stack at most `Options::ingress_packets_per_poll` device
+packets (default 16) before it runs the engine, so a device that keeps yielding
+cannot starve the SWIM timers or the rest of your loop. smoltcp's own
+`Interface::poll` drains the device until it is empty and documents that as
+unbounded work; this driver runs the bounded phases instead.
+
+When that budget is spent with the device still yielding, `poll` returns an
+instant **at or before the `now` you passed in**. That is not a timer: it means
+*a device backlog remains — service your other work, then poll again*. Do not
+sleep on it. A loop that sleeps *until* the returned instant and never before is
+already correct, since sleeping until a past instant returns immediately.
+
+The budget is device fairness, not gossip intake: a gossip datagram arriving with
+no free slot in `udp_rx_packets` is dropped by the UDP socket regardless of it.
+Raise `udp_rx_packets` (kept below `gossip_read_cap`) to accept more gossip per
+poll; raise `ingress_packets_per_poll` to clear more of a device backlog per poll.
+
 ## Feature flags
 
 | Feature | Description |

--- a/memberlist-smoltcp/README.md
+++ b/memberlist-smoltcp/README.md
@@ -89,6 +89,22 @@ no free slot in `udp_rx_packets` is dropped by the UDP socket regardless of it.
 Raise `udp_rx_packets` (kept below `gossip_read_cap`) to accept more gossip per
 poll; raise `ingress_packets_per_poll` to clear more of a device backlog per poll.
 
+### Gossip budget and the device MTU
+
+`EndpointOptions::gossip_mtu` is a plaintext budget; on the wire a datagram also
+carries the enabled transforms' wrapper overhead, the UDP header, and an IP
+header. This crate builds smoltcp without IP fragmentation, so a datagram wider
+than the bound device's IP MTU is not fragmented and not refused — it is enqueued
+and then discarded on egress, losing large metadata, user packets and compounded
+gossip while small probes keep working.
+
+Construction therefore rejects that combination up front
+(`InitError::GossipDatagramExceedsDeviceMtu`, carrying the bytes needed and the
+bytes available). A dual-stack interface is held to IPv6's wider header. Note the
+default 1400-byte budget does not fit a 1280-byte IPv6-minimum link. The check
+covers the LOCAL link only; sizing `gossip_mtu` for a narrower remote path is
+still yours.
+
 ## Feature flags
 
 | Feature | Description |

--- a/memberlist-smoltcp/src/config/mod.rs
+++ b/memberlist-smoltcp/src/config/mod.rs
@@ -12,6 +12,14 @@ use core::time::Duration;
 /// and its closing socket are reclaimed on the same order of timescale.
 pub const DEFAULT_CLOSE_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Default [`Options::ingress_packets_per_poll`]: 16 device packets.
+///
+/// Twice the default `udp_rx_packets`, so a burst that fills the gossip ring
+/// still leaves per-poll budget for the reliable plane's segments, while a
+/// sustained flood is cut off after a bounded amount of stack work and the engine
+/// runs on every call.
+pub const DEFAULT_INGRESS_PACKETS_PER_POLL: usize = 16;
+
 /// Sizing and ports for [`Memberlist`](crate::Memberlist). All buffers are
 /// fixed-capacity at construction (smoltcp has no growable backing on no_std);
 /// gossip overflow drops, reliable overflow backpressures.
@@ -56,6 +64,33 @@ pub struct Options {
   ///
   /// Must be non-zero. Defaults to [`memberlist_embedded::GOSSIP_READ_CAP`].
   pub gossip_read_cap: usize,
+  /// Maximum device packets one [`poll`](crate::Memberlist::poll) feeds into the
+  /// smoltcp stack before it runs the engine.
+  ///
+  /// smoltcp's own `Interface::poll` drains the device until it stops yielding,
+  /// which is unbounded work when packets arrive faster than they are processed —
+  /// its documented DoS caveat. A caller-driven super-loop has no preemption, so
+  /// an unbounded ingress phase would starve every SWIM timer, the application's
+  /// event drain, and whatever else shares the loop. `poll` therefore feeds at
+  /// most this many packets per call and always reaches the engine; when the
+  /// budget is spent with the device still yielding, `poll` returns an
+  /// already-due deadline meaning "device backlog remains: service your other
+  /// work, then poll again".
+  ///
+  /// This is a device-fairness knob, INDEPENDENT of the gossip ring: a gossip
+  /// datagram arriving with no free slot in [`udp_rx_packets`](Self::udp_rx_packets)
+  /// is tail-dropped by smoltcp's UDP socket inside the ingress loop whatever this
+  /// value is (`udp::Socket::process` drops on a full rx buffer). So raising it
+  /// buys TCP and device progress per poll, not gossip intake — raise
+  /// `udp_rx_packets` (below [`gossip_read_cap`](Self::gossip_read_cap)) for that.
+  ///
+  /// The tradeoff is throughput against latency: a larger budget clears more of a
+  /// device backlog per call and amortises the per-poll engine work, while a
+  /// smaller one returns to the caller — and to the SWIM timers — sooner under
+  /// sustained ingress. Must be non-zero; the default of 16 is twice the shipped
+  /// `udp_rx_packets`, so an idle-to-busy burst that fills the gossip ring still
+  /// leaves budget for the reliable plane's segments in the same poll.
+  pub ingress_packets_per_poll: usize,
   /// Maximum time a gracefully-closing TCP socket may stay parked before it is
   /// force-aborted and returned to the pool.
   ///
@@ -88,6 +123,7 @@ impl Default for Options {
       udp_rx_payload_bytes: 8 * 1500,
       udp_tx_payload_bytes: 8 * 1500,
       gossip_read_cap: memberlist_embedded::GOSSIP_READ_CAP,
+      ingress_packets_per_poll: DEFAULT_INGRESS_PACKETS_PER_POLL,
       close_timeout: DEFAULT_CLOSE_TIMEOUT,
       #[cfg(feature = "cidr")]
       cidr_policy: None,
@@ -124,6 +160,13 @@ impl Options {
   /// [`Options::gossip_read_cap`]). Must be non-zero.
   pub fn with_gossip_read_cap(mut self, cap: usize) -> Self {
     self.gossip_read_cap = cap;
+    self
+  }
+
+  /// Override the per-poll device ingress budget (see
+  /// [`Options::ingress_packets_per_poll`]). Must be non-zero.
+  pub fn with_ingress_packets_per_poll(mut self, n: usize) -> Self {
+    self.ingress_packets_per_poll = n;
     self
   }
 

--- a/memberlist-smoltcp/src/config/mod.rs
+++ b/memberlist-smoltcp/src/config/mod.rs
@@ -32,11 +32,11 @@ pub struct Options {
   pub tcp_socket_tx_bytes: usize,
   /// UDP rx datagram metadata slots.
   ///
-  /// Must be strictly below the engine's per-pump gossip read cap
-  /// ([`memberlist_embedded::GOSSIP_READ_CAP`]), which construction enforces —
-  /// here, before the UDP arenas this count sizes are allocated, and again in the
-  /// engine against the bound socket. The engine applies every datagram it pops
-  /// within that pump, so this count is the per-pump gossip work budget.
+  /// Must be strictly below [`gossip_read_cap`](Self::gossip_read_cap), which
+  /// construction enforces — here, before the UDP arenas this count sizes are
+  /// allocated, and again in the engine against the bound socket. The engine
+  /// applies every datagram it pops within that pump, so this count is the
+  /// per-pump gossip work budget.
   pub udp_rx_packets: usize,
   /// UDP tx datagram metadata slots.
   pub udp_tx_packets: usize,
@@ -44,6 +44,18 @@ pub struct Options {
   pub udp_rx_payload_bytes: usize,
   /// UDP tx payload byte arena.
   pub udp_tx_payload_bytes: usize,
+  /// The engine's per-pump gossip work ceiling, forwarded to
+  /// [`memberlist_embedded::Options::gossip_read_cap`].
+  ///
+  /// Construction rejects a [`udp_rx_packets`](Self::udp_rx_packets) at or above
+  /// it (before the UDP arenas are allocated), and the engine rejects a bound
+  /// gossip socket whose receive ring reaches it. A pump applies every datagram it
+  /// pops, so this bounds the unwrap/decode/apply work one
+  /// [`poll`](crate::Memberlist::poll) spends on gossip; its byte implication is
+  /// `gossip_read_cap × (gossip_mtu + transform overhead)`.
+  ///
+  /// Must be non-zero. Defaults to [`memberlist_embedded::GOSSIP_READ_CAP`].
+  pub gossip_read_cap: usize,
   /// Maximum time a gracefully-closing TCP socket may stay parked before it is
   /// force-aborted and returned to the pool.
   ///
@@ -75,6 +87,7 @@ impl Default for Options {
       udp_tx_packets: 8,
       udp_rx_payload_bytes: 8 * 1500,
       udp_tx_payload_bytes: 8 * 1500,
+      gossip_read_cap: memberlist_embedded::GOSSIP_READ_CAP,
       close_timeout: DEFAULT_CLOSE_TIMEOUT,
       #[cfg(feature = "cidr")]
       cidr_policy: None,
@@ -104,6 +117,13 @@ impl Options {
   /// Override the graceful-close timeout (see [`Options::close_timeout`]).
   pub fn with_close_timeout(mut self, d: Duration) -> Self {
     self.close_timeout = d;
+    self
+  }
+
+  /// Override the engine's per-pump gossip work ceiling (see
+  /// [`Options::gossip_read_cap`]). Must be non-zero.
+  pub fn with_gossip_read_cap(mut self, cap: usize) -> Self {
+    self.gossip_read_cap = cap;
     self
   }
 

--- a/memberlist-smoltcp/src/error/mod.rs
+++ b/memberlist-smoltcp/src/error/mod.rs
@@ -215,8 +215,8 @@ pub enum InitError {
   /// Both must be non-zero.
   ZeroUdpPackets,
   /// [`Options::udp_rx_packets`](crate::Options::udp_rx_packets) is not below the
-  /// engine's per-pump gossip read cap
-  /// ([`memberlist_embedded::GOSSIP_READ_CAP`]).
+  /// configured per-pump gossip read cap
+  /// ([`Options::gossip_read_cap`](crate::Options::gossip_read_cap)).
   ///
   /// The cap is the engine's per-pump work ceiling: it applies every datagram it
   /// pops within the pump that popped it, so the accepted ring size is that pump's
@@ -231,6 +231,12 @@ pub enum InitError {
   /// ([`memberlist_embedded::InitError::GossipRecvCapacityTooLarge`]), which this
   /// variant also carries — surfaced under the name of the option to lower.
   UdpRxPacketsTooLarge,
+  /// [`Options::gossip_read_cap`](crate::Options::gossip_read_cap) is zero.
+  ///
+  /// The cap is the engine's per-pump gossip work ceiling, and both the driver's
+  /// `udp_rx_packets` screen and the engine's receive-ring screen are STRICTLY
+  /// BELOW it, so a zero cap admits no gossip ring at all. Must be non-zero.
+  ZeroGossipReadCap,
   /// [`Options::close_timeout`](crate::Options::close_timeout) is zero.
   ///
   /// `close_timeout` bounds the graceful reliable-close drain: a connection
@@ -351,11 +357,11 @@ impl fmt::Display for InitError {
       InitError::ZeroUdpPackets => {
         f.write_str("udp_rx_packets and udp_tx_packets must be non-zero")
       }
-      InitError::UdpRxPacketsTooLarge => write!(
-        f,
-        "udp_rx_packets must be below the engine's per-pump gossip read cap ({})",
-        memberlist_embedded::GOSSIP_READ_CAP
+      InitError::UdpRxPacketsTooLarge => f.write_str(
+        "udp_rx_packets must be below the configured per-pump gossip read cap \
+         (Options::gossip_read_cap)",
       ),
+      InitError::ZeroGossipReadCap => f.write_str("gossip_read_cap must be non-zero"),
       InitError::ZeroCloseTimeout => f.write_str("close_timeout must be non-zero"),
     }
   }
@@ -382,6 +388,7 @@ impl InitError {
       E::AdvertisePortMismatch => InitError::AdvertisePortMismatch,
       E::ZeroPort => InitError::ZeroPort,
       E::ZeroCloseTimeout => InitError::ZeroCloseTimeout,
+      E::ZeroGossipReadCap => InitError::ZeroGossipReadCap,
       E::GossipMtuTooLarge(m) => InitError::GossipMtuTooLarge(GossipMtuTooLarge {
         gossip_mtu: m.gossip_mtu,
         ceiling: m.ceiling,

--- a/memberlist-smoltcp/src/error/mod.rs
+++ b/memberlist-smoltcp/src/error/mod.rs
@@ -174,6 +174,23 @@ pub enum InitError {
   /// wrap to an undersized arena in release). The configured value and the
   /// effective ceiling are carried for diagnostics.
   GossipMtuTooLarge(GossipMtuTooLarge),
+  /// The largest gossip datagram this configuration can emit does not fit the
+  /// bound device's IP MTU.
+  ///
+  /// This crate enables neither of smoltcp's IP fragmentation features, so an
+  /// oversized datagram is neither fragmented nor refused: the UDP socket accepts
+  /// it (gossip is best-effort, and `send_slice` checks only the payload arena) and
+  /// the next egress pass dequeues it and discards it — smoltcp's `dispatch_ip`
+  /// reports success without transmitting when the IP packet exceeds `ip_mtu()`.
+  /// Large metadata, user packets, compounded gossip and transformed frames would
+  /// silently vanish while small probes kept working: partial convergence and false
+  /// suspicion on a node that looks healthy.
+  ///
+  /// The device MTU is not path speculation — it is known and cached at
+  /// construction — so the constructor rejects the combination instead. A remote
+  /// path can still be narrower than the local link; sizing `gossip_mtu` for the
+  /// path remains the operator's.
+  GossipDatagramExceedsDeviceMtu(GossipDatagramExceedsDeviceMtu),
   /// A UDP arena byte count (`udp_*_packets × max on-wire datagram`) overflows
   /// `usize`.
   ///
@@ -253,6 +270,33 @@ pub enum InitError {
   /// immediately — the drain never runs and an in-flight push/pull response is
   /// truncated. Must be non-zero.
   ZeroCloseTimeout,
+}
+
+/// The largest gossip datagram this configuration can emit exceeds what the bound
+/// device can carry in one unfragmented IP packet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GossipDatagramExceedsDeviceMtu {
+  /// Bytes one maximum-size gossip datagram needs in an IP packet: the widest IP
+  /// header the configured address families use, plus the 8-byte UDP header, plus
+  /// `gossip_mtu` and the enabled transforms' wrapper overhead.
+  pub required: usize,
+  /// Bytes the bound device can carry in one IP packet — its MTU less any medium
+  /// header (smoltcp's `DeviceCapabilities::ip_mtu`), which is the same figure
+  /// smoltcp's own dispatch compares against before dropping.
+  pub available: usize,
+}
+
+impl fmt::Display for GossipDatagramExceedsDeviceMtu {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(
+      f,
+      "the largest gossip datagram this configuration can emit needs {} bytes of IP packet \
+       but the bound device carries only {} (no IP fragmentation is compiled in, so an \
+       oversized datagram would be enqueued and then silently discarded): lower gossip_mtu, \
+       drop a transform, or bind a device with a larger MTU",
+      self.required, self.available
+    )
+  }
 }
 
 /// The configured gossip MTU exceeds the largest plaintext payload whose on-wire
@@ -350,6 +394,7 @@ impl fmt::Display for InitError {
       #[cfg(checksum)]
       InitError::Checksum(e) => write!(f, "checksum configuration is unusable: {e}"),
       InitError::GossipMtuTooLarge(m) => write!(f, "{m}"),
+      InitError::GossipDatagramExceedsDeviceMtu(m) => write!(f, "{m}"),
       InitError::UdpArenaTooLarge => {
         f.write_str("UDP arena byte count (packets × max datagram) overflows usize")
       }

--- a/memberlist-smoltcp/src/error/mod.rs
+++ b/memberlist-smoltcp/src/error/mod.rs
@@ -237,6 +237,14 @@ pub enum InitError {
   /// `udp_rx_packets` screen and the engine's receive-ring screen are STRICTLY
   /// BELOW it, so a zero cap admits no gossip ring at all. Must be non-zero.
   ZeroGossipReadCap,
+  /// [`Options::ingress_packets_per_poll`](crate::Options::ingress_packets_per_poll)
+  /// is zero.
+  ///
+  /// It is the per-poll device ingress budget. Zero would feed the stack no
+  /// packet at all, so nothing inbound — no gossip datagram, no TCP segment, no
+  /// handshake — could ever reach the node while `poll` still reported a device
+  /// backlog on every call. Must be non-zero.
+  ZeroIngressPacketsPerPoll,
   /// [`Options::close_timeout`](crate::Options::close_timeout) is zero.
   ///
   /// `close_timeout` bounds the graceful reliable-close drain: a connection
@@ -362,6 +370,9 @@ impl fmt::Display for InitError {
          (Options::gossip_read_cap)",
       ),
       InitError::ZeroGossipReadCap => f.write_str("gossip_read_cap must be non-zero"),
+      InitError::ZeroIngressPacketsPerPoll => {
+        f.write_str("ingress_packets_per_poll must be non-zero")
+      }
       InitError::ZeroCloseTimeout => f.write_str("close_timeout must be non-zero"),
     }
   }

--- a/memberlist-smoltcp/src/error/tests.rs
+++ b/memberlist-smoltcp/src/error/tests.rs
@@ -3,6 +3,7 @@ use crate::interface::{
   EthernetAddress, HardwareAddress, IpAddress, IpCidr, Ipv4Address, Medium, Route,
 };
 use core::net::{Ipv4Addr, SocketAddr};
+use std::{vec, vec::Vec};
 
 fn sample_cidr() -> IpCidr {
   IpCidr::new(IpAddress::v4(224, 0, 0, 1), 24)
@@ -51,12 +52,18 @@ fn all_variants() -> Vec<InitError> {
       gossip_mtu: 70_000,
       ceiling: 65_467,
     }),
+    InitError::GossipDatagramExceedsDeviceMtu(GossipDatagramExceedsDeviceMtu {
+      required: 1_520,
+      available: 1_500,
+    }),
     InitError::UdpArenaTooLarge,
     InitError::TcpPoolTooSmall,
     InitError::ZeroTcpSocketBuffer,
     InitError::TcpRxBufferTooLarge,
     InitError::ZeroUdpPackets,
     InitError::UdpRxPacketsTooLarge,
+    InitError::ZeroGossipReadCap,
+    InitError::ZeroIngressPacketsPerPoll,
     InitError::ZeroCloseTimeout,
   ]
 }
@@ -184,11 +191,13 @@ fn source_chains_only_for_wrapping_variants() {
       .source()
       .is_some()
   );
+  #[cfg(encryption)]
   assert!(
     InitError::Encryption(memberlist_proto::EncryptionError::AuthFailed)
       .source()
       .is_some()
   );
+  #[cfg(checksum)]
   assert!(
     InitError::Checksum(memberlist_proto::ChecksumError::Mismatch)
       .source()

--- a/memberlist-smoltcp/src/lib.rs
+++ b/memberlist-smoltcp/src/lib.rs
@@ -23,7 +23,9 @@ extern crate std;
 compile_error!("memberlist-smoltcp requires the `std` or `alloc` feature");
 
 pub use config::Options;
-pub use error::{GossipMtuTooLarge, InitError, JoinError, MediumMismatch};
+pub use error::{
+  GossipDatagramExceedsDeviceMtu, GossipMtuTooLarge, InitError, JoinError, MediumMismatch,
+};
 pub use interface::{
   EthernetAddress, HardwareAddress, InterfaceOptions, IpAddress, IpCidr, Ipv4Address, Ipv6Address,
   Medium, Route,

--- a/memberlist-smoltcp/src/memberlist/mod.rs
+++ b/memberlist-smoltcp/src/memberlist/mod.rs
@@ -22,12 +22,14 @@ use smoltcp::{
   socket::{tcp, udp},
 };
 
+use smoltcp::wire::{IPV4_HEADER_LEN, IPV6_HEADER_LEN, UDP_HEADER_LEN};
+
 use crate::{
   InitError, InterfaceOptions, JoinError, Options, Resolver, TransformOptions,
   addr::{from_smoltcp_instant, to_endpoint, to_smoltcp_duration, to_smoltcp_instant},
-  error::{GossipMtuTooLarge, MediumMismatch},
+  error::{GossipDatagramExceedsDeviceMtu, GossipMtuTooLarge, MediumMismatch},
   gossip_io::SmoltcpGossip,
-  interface::{HardwareAddress, Medium},
+  interface::{HardwareAddress, IpCidr, Medium},
   stream_io::SmoltcpStream,
 };
 use core::marker::PhantomData;
@@ -36,6 +38,19 @@ use std::{boxed::Box, sync::Arc, vec::Vec};
 /// The maximum UDP payload (`u16` length minus the 8-byte UDP header), the
 /// hard ceiling for an on-wire gossip datagram. Matches the async drivers.
 const UDP_PAYLOAD_MAX: usize = 65507;
+
+/// The largest on-wire gossip datagram a node with this `gossip_mtu` can emit:
+/// the machine caps an outbound datagram's PLAINTEXT at `gossip_mtu`, and the
+/// enabled transforms add at most one encryption wrapper and one checksum wrapper
+/// on top of it.
+///
+/// The UDP arenas are floored at this per slot, and the device-MTU guard measures
+/// it against the bound link, so both read one definition. `gossip_mtu` is bounded
+/// above by the UDP payload ceiling before either uses this, so the addition
+/// cannot overflow.
+const fn max_gossip_datagram(gossip_mtu: usize) -> usize {
+  gossip_mtu + ENCRYPTED_WRAPPER_OVERHEAD + CHECKSUMED_WRAPPER_OVERHEAD
+}
 
 /// The largest the encrypted wrapper can inflate a gossip datagram, or `0` when
 /// no encryption backend is built in. The proto const exists only under an
@@ -317,6 +332,13 @@ where
   ///   neither unicast nor unspecified (checked here so smoltcp's
   ///   `check_ip_addrs` can never `panic!`).
   /// - [`InitError::MissingIpAddress`] — `iface.ip_addrs` is empty.
+  /// - [`InitError::GossipDatagramExceedsDeviceMtu`] — the largest gossip
+  ///   datagram `ep_cfg.gossip_mtu()` and the enabled transforms can produce does
+  ///   not fit `device.capabilities().ip_mtu()` once the UDP header and the widest
+  ///   IP header of the configured address families are added. This build has no
+  ///   IP fragmentation, so such a datagram would be enqueued and then silently
+  ///   discarded on egress; lower `gossip_mtu` or bind a wider device. The check
+  ///   is against the LOCAL link only — a remote path can still be narrower.
   /// - [`InitError::TooManyIpAddresses`] / [`InitError::TooManyRoutes`] — more
   ///   addresses or routes than smoltcp's interface can hold.
   /// - [`InitError::Entropy`] — `iface.random_seed` was `None` and the system
@@ -375,7 +397,12 @@ where
     //    supported but differs from the device's is a `MediumMismatch`.
     let expected =
       hardware_address_medium(&iface.hardware_addr).ok_or(InitError::UnsupportedMedium)?;
-    let actual = device.capabilities().medium;
+    // Read the device's capabilities ONCE: the medium is checked here, and the IP
+    // MTU below bounds the largest gossip datagram this configuration can emit.
+    // smoltcp itself caches these at `Interface::new`, so the device is expected to
+    // report the same values throughout its life.
+    let caps = device.capabilities();
+    let actual = caps.medium;
     if expected != actual {
       return Err(InitError::MediumMismatch(MediumMismatch {
         expected,
@@ -460,6 +487,43 @@ where
         gossip_mtu: ep_cfg.gossip_mtu(),
         ceiling: gossip_mtu_ceiling,
       }));
+    }
+
+    // Reject a gossip datagram the BOUND DEVICE cannot carry in one IP packet.
+    // The ceiling above bounds the datagram against the protocol's 65507-byte UDP
+    // limit; this bounds it against the link actually in hand, which construction
+    // already knows. This crate enables neither of smoltcp's fragmentation
+    // features, so an oversized datagram is not fragmented and not refused: the UDP
+    // socket accepts it (gossip is best-effort, `send_slice` only checks the arena),
+    // and the next egress pass dequeues it and drops it — `dispatch_ip` returns
+    // success without transmitting when the IP packet exceeds `ip_mtu()`. Large
+    // metadata, user packets and compounded gossip would vanish while small probes
+    // kept working: partial convergence and false suspicion on a node that looks
+    // healthy. Reject it here instead, before any allocation.
+    //
+    // The comparison mirrors `dispatch_ip`'s own: the IP packet is the header plus
+    // the UDP header plus the largest transformed datagram the machine can emit, and
+    // it must fit `ip_mtu()` (the device MTU less any medium header). The IP header
+    // is the widest of the configured address families — a dual-stack interface must
+    // satisfy both, and IPv6's 40-byte header is the binding one.
+    let ip_header = if iface
+      .ip_addrs
+      .iter()
+      .any(|cidr| matches!(cidr, IpCidr::Ipv6(_)))
+    {
+      IPV6_HEADER_LEN
+    } else {
+      IPV4_HEADER_LEN
+    };
+    let required = ip_header + UDP_HEADER_LEN + max_gossip_datagram(ep_cfg.gossip_mtu());
+    let available = caps.ip_mtu();
+    if required > available {
+      return Err(InitError::GossipDatagramExceedsDeviceMtu(
+        GossipDatagramExceedsDeviceMtu {
+          required,
+          available,
+        },
+      ));
     }
 
     // Reject a sub-2 TCP pool. Construction dedicates one pooled socket to the
@@ -621,8 +685,7 @@ where
     // 32-bit target (e.g. `usize::MAX / 65507 ≈ 65541` packet slots), so use
     // `checked_mul` and reject an overflowing arena rather than wrapping to an
     // undersized one.
-    let max_datagram =
-      ep_cfg.gossip_mtu() + ENCRYPTED_WRAPPER_OVERHEAD + CHECKSUMED_WRAPPER_OVERHEAD;
+    let max_datagram = max_gossip_datagram(ep_cfg.gossip_mtu());
     let udp_rx_arena = cfg.udp_rx_payload_bytes.max(
       cfg
         .udp_rx_packets
@@ -855,7 +918,12 @@ where
     //    supported but differs from the device's is a `MediumMismatch`.
     let expected =
       hardware_address_medium(&iface.hardware_addr).ok_or(InitError::UnsupportedMedium)?;
-    let actual = device.capabilities().medium;
+    // Read the device's capabilities ONCE: the medium is checked here, and the IP
+    // MTU below bounds the largest gossip datagram this configuration can emit.
+    // smoltcp itself caches these at `Interface::new`, so the device is expected to
+    // report the same values throughout its life.
+    let caps = device.capabilities();
+    let actual = caps.medium;
     if expected != actual {
       return Err(InitError::MediumMismatch(MediumMismatch {
         expected,
@@ -940,6 +1008,43 @@ where
         gossip_mtu: ep_cfg.gossip_mtu(),
         ceiling: gossip_mtu_ceiling,
       }));
+    }
+
+    // Reject a gossip datagram the BOUND DEVICE cannot carry in one IP packet.
+    // The ceiling above bounds the datagram against the protocol's 65507-byte UDP
+    // limit; this bounds it against the link actually in hand, which construction
+    // already knows. This crate enables neither of smoltcp's fragmentation
+    // features, so an oversized datagram is not fragmented and not refused: the UDP
+    // socket accepts it (gossip is best-effort, `send_slice` only checks the arena),
+    // and the next egress pass dequeues it and drops it — `dispatch_ip` returns
+    // success without transmitting when the IP packet exceeds `ip_mtu()`. Large
+    // metadata, user packets and compounded gossip would vanish while small probes
+    // kept working: partial convergence and false suspicion on a node that looks
+    // healthy. Reject it here instead, before any allocation.
+    //
+    // The comparison mirrors `dispatch_ip`'s own: the IP packet is the header plus
+    // the UDP header plus the largest transformed datagram the machine can emit, and
+    // it must fit `ip_mtu()` (the device MTU less any medium header). The IP header
+    // is the widest of the configured address families — a dual-stack interface must
+    // satisfy both, and IPv6's 40-byte header is the binding one.
+    let ip_header = if iface
+      .ip_addrs
+      .iter()
+      .any(|cidr| matches!(cidr, IpCidr::Ipv6(_)))
+    {
+      IPV6_HEADER_LEN
+    } else {
+      IPV4_HEADER_LEN
+    };
+    let required = ip_header + UDP_HEADER_LEN + max_gossip_datagram(ep_cfg.gossip_mtu());
+    let available = caps.ip_mtu();
+    if required > available {
+      return Err(InitError::GossipDatagramExceedsDeviceMtu(
+        GossipDatagramExceedsDeviceMtu {
+          required,
+          available,
+        },
+      ));
     }
 
     // Reject a sub-2 TCP pool. Construction dedicates one pooled socket to the
@@ -1091,8 +1196,7 @@ where
     // 32-bit target (e.g. `usize::MAX / 65507 ≈ 65541` packet slots), so use
     // `checked_mul` and reject an overflowing arena rather than wrapping to an
     // undersized one.
-    let max_datagram =
-      ep_cfg.gossip_mtu() + ENCRYPTED_WRAPPER_OVERHEAD + CHECKSUMED_WRAPPER_OVERHEAD;
+    let max_datagram = max_gossip_datagram(ep_cfg.gossip_mtu());
     let udp_rx_arena = cfg.udp_rx_payload_bytes.max(
       cfg
         .udp_rx_packets

--- a/memberlist-smoltcp/src/memberlist/mod.rs
+++ b/memberlist-smoltcp/src/memberlist/mod.rs
@@ -15,7 +15,9 @@ use memberlist_proto::{
   typed::NodeState,
 };
 use smoltcp::{
-  iface::{Config as IfConfig, Interface, SocketHandle, SocketSet},
+  iface::{
+    Config as IfConfig, Interface, PollIngressSingleResult, PollResult, SocketHandle, SocketSet,
+  },
   phy::Device,
   socket::{tcp, udp},
 };
@@ -205,6 +207,11 @@ pub struct Memberlist<I, A, D, R = SmallRng> {
   sockets: SocketSet<'static>,
   /// Handle into `sockets` for the gossip UDP socket.
   udp: SocketHandle,
+  /// Maximum device packets one [`poll`](Self::poll) feeds into the stack before
+  /// it runs the engine (`Options::ingress_packets_per_poll`). Retained because
+  /// the bound applies to every poll, not just construction; validated non-zero
+  /// there.
+  ingress_packets_per_poll: usize,
   /// The transport-agnostic driving core: the SWIM machine, the reliable-plane
   /// connection state machine and its `SocketHandle` pool, the gossip codec
   /// pipeline, and the join-seed queue. The driver owns only the smoltcp sockets;
@@ -492,6 +499,15 @@ where
       return Err(InitError::ZeroUdpPackets);
     }
 
+    // Reject a zero per-poll device ingress budget. `poll` feeds the stack at most
+    // that many packets before running the engine, so zero would feed it none: no
+    // gossip datagram, TCP segment or handshake could ever reach the node, while
+    // every poll still reported a device backlog. Checked with the other
+    // pure-`Options` guards.
+    if cfg.ingress_packets_per_poll == 0 {
+      return Err(InitError::ZeroIngressPacketsPerPoll);
+    }
+
     // Reject a gossip rx ring at or above the CONFIGURED per-pump gossip read cap
     // BEFORE the UDP arenas are sized and allocated below. This is an allocation
     // guard: `udp_rx_packets` scales the metadata ring AND floors the payload
@@ -741,6 +757,7 @@ where
       iface_random_seed: random_seed,
       sockets,
       udp,
+      ingress_packets_per_poll: cfg.ingress_packets_per_poll,
       engine,
       _device: PhantomData,
       _a: PhantomData,
@@ -960,6 +977,15 @@ where
     // packet buffers below.
     if cfg.udp_rx_packets == 0 || cfg.udp_tx_packets == 0 {
       return Err(InitError::ZeroUdpPackets);
+    }
+
+    // Reject a zero per-poll device ingress budget. `poll` feeds the stack at most
+    // that many packets before running the engine, so zero would feed it none: no
+    // gossip datagram, TCP segment or handshake could ever reach the node, while
+    // every poll still reported a device backlog. Checked with the other
+    // pure-`Options` guards.
+    if cfg.ingress_packets_per_poll == 0 {
+      return Err(InitError::ZeroIngressPacketsPerPoll);
     }
 
     // Reject a gossip rx ring at or above the CONFIGURED per-pump gossip read cap
@@ -1193,6 +1219,7 @@ where
       iface_random_seed: random_seed,
       sockets,
       udp,
+      ingress_packets_per_poll: cfg.ingress_packets_per_poll,
       engine,
       _device: PhantomData,
       _a: PhantomData,
@@ -1741,33 +1768,98 @@ where
   /// caller that sleeps exactly to it always wakes in time to honor them —
   /// including reclaiming a closing socket by `Options::close_timeout`.
   ///
+  /// # The already-due deadline: work remains
+  ///
+  /// A returned instant at or before `now` is not a timer; it means **a device
+  /// backlog remains — service your other work, then poll again**. It is folded
+  /// when the ingress phase spends its whole
+  /// [`ingress_packets_per_poll`](crate::Options::ingress_packets_per_poll) budget
+  /// with the device still yielding packets. The unread remainder stays in the
+  /// device's own receive queue, ahead of the stack, and is drained by the
+  /// immediately following poll. A caller must not sleep on it: run the rest of
+  /// its loop and come straight back. A caller that treats every returned instant
+  /// uniformly — sleep until it, never before — is already correct, since sleeping
+  /// until an instant already past returns at once.
+  ///
   /// # Order
   ///
-  /// 1. **Stack tick** — `iface.poll` drains the device and services TCP/UDP.
-  /// 2. **Engine pump** — the engine runs every protocol phase over a
+  /// 1. **Stack maintenance** — advance the interface's clock and run its
+  ///    time-driven upkeep.
+  /// 2. **Bounded ingress** — feed the stack at most `ingress_packets_per_poll`
+  ///    device packets, stopping early when the device has none left. This
+  ///    replaces smoltcp's own `Interface::poll`, whose ingress loop runs until
+  ///    the device stops yielding and is therefore unbounded when packets arrive
+  ///    faster than they are processed (smoltcp documents this DoS caveat on
+  ///    `poll` and offers `poll_ingress_single` for exactly this reason). A
+  ///    caller-driven super-loop has no preemption, so an unbounded ingress phase
+  ///    would starve every SWIM timer and every other task sharing the loop.
+  /// 3. **Stack egress** — completing the tick, since smoltcp applies a socket's
+  ///    inactivity timeout on its dispatch path: this is where the link layer's
+  ///    own reaping becomes visible to the engine that reads the sockets next.
+  /// 4. **Engine pump** — the engine runs every protocol phase over a
   ///    [`SmoltcpGossip`] + [`SmoltcpStream`] view of the just-ticked sockets:
   ///    reap closing sockets, accept inbound and replenish the listener,
   ///    rebalance deferred dials, drain UDP gossip ingress through the codec,
   ///    pump reliable ingress, drain join seeds, fire machine timers, then drain
   ///    stream actions and TCP/UDP egress. See
   ///    [`Engine::pump`](memberlist_embedded::Engine::pump) for the full ordered
-  ///    phase list.
-  /// 3. **Deadline** — fold the smoltcp stack's next scheduled event (`poll_at`)
-  ///    into the engine's returned `min(machine, closing)` wakeup, so a caller
-  ///    sleeping to the result wakes in time for the stack's retransmit /
-  ///    delayed-ACK timers as well as every engine-owned deadline.
+  ///    phase list. It runs on EVERY poll, whatever the device is doing.
+  /// 5. **Egress again** — put what the pump just produced on the wire in this
+  ///    same poll, rather than leaving it for the next one: its gossip datagrams,
+  ///    its reliable segments, and the RST of anything it aborted, the last ahead
+  ///    of any later poll's rebalance reusing that socket for a new role.
+  /// 6. **Deadline** — fold the smoltcp stack's next scheduled event (`poll_at`)
+  ///    into the engine's returned `min(machine, closing)` wakeup, plus `now`
+  ///    itself if the ingress budget was exhausted, so a caller sleeping to the
+  ///    result wakes in time for the stack's retransmit / delayed-ACK timers, for
+  ///    every engine-owned deadline, and at once while a device backlog remains.
   pub fn poll(&mut self, now: Instant, device: &mut D) -> Option<Instant>
   where
     D: Device,
   {
     let s_now = to_smoltcp_instant(now);
 
-    // 1. Stack tick.
-    // `PollResult` is ignored — the engine drives its own state over the views
-    // below; we do not gate machine work on stack idle/active.
-    self.iface.poll(s_now, device, &mut self.sockets);
+    // 1. Stack maintenance. `Interface::poll` begins by stamping this instant onto
+    // the interface and running its time-driven upkeep (fragment-reassembly expiry,
+    // SLAAC); `poll_maintenance` is that same step, exposed for callers that drive
+    // the phases themselves. It must run even on a poll that feeds no packet, so
+    // the stack's notion of "now" tracks the caller's clock.
+    self.iface.poll_maintenance(s_now);
 
-    // 2. Engine pump over a view of the just-ticked sockets. smoltcp keeps the
+    // 2. Bounded ingress. This is the loop `Interface::poll` runs unbounded: each
+    // `poll_ingress_single` takes at most one packet from the device and drives it
+    // through the interface into the sockets, so capping the iteration count caps
+    // the work. `None` means the device had nothing more and the backlog is clear;
+    // any other result means a packet was processed and there may be more.
+    //
+    // Spending the whole budget without ever seeing `None` is the only signal that
+    // the device still has traffic waiting: the remainder sits in the DEVICE's own
+    // queue, untouched by the stack, and the immediately following poll drains it.
+    // That is what step 5 turns into an already-due deadline.
+    let mut budget_exhausted = true;
+    for _ in 0..self.ingress_packets_per_poll {
+      if self
+        .iface
+        .poll_ingress_single(s_now, device, &mut self.sockets)
+        == PollIngressSingleResult::None
+      {
+        budget_exhausted = false;
+        break;
+      }
+    }
+
+    // 3. Stack egress, completing the tick `Interface::poll` would have performed:
+    // maintenance, ingress, then egress to exhaustion. It is not optional dressing
+    // — smoltcp applies a socket's inactivity timeout inside its dispatch, on the
+    // egress path (`tcp::Socket::dispatch` aborts a socket whose peer has been
+    // silent past `set_timeout`), so the engine's view of which sockets the link
+    // layer has reaped is established here, before the pump reads it. `poll_egress`
+    // is bounded per call and reports whether it changed any socket state, so it is
+    // looped to exhaustion exactly as `Interface::poll` does; the input is only
+    // what this node already chose to send.
+    while self.iface.poll_egress(s_now, device, &mut self.sockets) != PollResult::None {}
+
+    // 4. Engine pump over a view of the just-ticked sockets. smoltcp keeps the
     // gossip UDP socket and the reliable-plane TCP pool in ONE `SocketSet`, so the
     // gossip and stream views share mutable access to it through a `RefCell` held
     // for the pump's duration; each view's methods take a brief `borrow_mut` and
@@ -1783,10 +1875,10 @@ where
       self.engine.pump(now, &mut gossip, &mut stream)
     };
 
-    // 2b. Re-arm a listener the inactivity timeout just reaped, routing it through
+    // 4b. Re-arm a listener the inactivity timeout just reaped, routing it through
     // the engine's occupancy ledger. When an unauthenticated half-open (a
     // `SynReceived` whose final ACK is withheld) — or a stalled established exchange
-    // — sits idle past the socket timeout, step 1's stack tick drives that socket to
+    // — sits idle past the socket timeout, the ingress phase drives that socket to
     // `Closed`. The engine keeps its handle installed as the listener (it swaps the
     // slot out only on a completed accept, and never re-arms a socket the link layer
     // closed underneath it), so without this the single direct-smoltcp listener
@@ -1809,18 +1901,34 @@ where
       self.engine.rearm_reaped_listener(now, &mut stream);
     }
 
-    // 3. Fold the smoltcp stack's next scheduled event into the engine's returned
+    // 5. Egress again, for what this poll's pump produced: its gossip datagrams,
+    // its reliable-plane segments, and the RSTs of anything it aborted. Without
+    // this pass those bytes would sit in the socket buffers until the next poll's
+    // stack tick, so every emission would cost the caller a second round; with it,
+    // an abort's RST also leaves the interface in the poll that ordered it, ahead
+    // of any later `listen`/`connect` that would reset the socket and erase the
+    // tuple the RST needs.
+    while self.iface.poll_egress(s_now, device, &mut self.sockets) != PollResult::None {}
+
+    // 6. Fold the smoltcp stack's next scheduled event into the engine's returned
     // deadline. The engine returns only `min(machine, closing)` — the SWIM timers
     // and the soonest gracefully-closing socket's force-abort instant — because it
     // owns no link layer. The driver adds the stack's `poll_at` (retransmit /
     // delayed-ACK / etc.) so a caller sleeping to the result wakes in time for
     // both. `poll_at` is re-read AFTER the pump so it reflects any socket the pump
     // just opened/closed (e.g. a dial whose SYN is queued reports ~now).
+    //
+    // An exhausted ingress budget folds `now` itself: the device still holds
+    // traffic the stack has not seen, so the caller must come back at once rather
+    // than sleep on a timer with unread packets behind it.
     let stack = self
       .iface
       .poll_at(s_now, &self.sockets)
       .map(from_smoltcp_instant);
-    min_opt(stack, next)
+    min_opt(
+      min_opt(stack, next),
+      if budget_exhausted { Some(now) } else { None },
+    )
   }
 }
 

--- a/memberlist-smoltcp/src/memberlist/mod.rs
+++ b/memberlist-smoltcp/src/memberlist/mod.rs
@@ -142,7 +142,8 @@ fn gossip_seed_from(interface_seed: u64, advertise: &SocketAddr) -> u64 {
 fn embedded_options(cfg: &Options) -> memberlist_embedded::Options {
   let opts = memberlist_embedded::Options::new()
     .with_port(cfg.port)
-    .with_close_timeout(cfg.close_timeout);
+    .with_close_timeout(cfg.close_timeout)
+    .with_gossip_read_cap(cfg.gossip_read_cap);
   // Forward the CIDR policy into the engine, which enforces it at the gossip
   // source (recv), the reliable accept, and membership admission.
   #[cfg(feature = "cidr")]
@@ -491,7 +492,7 @@ where
       return Err(InitError::ZeroUdpPackets);
     }
 
-    // Reject a gossip rx ring at or above the engine's per-pump gossip read cap
+    // Reject a gossip rx ring at or above the CONFIGURED per-pump gossip read cap
     // BEFORE the UDP arenas are sized and allocated below. This is an allocation
     // guard: `udp_rx_packets` scales the metadata ring AND floors the payload
     // arena at `packets * max_datagram`, so a large-but-non-overflowing count
@@ -501,7 +502,7 @@ where
     // returned error. The engine's own check against the bound socket's actual
     // capacity stays as defence in depth: it is the authority on the ring the
     // engine will read, and it binds every driver, not just this one.
-    if cfg.udp_rx_packets >= memberlist_embedded::GOSSIP_READ_CAP {
+    if cfg.udp_rx_packets >= cfg.gossip_read_cap {
       return Err(InitError::UdpRxPacketsTooLarge);
     }
 
@@ -961,7 +962,7 @@ where
       return Err(InitError::ZeroUdpPackets);
     }
 
-    // Reject a gossip rx ring at or above the engine's per-pump gossip read cap
+    // Reject a gossip rx ring at or above the CONFIGURED per-pump gossip read cap
     // BEFORE the UDP arenas are sized and allocated below. This is an allocation
     // guard: `udp_rx_packets` scales the metadata ring AND floors the payload
     // arena at `packets * max_datagram`, so a large-but-non-overflowing count
@@ -971,7 +972,7 @@ where
     // returned error. The engine's own check against the bound socket's actual
     // capacity stays as defence in depth: it is the authority on the ring the
     // engine will read, and it binds every driver, not just this one.
-    if cfg.udp_rx_packets >= memberlist_embedded::GOSSIP_READ_CAP {
+    if cfg.udp_rx_packets >= cfg.gossip_read_cap {
       return Err(InitError::UdpRxPacketsTooLarge);
     }
 

--- a/memberlist-smoltcp/src/memberlist/tests.rs
+++ b/memberlist-smoltcp/src/memberlist/tests.rs
@@ -304,11 +304,12 @@ fn invalid_config_is_rejected_before_resolution() {
 // inbound reliable streams; without that re-arm the listener stays `Closed` and the
 // DoS is permanent rather than bounded to one timeout window.
 
+use core::cell::RefCell;
 use smoltcp::{
   phy::{ChecksumCapabilities, DeviceCapabilities, RxToken, TxToken},
   time::Instant as SmolInstant,
 };
-use std::{cell::RefCell, collections::VecDeque, rc::Rc};
+use std::{collections::VecDeque, rc::Rc};
 
 /// A shared in-memory IP-frame FIFO (one direction of a paired link).
 #[derive(Clone)]

--- a/memberlist-smoltcp/src/memberlist/tests.rs
+++ b/memberlist-smoltcp/src/memberlist/tests.rs
@@ -448,3 +448,236 @@ fn poll_re_arms_a_listener_reaped_by_the_inactivity_timeout() {
      re-arm the listener stays Closed and this is false)"
   );
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bounded stack ingress. smoltcp's `Interface::poll` drains the device until it
+// stops yielding, so a device that keeps producing packets keeps the call inside
+// smoltcp: on a caller-driven super-loop with no preemption that starves every
+// SWIM timer, the event drain, and whatever else shares the loop. `poll` feeds a
+// bounded number of packets instead and always reaches the engine, signalling the
+// unread remainder with an already-due deadline.
+
+use core::cell::Cell;
+
+/// A device with a scripted receive supply, counting what the stack takes and
+/// emits.
+///
+/// `remaining == None` is an inexhaustible backlog — the hostile/overloaded case,
+/// which the unbounded entry point would never finish draining. The frames are
+/// 20 zero bytes: a non-empty frame the stack accounts for as processed, whose IP
+/// version matches neither v4 nor v6, so it is dropped without touching a socket
+/// or emitting a reply.
+struct FloodDevice {
+  remaining: Option<usize>,
+  receives: Rc<Cell<usize>>,
+  emitted: Rc<Cell<usize>>,
+}
+
+impl FloodDevice {
+  /// A device with nothing to deliver.
+  fn quiet() -> Self {
+    Self {
+      remaining: Some(0),
+      receives: Rc::new(Cell::new(0)),
+      emitted: Rc::new(Cell::new(0)),
+    }
+  }
+
+  /// Supply `n` more frames, or an inexhaustible backlog when `n` is `None`.
+  fn supply(&mut self, n: Option<usize>) {
+    self.remaining = n;
+  }
+
+  /// Frames the stack has taken from the device (one per ingress iteration).
+  fn receives(&self) -> usize {
+    self.receives.get()
+  }
+
+  /// Frames the stack has actually put on the wire.
+  fn emitted(&self) -> usize {
+    self.emitted.get()
+  }
+
+  fn reset_counters(&mut self) {
+    self.receives.set(0);
+    self.emitted.set(0);
+  }
+}
+
+/// A TX token that counts the frames the stack emits.
+struct CountingTx(Rc<Cell<usize>>);
+
+impl TxToken for CountingTx {
+  fn consume<R, F: FnOnce(&mut [u8]) -> R>(self, len: usize, f: F) -> R {
+    let mut buf = std::vec![0u8; len];
+    let r = f(&mut buf);
+    self.0.set(self.0.get() + 1);
+    r
+  }
+}
+
+impl Device for FloodDevice {
+  type RxToken<'a> = IpRx;
+  type TxToken<'a> = CountingTx;
+
+  fn receive(&mut self, _t: SmolInstant) -> Option<(IpRx, CountingTx)> {
+    match self.remaining {
+      Some(0) => return None,
+      Some(ref mut n) => *n -= 1,
+      None => {}
+    }
+    self.receives.set(self.receives.get() + 1);
+    Some((IpRx(std::vec![0u8; 20]), CountingTx(self.emitted.clone())))
+  }
+
+  fn transmit(&mut self, _t: SmolInstant) -> Option<CountingTx> {
+    Some(CountingTx(self.emitted.clone()))
+  }
+
+  fn capabilities(&self) -> DeviceCapabilities {
+    let mut caps = DeviceCapabilities::default();
+    caps.medium = Medium::Ip;
+    caps.max_transmission_unit = 1500;
+    caps.checksum = ChecksumCapabilities::ignored();
+    caps
+  }
+}
+
+/// Build a started node with one statically-known peer, quiesced over `dev`.
+///
+/// The peer gives the SWIM schedulers a destination, so a due probe or gossip
+/// deadline produces an observable datagram on the wire.
+fn node_with_peer(
+  cfg: crate::Options,
+  dev: &mut FloodDevice,
+  now: memberlist_proto::Instant,
+) -> Memberlist<SmolStr, SocketAddr, FloodDevice> {
+  let mut m: Memberlist<SmolStr, SocketAddr, _> = Memberlist::new(
+    cfg,
+    ip_iface(),
+    TransformOptions::default(),
+    memberlist_proto::EndpointOptions::new(SmolStr::new("a"), addr(7946)),
+    &crate::SocketAddrResolver,
+    dev,
+    now,
+  );
+  m.start(now);
+  m.inject_alive(
+    SmolStr::new("peer"),
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 7946),
+    now,
+  );
+  // Drain the start-up burst so the counters below see only the poll under test.
+  m.poll(now, dev);
+  m
+}
+
+/// One `poll` over a device with an inexhaustible backlog RETURNS, having taken
+/// exactly the configured budget of packets, run the engine — an already-due
+/// timer fires and its datagram reaches the wire — and asked to be polled again
+/// at once.
+///
+/// This is the starvation regression. With the unbounded entry point the same
+/// device never lets the call reach the engine at all, so no SWIM deadline is
+/// ever enforced and the caller's loop never regains control.
+#[test]
+fn poll_bounds_ingress_fires_due_timers_and_asks_to_be_polled_again() {
+  for budget in [1usize, 4, crate::config::DEFAULT_INGRESS_PACKETS_PER_POLL] {
+    let t0 = memberlist_proto::Instant::from_origin(Duration::from_secs(86_400));
+    let mut dev = FloodDevice::quiet();
+    let mut m = node_with_peer(
+      crate::Options::new().with_ingress_packets_per_poll(budget),
+      &mut dev,
+      t0,
+    );
+
+    // Far enough past every periodic deadline armed at `start` that at least one
+    // is due, whatever the randomized schedule picked.
+    let t1 = t0 + Duration::from_secs(60);
+    dev.supply(None);
+    dev.reset_counters();
+    let next = m.poll(t1, &mut dev);
+
+    assert_eq!(
+      dev.receives(),
+      budget,
+      "budget {budget}: the ingress phase takes exactly the configured number of packets \
+       from a device that never runs dry"
+    );
+    assert!(
+      dev.emitted() > 0,
+      "budget {budget}: an already-due engine timer must fire inside the flooded poll and its \
+       datagram must reach the wire (mutation anchor: an unbounded ingress phase never \
+       reaches the engine)"
+    );
+    assert_eq!(
+      next,
+      Some(t1),
+      "budget {budget}: an exhausted budget means device backlog remains, so the caller is \
+       asked to poll again at once rather than sleep on a timer"
+    );
+  }
+}
+
+/// A device that runs dry inside the budget yields the stack's and the engine's
+/// real deadline — the already-due instant is reserved for an actual backlog, not
+/// folded on every poll.
+#[test]
+fn poll_returns_a_real_deadline_when_the_device_runs_dry_inside_the_budget() {
+  const BUDGET: usize = 8;
+  let t0 = memberlist_proto::Instant::from_origin(Duration::from_secs(86_400));
+  let mut dev = FloodDevice::quiet();
+  let mut m = node_with_peer(
+    crate::Options::new().with_ingress_packets_per_poll(BUDGET),
+    &mut dev,
+    t0,
+  );
+
+  let t1 = t0 + Duration::from_secs(60);
+  dev.supply(Some(BUDGET - 1));
+  dev.reset_counters();
+  let next = m.poll(t1, &mut dev);
+
+  assert_eq!(
+    dev.receives(),
+    BUDGET - 1,
+    "the loop stops as soon as the device reports nothing left, without spending the budget"
+  );
+  assert!(
+    next > Some(t1),
+    "a drained device leaves no backlog, so the returned deadline is the real next wake, \
+     not an already-due re-poll: got {next:?}"
+  );
+}
+
+/// Negative control for the bound: smoltcp's own `Interface::poll` — the entry
+/// point this driver no longer calls — drains the device to exhaustion whatever
+/// the driver's budget says, taking every one of the many-times-the-budget frames
+/// offered here plus the one that reports empty. Given the inexhaustible device
+/// of the regression above it would not return at all, which is precisely why the
+/// driver runs the bounded phases instead.
+#[test]
+fn smoltcp_interface_poll_ignores_the_drivers_ingress_budget() {
+  const OFFERED: usize = 4 * crate::config::DEFAULT_INGRESS_PACKETS_PER_POLL;
+  let mut dev = FloodDevice::quiet();
+  let mut cfg = IfConfig::new(HardwareAddress::Ip);
+  cfg.random_seed = 0x51a2_1166;
+  let mut iface = Interface::new(cfg, &mut dev, SmolInstant::from_millis(0));
+  iface.update_ip_addrs(|addrs| {
+    addrs
+      .push(IpCidr::new(crate::IpAddress::v4(10, 0, 0, 1), 24))
+      .expect("push ip");
+  });
+  let mut sockets = SocketSet::new(Vec::new());
+
+  dev.supply(Some(OFFERED));
+  dev.reset_counters();
+  iface.poll(SmolInstant::from_millis(1_000), &mut dev, &mut sockets);
+
+  assert_eq!(
+    dev.receives(),
+    OFFERED,
+    "the unbounded entry point drains the device to exhaustion, so no configured budget \
+     bounds it"
+  );
+}

--- a/memberlist-smoltcp/src/stream_io/tests.rs
+++ b/memberlist-smoltcp/src/stream_io/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 
-use std::{cell::RefCell, collections::VecDeque, rc::Rc, vec, vec::Vec};
+use core::cell::RefCell;
+use std::{collections::VecDeque, rc::Rc, vec, vec::Vec};
 
 use core::net::{IpAddr, Ipv4Addr};
 use smoltcp::{

--- a/memberlist-smoltcp/tests/gossip_mtu.rs
+++ b/memberlist-smoltcp/tests/gossip_mtu.rs
@@ -51,8 +51,10 @@ fn oversized_gossip_datagram_is_received() {
   // frame: this smoltcp build does not enable IPv4 fragmentation, so an
   // over-MTU datagram could not traverse a 1500-MTU link at all. The point
   // under test is the driver's RECEIVE-buffer sizing, not IP fragmentation, so
-  // the link is widened to isolate it.
-  let (mut da, mut db) = harness::link(4096);
+  // the link is widened to isolate it. It must exceed `GOSSIP_MTU` with room to
+  // spare, since construction requires the IP and UDP headers and the enabled
+  // transforms' wrapper overhead to fit alongside the payload budget.
+  let (mut da, mut db) = harness::link(8192);
   let mut clk = harness::Clock::new();
   let now = clk.now();
 

--- a/memberlist-smoltcp/tests/interface.rs
+++ b/memberlist-smoltcp/tests/interface.rs
@@ -12,9 +12,9 @@ use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use memberlist_proto::{EndpointOptions, Instant};
 use memberlist_smoltcp::{
-  EthernetAddress, GOSSIP_READ_CAP, GossipMtuTooLarge, HardwareAddress, InitError,
-  InterfaceOptions, IpCidr, Medium, Memberlist, Options, Route, SocketAddrResolver,
-  TransformOptions,
+  EthernetAddress, GOSSIP_READ_CAP, GossipDatagramExceedsDeviceMtu, GossipMtuTooLarge,
+  HardwareAddress, InitError, InterfaceOptions, IpCidr, Medium, Memberlist, Options, Route,
+  SocketAddrResolver, TransformOptions,
 };
 use smol_str::SmolStr;
 
@@ -900,4 +900,134 @@ fn zero_close_timeout_rejected() {
     matches!(res, Err(InitError::ZeroCloseTimeout)),
     "a zero close_timeout must be rejected as ZeroCloseTimeout"
   );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The bound device's IP MTU bounds the gossip budget. This build enables neither
+// of smoltcp's IP fragmentation features, so a datagram larger than the link can
+// carry is neither fragmented nor refused: the UDP socket accepts it and the next
+// egress pass dequeues and discards it. Construction knows the device MTU, so the
+// combination is rejected there instead of black-holing large gossip at runtime.
+
+/// Try to construct a node with `gossip_mtu` over a device of `device_mtu`,
+/// optionally giving the interface an IPv6 address alongside its IPv4 one.
+fn try_with_device_mtu(
+  device_mtu: usize,
+  gossip_mtu: Option<usize>,
+  dual_stack: bool,
+) -> Result<(), InitError> {
+  let (mut dev, _peer) = harness::link(device_mtu);
+  let now: Instant = harness::Clock::new().now();
+  let mut iface = InterfaceOptions::new(HardwareAddress::Ip).with_ip_addr(ip_cidr(1));
+  if dual_stack {
+    iface = iface.with_ip_addr(IpCidr::new(
+      IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)).into(),
+      64,
+    ));
+  }
+  let mut ep_cfg = ep("a", 1);
+  if let Some(mtu) = gossip_mtu {
+    ep_cfg = ep_cfg.with_gossip_mtu(mtu);
+  }
+  let res: Result<Memberlist<SmolStr, SocketAddr, _>, _> = Memberlist::try_new(
+    Options::new(),
+    iface,
+    TransformOptions::default(),
+    ep_cfg,
+    &SocketAddrResolver,
+    &mut dev,
+    now,
+  );
+  // Drop the node without moving it into an assertion: `Memberlist` is not `Debug`.
+  res.map(|_| ())
+}
+
+/// The bytes a datagram needs beyond `gossip_mtu` itself on this build: the IPv4
+/// and UDP headers plus whatever wrapper overhead the enabled transforms add.
+/// Read off a rejection rather than recomputed, so the assertions below track the
+/// feature set the suite is compiled with.
+fn per_datagram_overhead() -> usize {
+  match try_with_device_mtu(1500, Some(4096), false) {
+    Err(InitError::GossipDatagramExceedsDeviceMtu(GossipDatagramExceedsDeviceMtu {
+      required,
+      available,
+    })) => {
+      assert_eq!(
+        available, 1500,
+        "Medium::Ip has no medium header to subtract"
+      );
+      required - 4096
+    }
+    other => panic!("a 4096-byte gossip budget cannot fit a 1500-byte link: {other:?}"),
+  }
+}
+
+/// A 1500-byte device carries the default gossip budget, and the boundary is
+/// exact: the largest budget that fits constructs, one byte more is rejected, and
+/// the rejection reports the bytes needed against the bytes available.
+#[test]
+fn the_device_ip_mtu_bounds_the_gossip_budget_exactly() {
+  let overhead = per_datagram_overhead();
+
+  assert!(
+    try_with_device_mtu(1500, None, false).is_ok(),
+    "the default gossip budget must fit an ordinary 1500-byte link"
+  );
+
+  let largest = 1500 - overhead;
+  assert!(
+    try_with_device_mtu(1500, Some(largest), false).is_ok(),
+    "a gossip budget whose datagram exactly fills the link's IP MTU must construct"
+  );
+  match try_with_device_mtu(1500, Some(largest + 1), false) {
+    Err(InitError::GossipDatagramExceedsDeviceMtu(m)) => {
+      assert_eq!(
+        (m.required, m.available),
+        (1501, 1500),
+        "the rejection carries the bytes needed and the bytes the device can carry"
+      );
+    }
+    other => panic!("one byte past the link's capacity must be rejected: {other:?}"),
+  }
+}
+
+/// An IPv6-minimum 1280-byte device rejects even the DEFAULT gossip budget: 1400
+/// bytes of plaintext plus headers and transform overhead cannot cross that link,
+/// and without this guard every full-size gossip datagram would be enqueued and
+/// then silently discarded while small probes kept working.
+#[test]
+fn a_1280_byte_device_rejects_the_default_gossip_budget() {
+  match try_with_device_mtu(1280, None, false) {
+    Err(InitError::GossipDatagramExceedsDeviceMtu(m)) => {
+      assert_eq!(m.available, 1280);
+      assert!(
+        m.required > m.available,
+        "the rejection must report needing more than the device carries, got {m}"
+      );
+    }
+    other => panic!("the default gossip budget cannot cross a 1280-byte link: {other:?}"),
+  }
+}
+
+/// A dual-stack interface is measured against the WIDER IPv6 header: a budget that
+/// exactly fills the link over IPv4 no longer fits once the interface can also
+/// source IPv6, and the shortfall is exactly the 20 bytes by which the IPv6 header
+/// exceeds the IPv4 one.
+#[test]
+fn a_dual_stack_interface_is_measured_against_the_ipv6_header() {
+  let largest_v4 = 1500 - per_datagram_overhead();
+  assert!(
+    try_with_device_mtu(1500, Some(largest_v4), false).is_ok(),
+    "the budget fits while the interface can only source IPv4"
+  );
+  match try_with_device_mtu(1500, Some(largest_v4), true) {
+    Err(InitError::GossipDatagramExceedsDeviceMtu(m)) => {
+      assert_eq!(
+        (m.required, m.available),
+        (1520, 1500),
+        "the same budget is measured against IPv6's 40-byte header, 20 more than IPv4's"
+      );
+    }
+    other => panic!("a dual-stack interface must be held to the IPv6 header: {other:?}"),
+  }
 }

--- a/memberlist-smoltcp/tests/interface.rs
+++ b/memberlist-smoltcp/tests/interface.rs
@@ -821,6 +821,64 @@ fn udp_rx_packets_at_or_above_the_gossip_read_cap_rejected() {
   }
 }
 
+/// The driver's pre-allocation screen follows the CONFIGURED ceiling, not the
+/// default constant: with `gossip_read_cap` lowered to 8, an 8-slot `udp_rx_packets`
+/// — the shipped default, which the default cap of 64 admits — is rejected under
+/// the name of the option to lower, and 7 slots constructs.
+#[test]
+fn udp_rx_packets_is_screened_against_the_configured_gossip_read_cap() {
+  const CAP: usize = 8;
+  for (slots, accepted) in [(CAP + 1, false), (CAP, false), (CAP - 1, true)] {
+    let mut dev = smoltcp::phy::Loopback::new(Medium::Ip);
+    let now: Instant = harness::Clock::new().now();
+    let mut cfg = Options::new().with_gossip_read_cap(CAP);
+    cfg.udp_rx_packets = slots;
+    let res: Result<Memberlist<SmolStr, SocketAddr, _>, _> = Memberlist::try_new(
+      cfg,
+      InterfaceOptions::new(HardwareAddress::Ip).with_ip_addr(ip_cidr(1)),
+      TransformOptions::default(),
+      ep("a", 1),
+      &SocketAddrResolver,
+      &mut dev,
+      now,
+    );
+    if accepted {
+      assert!(
+        res.is_ok(),
+        "{slots} slots is below the configured cap of {CAP} and must construct"
+      );
+    } else {
+      assert!(
+        matches!(res, Err(InitError::UdpRxPacketsTooLarge)),
+        "{slots} slots is not below the configured cap of {CAP} and must be rejected, \
+         even though the default cap would admit it"
+      );
+    }
+  }
+}
+
+/// A zero `gossip_read_cap` is rejected as the knob itself. The ring screens are
+/// strictly below the cap, so zero admits no gossip ring at all: reporting it as a
+/// packet-count failure would name a field no value could fix.
+#[test]
+fn zero_gossip_read_cap_rejected() {
+  let mut dev = smoltcp::phy::Loopback::new(Medium::Ip);
+  let now: Instant = harness::Clock::new().now();
+  let res: Result<Memberlist<SmolStr, SocketAddr, _>, _> = Memberlist::try_new(
+    Options::new().with_gossip_read_cap(0),
+    InterfaceOptions::new(HardwareAddress::Ip).with_ip_addr(ip_cidr(1)),
+    TransformOptions::default(),
+    ep("a", 1),
+    &SocketAddrResolver,
+    &mut dev,
+    now,
+  );
+  assert!(
+    matches!(res, Err(InitError::ZeroGossipReadCap)),
+    "a zero gossip_read_cap must be rejected as ZeroGossipReadCap"
+  );
+}
+
 /// A zero `close_timeout` is rejected: it would force-abort every graceful
 /// reliable close immediately (deadline == `now`), truncating in-flight push/pull
 /// responses instead of draining them.

--- a/memberlist-smoltcp/tests/transform.rs
+++ b/memberlist-smoltcp/tests/transform.rs
@@ -20,10 +20,11 @@ use core::{
 };
 
 use memberlist_proto::{EndpointOptions, Instant};
-use memberlist_smoltcp::{
-  CompressAlgorithm, CompressionOptions, EncryptionOptions, Keyring, LabelError, Memberlist,
-  Options, SecretKey, SocketAddrResolver, TransformOptions,
-};
+#[cfg(feature = "lz4")]
+use memberlist_smoltcp::{CompressAlgorithm, CompressionOptions};
+#[cfg(feature = "aes-gcm")]
+use memberlist_smoltcp::{EncryptionOptions, Keyring, SecretKey};
+use memberlist_smoltcp::{LabelError, Memberlist, Options, SocketAddrResolver, TransformOptions};
 use smol_str::SmolStr;
 
 fn addr(ip: u8, port: u16) -> SocketAddr {
@@ -45,6 +46,7 @@ fn mk(id: &str, ip: u8) -> EndpointOptions<SmolStr, SocketAddr> {
 
 /// A single shared 256-bit AES-GCM key — the cluster secret both encrypted
 /// nodes hold.
+#[cfg(feature = "aes-gcm")]
 fn shared_encryption() -> EncryptionOptions {
   let key = SecretKey::Aes256([0x42; 32]);
   EncryptionOptions::new().with_keyring(Keyring::new(key))
@@ -53,6 +55,7 @@ fn shared_encryption() -> EncryptionOptions {
 /// Both nodes share a keyring: their AES-GCM-wrapped gossip round-trips, so the
 /// pair converges and STAYS Alive across a window long enough that a broken
 /// transform (dropped datagrams) would have demoted each peer to Dead.
+#[cfg(feature = "aes-gcm")]
 #[test]
 fn encrypted_gossip_round_trips() {
   // 80 ticks × 10 ms = 800 ms — past the ~550 ms worst-case probe→dead path, so
@@ -114,6 +117,7 @@ fn encrypted_gossip_round_trips() {
 /// therefore demotes B: A does NOT keep B Alive. (With both plaintext — the
 /// pre-transform behaviour — A would have happily kept B Alive, which is the
 /// hole this test closes.)
+#[cfg(feature = "aes-gcm")]
 #[test]
 fn encrypted_node_rejects_plaintext_gossip() {
   // Long enough for A's probe→suspect→dead path (~550 ms worst case) to run to
@@ -311,6 +315,7 @@ fn gossip_label_isolates_clusters() {
 ///   (which holds key1) can read it. Both nodes stay Alive for the full
 ///   discriminating window — proving the rotation is reflected immediately on
 ///   the next gossip emission.
+#[cfg(feature = "aes-gcm")]
 #[test]
 fn runtime_set_encryption_rotates_key() {
   let key1 = EncryptionOptions::new().with_keyring(Keyring::new(SecretKey::Aes256([0xAA; 32])));
@@ -422,6 +427,7 @@ fn runtime_set_encryption_rotates_key() {
 
 /// Both nodes enable LZ4 compression: their compressed gossip round-trips, so
 /// the pair converges and STAYS Alive across a discriminating window.
+#[cfg(feature = "lz4")]
 #[test]
 fn compressed_gossip_round_trips() {
   const TICKS: u32 = 80;


### PR DESCRIPTION
PR-2 of the #162 embedded-tier plan: the ingress-budget knobs, a bounded smoltcp stack poll (#161 F1), a device-MTU guard (#161 F2), and the advertised-but-uncompilable test lanes (#159/#160/#161 Low items). Builds on #216/#217.

## Follow-ups

PR-3: #159 F5 (bounded, expiry-checked dial admission). Then X2/X4 (send-acceptance tokens). Out of tree: `serf-embedded` (own pump) and the serf drivers (`GossipIo::recv_capacity`).
